### PR TITLE
Fix clippy warnings and code format

### DIFF
--- a/crates/duke-bytecode/src/lib.rs
+++ b/crates/duke-bytecode/src/lib.rs
@@ -38,7 +38,7 @@ mod tests {
         p
     }
 
-    fn get_method_code<'a>(class_bytes: &'a [u8], method_name: &str) -> (Vec<u8>, u16, u16) {
+    fn get_method_code(class_bytes: &[u8], method_name: &str) -> (Vec<u8>, u16, u16) {
         let cf = parse(class_bytes).expect("parse failed");
         let method = cf
             .methods

--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -783,7 +783,7 @@ mod tests {
             age: 0,
             forward: None,
         }));
-        let a_ref = 0u64 | OLD_BIT;
+        let a_ref = OLD_BIT;
         let b_ref = 1u64 | OLD_BIT;
         heap.write_field(a_ref, 0, Slot::Reference(Some(b_ref)))
             .unwrap();
@@ -894,7 +894,7 @@ mod tests {
             age: 0,
             forward: None,
         }));
-        let old_ref = 0u64 | OLD_BIT;
+        let old_ref = OLD_BIT;
         let young_ref = heap.allocate("Young".to_string(), 0);
         // Wire old→young via write_field (populates remembered_set).
         heap.write_field(old_ref, 0, Slot::Reference(Some(young_ref)))
@@ -940,7 +940,7 @@ mod tests {
     #[test]
     fn apply_forward_is_no_op_on_old_gen_ref() {
         let heap = Heap::new();
-        let old_ref = 0u64 | OLD_BIT;
+        let old_ref = OLD_BIT;
         let mut slot = Slot::Reference(Some(old_ref));
         heap.apply_forward(&mut slot);
         // No forwarding pointer in old gen → slot unchanged.
@@ -960,7 +960,7 @@ mod tests {
             age: 0,
             forward: None,
         }));
-        let old_ref = 0u64 | OLD_BIT;
+        let old_ref = OLD_BIT;
         assert_ne!(old_ref & OLD_BIT, 0, "old ref must have OLD_BIT set");
         assert_eq!(heap.get(old_ref).unwrap().class_name, "OldObj");
     }
@@ -984,7 +984,7 @@ mod tests {
             age: 0,
             forward: None,
         }));
-        let keep_ref = 0u64 | OLD_BIT;
+        let keep_ref = OLD_BIT;
         let drop_ref = 1u64 | OLD_BIT;
         let roots = vec![Slot::Reference(Some(keep_ref))];
         heap.major_collect(&roots);
@@ -1012,7 +1012,7 @@ mod tests {
         }));
         heap.old.push(Some(HeapObject {
             class_name: "B".to_string(),
-            fields: vec![Slot::Reference(Some(0u64 | OLD_BIT))],
+            fields: vec![Slot::Reference(Some(OLD_BIT))],
             string_value: None,
             marked: false,
             age: 0,
@@ -1052,7 +1052,7 @@ mod tests {
             age: 0,
             forward: None,
         }));
-        let keep_ref = 0u64 | OLD_BIT;
+        let keep_ref = OLD_BIT;
         heap.major_collect(&[Slot::Reference(Some(keep_ref))]);
         // old_free_list has raw index 1 (no OLD_BIT).
         assert!(heap.old_free_list.contains(&1u64));

--- a/crates/duke-interpreter/benches/interpreter.rs
+++ b/crates/duke-interpreter/benches/interpreter.rs
@@ -118,7 +118,8 @@ fn bench_bootstrap_only(c: &mut Criterion) {
         b.iter(|| {
             let mut registry = ClassRegistry::new();
             let mut heap = duke_gc::Heap::new();
-            black_box(bootstrap_stdlib(&mut registry, &mut heap));
+            bootstrap_stdlib(&mut registry, &mut heap);
+            black_box(());
         });
     });
 }

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -695,14 +695,12 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         bootstrap_methods: Vec::new(),
     };
     registry.register(throwable_ctx);
-    registry
-        .natives_mut()
-        .register(
-            "java/lang/Throwable",
-            "addSuppressed",
-            "(Ljava/lang/Throwable;)V",
-            native_throwable_add_suppressed,
-        );
+    registry.natives_mut().register(
+        "java/lang/Throwable",
+        "addSuppressed",
+        "(Ljava/lang/Throwable;)V",
+        native_throwable_add_suppressed,
+    );
 
     // java/lang/Exception extends Throwable
     let exception_ctx = ClassContext {
@@ -2083,7 +2081,9 @@ fn heap_object_to_string(obj: &duke_gc::HeapObject, obj_ref: u64) -> String {
                 _ => "false".to_string(),
             };
         }
-        "java/lang/Character" => {
+        "java/lang/Character" =>
+        {
+            #[allow(clippy::collapsible_if)]
             if let Some(Slot::Int(v)) = obj.fields.first() {
                 if let Some(c) = char::from_u32(*v as u32) {
                     return c.to_string();
@@ -8513,6 +8513,7 @@ fn init_object_fields(
             for field in ctx.fields.iter().filter(|f| !f.is_static) {
                 let default = default_slot_for_descriptor(&field.descriptor);
                 // Only write non-Int-zero defaults (avoids an unnecessary mut borrow).
+                #[allow(clippy::collapsible_if)]
                 if !matches!(default, Slot::Int(0)) {
                     if let Ok(obj) = heap.get_mut(obj_ref) {
                         if slot_idx < obj.fields.len() {
@@ -9836,6 +9837,7 @@ mod tests {
 
     #[test]
     fn native_registry_register_callback_can_be_looked_up() {
+        #[allow(clippy::type_complexity)]
         fn dummy_cb(
             _args: &[Slot],
             _heap: &mut duke_gc::Heap,
@@ -14430,7 +14432,7 @@ mod tests {
         assert_eq!(result, Some(Slot::Int(99)));
         let events = &registry.telemetry.exception_flow.events;
         // Two throw events: inner throw + rethrow
-        assert!(events.len() >= 1);
+        assert!(!events.is_empty());
         assert!(events.iter().all(|e| e.catch_site.is_some()));
     }
 

--- a/crates/duke-loader/src/jimage.rs
+++ b/crates/duke-loader/src/jimage.rs
@@ -167,11 +167,17 @@ impl JImageReader {
             usize::try_from(info.uncompressed).unwrap_or(usize::MAX)
         };
         let offset = usize::try_from(info.offset).unwrap_or(usize::MAX);
-        let start = self.data_offset.checked_add(offset).ok_or_else(|| LoadError::JImageFormat {
-            msg: format!("resource '{path}' offset overflow"),
-        })?;
+        let start =
+            self.data_offset
+                .checked_add(offset)
+                .ok_or_else(|| LoadError::JImageFormat {
+                    msg: format!("resource '{path}' offset overflow"),
+                })?;
 
-        if start.checked_add(raw_len).map_or(true, |end| end > self.data.len()) {
+        if start
+            .checked_add(raw_len)
+            .is_none_or(|end| end > self.data.len())
+        {
             return Err(LoadError::JImageFormat {
                 msg: format!("resource '{path}' data out of bounds"),
             });
@@ -406,8 +412,8 @@ fn read_u32_le(data: &[u8], offset: usize) -> u32 {
 #[cfg(test)]
 mod proptests {
     use super::*;
-    use std::collections::HashMap;
     use proptest::prelude::*;
+    use std::collections::HashMap;
 
     proptest! {
         #[test]


### PR DESCRIPTION
- Removed needless lifetime in `get_method_code`
- Used `is_none_or` instead of `map_or` where applicable
- Avoided identity bitwise operations
- Added `allow(clippy::collapsible_if)` to nested if blocks to avoid unstable `let_chains` compilation error
- Used `!events.is_empty()` instead of `events.len() >= 1`
- Added `allow(clippy::type_complexity)` where appropriate in test dummy code
- Formatted entire workspace with `cargo fmt --all`

---
*PR created automatically by Jules for task [16397019272367951078](https://jules.google.com/task/16397019272367951078) started by @madmax983*