### PR TITLE
👺 Havoc: Fix OOM Capacity Overflow in JImage Reader

### DIFF
--- a/crates/duke-loader/src/jimage.rs
+++ b/crates/duke-loader/src/jimage.rs
@@ -189,7 +189,7 @@ impl JImageReader {
             // Raw deflate stream (negative window bits — no zlib header)
             let cap = usize::try_from(info.uncompressed).unwrap_or(0);
             let mut decoder = DeflateDecoder::new(raw);
-            let mut out = Vec::with_capacity(cap);
+            let mut out = Vec::with_capacity(cap.min(1024 * 1024 * 32));
             decoder
                 .read_to_end(&mut out)
                 .map_err(|_| LoadError::Decompress {
@@ -743,6 +743,19 @@ mod tests {
         assert!(
             matches!(result, Ok(ref v) if v == &[1, 2, 3, 4, 5]),
             "resource ending exactly at data boundary must succeed"
+        );
+    }
+
+    #[test]
+    fn read_resource_rejects_capacity_overflow() {
+        // Attack: Provide an uncompressed size of u64::MAX.
+        // If unpatched, Vec::with_capacity(usize::MAX) will panic with a capacity overflow.
+        // Uncompressed is max, compressed is 1 byte, so bounds check passes.
+        let reader = make_reader(vec![0xFF, 0xFF, 0, 0, 0], 2, u64::MAX);
+        let result = reader.read_resource("r");
+        assert!(
+            matches!(result, Err(LoadError::Decompress { .. })),
+            "should safely fail decompression, not panic with capacity overflow"
         );
     }
 }

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -312,11 +312,20 @@ pub struct TelemetryStore {
 #[cfg(feature = "telemetry")]
 impl TelemetryStore {
     /// Serialize the store to pretty-printed JSON.
+    ///
+    /// # Panics
+    ///
+    /// Panics if telemetry serialization fails.
+    #[must_use]
     pub fn to_json(&self) -> String {
         serde_json::to_string_pretty(self).expect("telemetry serialization failed")
     }
 
     /// Print a human-readable top-10 summary per channel to `w`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if writing to `w` fails.
     pub fn print_report(&self, w: &mut dyn std::io::Write) -> std::io::Result<()> {
         writeln!(w, "=== Duke VM Telemetry Report ===")?;
 
@@ -360,11 +369,10 @@ impl TelemetryStore {
             self.exception_flow.events.len()
         )?;
         for ev in &self.exception_flow.events {
-            let catch = ev
-                .catch_site
-                .as_ref()
-                .map(|(c, m, pc)| format!("{}::{} @{}", c, m, pc))
-                .unwrap_or_else(|| "uncaught".to_string());
+            let catch = ev.catch_site.as_ref().map_or_else(
+                || "uncaught".to_string(),
+                |(c, m, pc)| format!("{c}::{m} @{pc}"),
+            );
             writeln!(
                 w,
                 "  {} thrown at {:?} caught at {}",


### PR DESCRIPTION
🧨 **The Trigger:** A `.jimage` file header providing `uncompressed = 0xFFFFFFFFFFFFFFFF` for a resource attribute.

📉 **The Stack Trace:**
```
thread 'main' panicked at 'capacity overflow', library/alloc/src/raw_vec.rs
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: alloc::raw_vec::capacity_overflow
   3: alloc::raw_vec::RawVec<T,A>::allocate_in
   4: alloc::raw_vec::RawVec<T,A>::with_capacity_in
   5: alloc::vec::Vec<T,A>::with_capacity_in
   6: alloc::vec::Vec<T>::with_capacity
   7: duke_loader::jimage::JImageReader::read_resource
```

🧪 **Reproduction:** Run `cargo test jimage::tests::read_resource_rejects_capacity_overflow`

😈 **Comment:** You assumed the `uncompressed` size field in the jimage was trustworthy. You were wrong. Now I can't crash your JVM.

---
*PR created automatically by Jules for task [11766338036202557303](https://jules.google.com/task/11766338036202557303) started by @madmax983*