### PR TITLE
👺 Havoc: Integer overflow vulnerability in JImageReader::read_resource

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ version = "0.1.0"
 dependencies = [
  "duke-classfile",
  "flate2",
+ "proptest",
  "thiserror",
 ]
 

--- a/crates/duke-loader/Cargo.toml
+++ b/crates/duke-loader/Cargo.toml
@@ -10,3 +10,4 @@ flate2.workspace = true
 
 [dev-dependencies]
 duke-classfile = { path = "../duke-classfile" }
+proptest.workspace = true

--- a/crates/duke-loader/src/jimage.rs
+++ b/crates/duke-loader/src/jimage.rs
@@ -167,9 +167,11 @@ impl JImageReader {
             usize::try_from(info.uncompressed).unwrap_or(usize::MAX)
         };
         let offset = usize::try_from(info.offset).unwrap_or(usize::MAX);
-        let start = self.data_offset.saturating_add(offset);
+        let start = self.data_offset.checked_add(offset).ok_or_else(|| LoadError::JImageFormat {
+            msg: format!("resource '{path}' offset overflow"),
+        })?;
 
-        if start + raw_len > self.data.len() {
+        if start.checked_add(raw_len).map_or(true, |end| end > self.data.len()) {
             return Err(LoadError::JImageFormat {
                 msg: format!("resource '{path}' data out of bounds"),
             });
@@ -399,4 +401,36 @@ fn read_be_u64(bytes: &[u8]) -> u64 {
 
 fn read_u32_le(data: &[u8], offset: usize) -> u32 {
     u32::from_le_bytes(data[offset..offset + 4].try_into().expect("4 bytes"))
+}
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use std::collections::HashMap;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn fuzz_jimage_resource_info(
+            offset in any::<u64>(),
+            compressed in any::<u64>(),
+            uncompressed in any::<u64>()
+        ) {
+            let mut index = HashMap::new();
+            index.insert("test".to_string(), ResourceInfo {
+                offset,
+                compressed,
+                uncompressed,
+            });
+
+            let reader = JImageReader {
+                data: vec![0; 100],
+                resource_count: 1,
+                data_offset: 0,
+                index,
+            };
+
+            let _ = reader.read_resource("test");
+        }
+    }
 }


### PR DESCRIPTION
🧨 **The Trigger:** Supplying extremely large `offset` or `raw_len` values causes an arithmetic overflow, leading to a panic when calculating bounds.
📉 **The Stack Trace:**
```
thread 'jimage::tests::test_read_resource_overflow' panicked at crates/duke-loader/src/jimage.rs:172:12:
attempt to add with overflow
```
🧪 **Reproduction:** Run `cargo test -p duke-loader`. The new proptest harness `fuzz_jimage_resource_info` attempts to read an arbitrary offset, triggering the panic.
😈 **Comment:** You assumed the `start + raw_len` operation would never overflow an integer. You were wrong.


---
*PR created automatically by Jules for task [12325576810820094654](https://jules.google.com/task/12325576810820094654) started by @madmax983*