### PR TITLE
⚒️ Forge: Extract duplicated invoke_cb closure into macro

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -5,3 +5,6 @@
 **[Readability Smell]
 **Learning:** Found unused variables prefix with `_` triggering unused warnings because I removed the underscore but forgot to put `#[allow(unused_variables)]`.
 **Action:** Make sure to use `#[allow(unused_variables)]` if needed, or simply leave the `_` prefix if not used to avoid warnings.
+## 2026-03-16 - Extracted duplicated invoke_cb
+**Learning:** Found an inline `invoke_cb` closure duplicated 5 times with identical bodies to construct a callback. Creating an inline macro using `macro_rules!` cleans this up nicely without needing a free function to explicitly list captured vars.
+**Action:** Look out for code duplication and use `macro_rules!` for DRYing up closure logic where typical function extraction struggles due to context capture.

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -5191,6 +5191,22 @@ pub fn execute_class(
     descriptor: &str,
     args: &[Slot],
 ) -> VmResult<Option<Slot>> {
+    macro_rules! create_invoke_cb {
+        ($registry:ident, $loader:ident) => {
+            |heap: &mut duke_gc::Heap,
+             output: &mut dyn std::io::Write,
+             class: &str,
+             method: &str,
+             desc: &str,
+             cb_args: Vec<Slot>|
+             -> VmResult<Option<Slot>> {
+                execute_class(
+                    $registry, $loader, heap, output, class, method, desc, &cb_args,
+                )
+            }
+        };
+    }
+
     // Fast path: if a native handler is registered for this class/method/descriptor,
     // dispatch it directly without requiring a ClassContext in the registry.
     // This handles both Simple natives and Callback natives at the top-level call site.
@@ -5202,21 +5218,7 @@ pub fn execute_class(
             return h(args, heap, stdout);
         }
         Some(HandlerKind::Callback(h)) => {
-            // TODO: this `invoke_cb` closure body is duplicated at 5 dispatch
-            // sites. It can't be extracted into a free function because it
-            // captures `registry` and `loader` from the enclosing frame; a
-            // macro or an `InvokeContext` struct would remove the duplication.
-            let mut invoke_cb = |heap: &mut duke_gc::Heap,
-                                 output: &mut dyn std::io::Write,
-                                 class: &str,
-                                 method: &str,
-                                 desc: &str,
-                                 cb_args: Vec<Slot>|
-             -> VmResult<Option<Slot>> {
-                execute_class(
-                    registry, loader, heap, output, class, method, desc, &cb_args,
-                )
-            };
+            let mut invoke_cb = create_invoke_cb!(registry, loader);
             return h(args, heap, stdout, &mut invoke_cb);
         }
         None => {}
@@ -5492,19 +5494,7 @@ pub fn execute_class(
                                 native_args.reverse();
                                 #[cfg(feature = "telemetry")]
                                 let _native_start = std::time::Instant::now();
-                                let mut invoke_cb =
-                                    |heap: &mut duke_gc::Heap,
-                                     output: &mut dyn std::io::Write,
-                                     class: &str,
-                                     method: &str,
-                                     desc: &str,
-                                     cb_args: Vec<Slot>|
-                                     -> VmResult<Option<Slot>> {
-                                        execute_class(
-                                            registry, loader, heap, output, class, method, desc,
-                                            &cb_args,
-                                        )
-                                    };
+                                let mut invoke_cb = create_invoke_cb!(registry, loader);
                                 let result = handler(&native_args, heap, stdout, &mut invoke_cb);
                                 #[cfg(feature = "telemetry")]
                                 registry.telemetry.native_boundary.record_call(
@@ -6629,19 +6619,7 @@ pub fn execute_class(
                                 native_args.insert(0, this_slot);
                                 #[cfg(feature = "telemetry")]
                                 let _native_start = std::time::Instant::now();
-                                let mut invoke_cb =
-                                    |heap: &mut duke_gc::Heap,
-                                     output: &mut dyn std::io::Write,
-                                     class: &str,
-                                     method: &str,
-                                     desc: &str,
-                                     cb_args: Vec<Slot>|
-                                     -> VmResult<Option<Slot>> {
-                                        execute_class(
-                                            registry, loader, heap, output, class, method, desc,
-                                            &cb_args,
-                                        )
-                                    };
+                                let mut invoke_cb = create_invoke_cb!(registry, loader);
                                 let result = handler(&native_args, heap, stdout, &mut invoke_cb);
                                 #[cfg(feature = "telemetry")]
                                 {
@@ -7561,18 +7539,7 @@ pub fn execute_class(
                                     callee_args.insert(0, this_slot);
                                     #[cfg(feature = "telemetry")]
                                     let _native_start = std::time::Instant::now();
-                                    let mut invoke_cb = |heap: &mut duke_gc::Heap,
-                                                         output: &mut dyn std::io::Write,
-                                                         class: &str,
-                                                         method: &str,
-                                                         desc: &str,
-                                                         cb_args: Vec<Slot>|
-                                     -> VmResult<Option<Slot>> {
-                                        execute_class(
-                                            registry, loader, heap, output, class, method, desc,
-                                            &cb_args,
-                                        )
-                                    };
+                                    let mut invoke_cb = create_invoke_cb!(registry, loader);
                                     let result =
                                         handler(&callee_args, heap, stdout, &mut invoke_cb);
                                     #[cfg(feature = "telemetry")]
@@ -7761,19 +7728,7 @@ pub fn execute_class(
                                         Some(HandlerKind::Callback(handler)) => {
                                             #[cfg(feature = "telemetry")]
                                             let _native_start = std::time::Instant::now();
-                                            let mut invoke_cb =
-                                                |heap: &mut duke_gc::Heap,
-                                                 output: &mut dyn std::io::Write,
-                                                 class: &str,
-                                                 method: &str,
-                                                 desc: &str,
-                                                 cb_args: Vec<Slot>|
-                                                 -> VmResult<Option<Slot>> {
-                                                    execute_class(
-                                                        registry, loader, heap, output, class,
-                                                        method, desc, &cb_args,
-                                                    )
-                                                };
+                                            let mut invoke_cb = create_invoke_cb!(registry, loader);
                                             let result =
                                                 handler(&impl_args, heap, stdout, &mut invoke_cb);
                                             #[cfg(feature = "telemetry")]


### PR DESCRIPTION
🚮 **Smell:** 
The `invoke_cb` closure was duplicated exactly 5 times across different dispatch branches in `crates/duke-interpreter/src/lib.rs`. As noted by an inline TODO, it couldn't easily be extracted into a free function because it needed to capture `registry` and `loader` from the surrounding `execute_class` frame.

✨ **Solution:**
Created a local `macro_rules! create_invoke_cb` macro inside `execute_class` that generates the closure definition, allowing it to seamlessly capture the `registry` and `loader` context variables without boilerplate. Replaced all 5 occurrences with a simple `create_invoke_cb!(registry, loader)` invocation.

🧼 **Benefit:**
Reduces code duplication, removes a nagging inline TODO, and makes the various native handler dispatch paths much cleaner and easier to read.

🛡️ **Verification:**
- `cargo fmt --all` passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` passed cleanly
- `cargo test` in the `duke-interpreter` crate passed all 705 tests. No runtime logic was changed.

---
*PR created automatically by Jules for task [3515847901325188727](https://jules.google.com/task/3515847901325188727) started by @madmax983*