### PR TITLE
⚒️ Forge: Idiomatic iterators & dispatch closure deduplication

### DIFF
--- a/crates/duke-bytecode/src/decoder.rs
+++ b/crates/duke-bytecode/src/decoder.rs
@@ -311,10 +311,9 @@ fn decode_one(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> DecodeResult<Instruc
                 return Err(DecodeError::InvalidTableswitch { pc, low, high });
             }
             let count = usize::try_from(count_i64).unwrap_or(0);
-            let mut offsets = Vec::with_capacity(count);
-            for _ in 0..count {
-                offsets.push(c.read_i32()?);
-            }
+            let offsets = (0..count)
+                .map(|_| c.read_i32())
+                .collect::<DecodeResult<Vec<_>>>()?;
             Instruction::Tableswitch {
                 default,
                 low,
@@ -335,12 +334,13 @@ fn decode_one(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> DecodeResult<Instruc
             if usize::try_from(npairs).unwrap_or(usize::MAX) > remaining_pairs {
                 return Err(DecodeError::InvalidLookupswitch { pc, npairs });
             }
-            let mut pairs = Vec::with_capacity(usize::try_from(npairs).unwrap_or(0));
-            for _ in 0..npairs {
-                let match_val = c.read_i32()?;
-                let offset = c.read_i32()?;
-                pairs.push((match_val, offset));
-            }
+            let pairs = (0..npairs)
+                .map(|_| {
+                    let match_val = c.read_i32()?;
+                    let offset = c.read_i32()?;
+                    Ok((match_val, offset))
+                })
+                .collect::<DecodeResult<Vec<_>>>()?;
             Instruction::Lookupswitch { default, pairs }
         }
 

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -166,24 +166,21 @@ fn parse_class_file(c: &mut Cursor<'_>) -> ParseResult<ClassFile> {
 
     // interfaces
     let interfaces_count = c.read_u16()?;
-    let mut interfaces = Vec::with_capacity(interfaces_count as usize);
-    for _ in 0..interfaces_count {
-        interfaces.push(c.read_cp_index()?);
-    }
+    let interfaces = (0..interfaces_count)
+        .map(|_| c.read_cp_index())
+        .collect::<ParseResult<Vec<_>>>()?;
 
     // fields
     let fields_count = c.read_u16()?;
-    let mut fields = Vec::with_capacity(fields_count as usize);
-    for _ in 0..fields_count {
-        fields.push(parse_field(c, cp_len)?);
-    }
+    let fields = (0..fields_count)
+        .map(|_| parse_field(c, cp_len))
+        .collect::<ParseResult<Vec<_>>>()?;
 
     // methods
     let methods_count = c.read_u16()?;
-    let mut methods = Vec::with_capacity(methods_count as usize);
-    for _ in 0..methods_count {
-        methods.push(parse_method(c, cp_len)?);
-    }
+    let methods = (0..methods_count)
+        .map(|_| parse_method(c, cp_len))
+        .collect::<ParseResult<Vec<_>>>()?;
 
     // class-level attributes
     let attributes = parse_attributes(c, cp_len)?;
@@ -341,10 +338,9 @@ fn parse_method(c: &mut Cursor<'_>, cp_len: usize) -> ParseResult<MethodInfo> {
 
 fn parse_attributes(c: &mut Cursor<'_>, cp_len: usize) -> ParseResult<Vec<AttributeInfo>> {
     let count = c.read_u16()?;
-    let mut attrs = Vec::with_capacity(count as usize);
-    for _ in 0..count {
-        attrs.push(parse_attribute(c, cp_len)?);
-    }
+    let attrs = (0..count)
+        .map(|_| parse_attribute(c, cp_len))
+        .collect::<ParseResult<Vec<_>>>()?;
     Ok(attrs)
 }
 
@@ -409,54 +405,55 @@ fn decode_known_attribute(name: &str, raw: &[u8]) -> ParseResult<AttributeData> 
         "Code" => AttributeData::Code(parse_code_attribute(&mut c)?),
         "LineNumberTable" => {
             let len = c.read_u16()?;
-            let mut entries = Vec::with_capacity(len as usize);
-            for _ in 0..len {
-                entries.push(LineNumberEntry {
-                    start_pc: c.read_u16()?,
-                    line_number: c.read_u16()?,
-                });
-            }
+            let entries = (0..len)
+                .map(|_| {
+                    Ok(LineNumberEntry {
+                        start_pc: c.read_u16()?,
+                        line_number: c.read_u16()?,
+                    })
+                })
+                .collect::<ParseResult<Vec<_>>>()?;
             AttributeData::LineNumberTable(entries)
         }
         "LocalVariableTable" => {
             let len = c.read_u16()?;
-            let mut entries = Vec::with_capacity(len as usize);
-            for _ in 0..len {
-                entries.push(LocalVariableEntry {
-                    start_pc: c.read_u16()?,
-                    length: c.read_u16()?,
-                    name_index: c.read_cp_index()?,
-                    descriptor_index: c.read_cp_index()?,
-                    index: c.read_u16()?,
-                });
-            }
+            let entries = (0..len)
+                .map(|_| {
+                    Ok(LocalVariableEntry {
+                        start_pc: c.read_u16()?,
+                        length: c.read_u16()?,
+                        name_index: c.read_cp_index()?,
+                        descriptor_index: c.read_cp_index()?,
+                        index: c.read_u16()?,
+                    })
+                })
+                .collect::<ParseResult<Vec<_>>>()?;
             AttributeData::LocalVariableTable(entries)
         }
         "Exceptions" => {
             let num = c.read_u16()?;
-            let mut table = Vec::with_capacity(num as usize);
-            for _ in 0..num {
-                table.push(c.read_cp_index()?);
-            }
+            let table = (0..num)
+                .map(|_| c.read_cp_index())
+                .collect::<ParseResult<Vec<_>>>()?;
             AttributeData::Exceptions {
                 exception_index_table: table,
             }
         }
         "BootstrapMethods" => {
             let num = c.read_u16()?;
-            let mut entries = Vec::with_capacity(num as usize);
-            for _ in 0..num {
-                let method_ref = c.read_cp_index()?;
-                let num_args = c.read_u16()?;
-                let mut arguments = Vec::with_capacity(num_args as usize);
-                for _ in 0..num_args {
-                    arguments.push(c.read_cp_index()?);
-                }
-                entries.push(BootstrapMethodEntry {
-                    method_ref,
-                    arguments,
-                });
-            }
+            let entries = (0..num)
+                .map(|_| {
+                    let method_ref = c.read_cp_index()?;
+                    let num_args = c.read_u16()?;
+                    let arguments = (0..num_args)
+                        .map(|_| c.read_cp_index())
+                        .collect::<ParseResult<Vec<_>>>()?;
+                    Ok(BootstrapMethodEntry {
+                        method_ref,
+                        arguments,
+                    })
+                })
+                .collect::<ParseResult<Vec<_>>>()?;
             AttributeData::BootstrapMethods(entries)
         }
         _ => AttributeData::Raw(raw.to_vec()),
@@ -471,29 +468,31 @@ fn parse_code_attribute(c: &mut Cursor<'_>) -> ParseResult<CodeAttribute> {
     let code = c.read_bytes(code_len)?.to_vec();
 
     let ex_count = c.read_u16()?;
-    let mut exception_table = Vec::with_capacity(ex_count as usize);
-    for _ in 0..ex_count {
-        exception_table.push(ExceptionTableEntry {
-            start_pc: c.read_u16()?,
-            end_pc: c.read_u16()?,
-            handler_pc: c.read_u16()?,
-            catch_type: c.read_cp_index()?,
-        });
-    }
+    let exception_table = (0..ex_count)
+        .map(|_| {
+            Ok(ExceptionTableEntry {
+                start_pc: c.read_u16()?,
+                end_pc: c.read_u16()?,
+                handler_pc: c.read_u16()?,
+                catch_type: c.read_cp_index()?,
+            })
+        })
+        .collect::<ParseResult<Vec<_>>>()?;
 
     // Code sub-attributes (LineNumberTable etc.) — stored as Raw for now;
     // resolve_attributes will decode them.
     let attr_count = c.read_u16()?;
-    let mut attributes = Vec::with_capacity(attr_count as usize);
-    for _ in 0..attr_count {
-        let name_index = c.read_cp_index()?;
-        let attr_len = c.read_u32()? as usize;
-        let raw = c.read_bytes(attr_len)?.to_vec();
-        attributes.push(AttributeInfo {
-            name_index,
-            data: AttributeData::Raw(raw),
-        });
-    }
+    let attributes = (0..attr_count)
+        .map(|_| {
+            let name_index = c.read_cp_index()?;
+            let attr_len = c.read_u32()? as usize;
+            let raw = c.read_bytes(attr_len)?.to_vec();
+            Ok(AttributeInfo {
+                name_index,
+                data: AttributeData::Raw(raw),
+            })
+        })
+        .collect::<ParseResult<Vec<_>>>()?;
 
     Ok(CodeAttribute {
         max_stack,

--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -123,7 +123,11 @@ impl Heap {
 
     // ── Allocation ───────────────────────────────────────────────────────────
 
-    const fn make_obj(class_name: String, fields: Vec<Slot>, string_value: Option<String>) -> HeapObject {
+    const fn make_obj(
+        class_name: String,
+        fields: Vec<Slot>,
+        string_value: Option<String>,
+    ) -> HeapObject {
         HeapObject {
             class_name,
             fields,

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -5184,6 +5184,22 @@ pub fn execute_class(
     descriptor: &str,
     args: &[Slot],
 ) -> VmResult<Option<Slot>> {
+    macro_rules! create_invoke_cb {
+        () => {
+            |heap: &mut duke_gc::Heap,
+             output: &mut dyn std::io::Write,
+             class: &str,
+             method: &str,
+             desc: &str,
+             cb_args: Vec<Slot>|
+             -> VmResult<Option<Slot>> {
+                execute_class(
+                    registry, loader, heap, output, class, method, desc, &cb_args,
+                )
+            }
+        };
+    }
+
     // Fast path: if a native handler is registered for this class/method/descriptor,
     // dispatch it directly without requiring a ClassContext in the registry.
     // This handles both Simple natives and Callback natives at the top-level call site.
@@ -5199,17 +5215,7 @@ pub fn execute_class(
             // sites. It can't be extracted into a free function because it
             // captures `registry` and `loader` from the enclosing frame; a
             // macro or an `InvokeContext` struct would remove the duplication.
-            let mut invoke_cb = |heap: &mut duke_gc::Heap,
-                                 output: &mut dyn std::io::Write,
-                                 class: &str,
-                                 method: &str,
-                                 desc: &str,
-                                 cb_args: Vec<Slot>|
-             -> VmResult<Option<Slot>> {
-                execute_class(
-                    registry, loader, heap, output, class, method, desc, &cb_args,
-                )
-            };
+            let mut invoke_cb = create_invoke_cb!();
             return h(args, heap, stdout, &mut invoke_cb);
         }
         None => {}
@@ -5485,19 +5491,7 @@ pub fn execute_class(
                                 native_args.reverse();
                                 #[cfg(feature = "telemetry")]
                                 let _native_start = std::time::Instant::now();
-                                let mut invoke_cb =
-                                    |heap: &mut duke_gc::Heap,
-                                     output: &mut dyn std::io::Write,
-                                     class: &str,
-                                     method: &str,
-                                     desc: &str,
-                                     cb_args: Vec<Slot>|
-                                     -> VmResult<Option<Slot>> {
-                                        execute_class(
-                                            registry, loader, heap, output, class, method, desc,
-                                            &cb_args,
-                                        )
-                                    };
+                                let mut invoke_cb = create_invoke_cb!();
                                 let result = handler(&native_args, heap, stdout, &mut invoke_cb);
                                 #[cfg(feature = "telemetry")]
                                 registry.telemetry.native_boundary.record_call(
@@ -6622,19 +6616,7 @@ pub fn execute_class(
                                 native_args.insert(0, this_slot);
                                 #[cfg(feature = "telemetry")]
                                 let _native_start = std::time::Instant::now();
-                                let mut invoke_cb =
-                                    |heap: &mut duke_gc::Heap,
-                                     output: &mut dyn std::io::Write,
-                                     class: &str,
-                                     method: &str,
-                                     desc: &str,
-                                     cb_args: Vec<Slot>|
-                                     -> VmResult<Option<Slot>> {
-                                        execute_class(
-                                            registry, loader, heap, output, class, method, desc,
-                                            &cb_args,
-                                        )
-                                    };
+                                let mut invoke_cb = create_invoke_cb!();
                                 let result = handler(&native_args, heap, stdout, &mut invoke_cb);
                                 #[cfg(feature = "telemetry")]
                                 {
@@ -7554,18 +7536,7 @@ pub fn execute_class(
                                     callee_args.insert(0, this_slot);
                                     #[cfg(feature = "telemetry")]
                                     let _native_start = std::time::Instant::now();
-                                    let mut invoke_cb = |heap: &mut duke_gc::Heap,
-                                                         output: &mut dyn std::io::Write,
-                                                         class: &str,
-                                                         method: &str,
-                                                         desc: &str,
-                                                         cb_args: Vec<Slot>|
-                                     -> VmResult<Option<Slot>> {
-                                        execute_class(
-                                            registry, loader, heap, output, class, method, desc,
-                                            &cb_args,
-                                        )
-                                    };
+                                    let mut invoke_cb = create_invoke_cb!();
                                     let result =
                                         handler(&callee_args, heap, stdout, &mut invoke_cb);
                                     #[cfg(feature = "telemetry")]
@@ -7754,19 +7725,7 @@ pub fn execute_class(
                                         Some(HandlerKind::Callback(handler)) => {
                                             #[cfg(feature = "telemetry")]
                                             let _native_start = std::time::Instant::now();
-                                            let mut invoke_cb =
-                                                |heap: &mut duke_gc::Heap,
-                                                 output: &mut dyn std::io::Write,
-                                                 class: &str,
-                                                 method: &str,
-                                                 desc: &str,
-                                                 cb_args: Vec<Slot>|
-                                                 -> VmResult<Option<Slot>> {
-                                                    execute_class(
-                                                        registry, loader, heap, output, class,
-                                                        method, desc, &cb_args,
-                                                    )
-                                                };
+                                            let mut invoke_cb = create_invoke_cb!();
                                             let result =
                                                 handler(&impl_args, heap, stdout, &mut invoke_cb);
                                             #[cfg(feature = "telemetry")]


### PR DESCRIPTION
🚮 Smell: Repetitive `Vec::with_capacity` paired with manual `for` loops in parsing logic, plus a massive duplicated 10-line closure defined five times in the interpreter dispatch logic.
✨ Solution: Replaced manual iterations with `.map(...).collect::<Result<Vec<_>, _>>()` pipelines. Extracted the identical `invoke_cb` closure logic in `execute_class` into a strictly-scoped `macro_rules! create_invoke_cb`.
🧼 Benefit: Significantly flattens nesting, improves idiomatic Rust readability (using functional iterators), and thoroughly DRYs up the central JVM interpreter dispatch logic without angering the borrow checker.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [16844950143480603189](https://jules.google.com/task/16844950143480603189) started by @madmax983*