### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -230,7 +230,7 @@ impl Default for ClassRegistry {
 /// Arguments:
 /// - `&[Slot]`: method arguments (including `this` in slot 0 for instance methods)
 /// - `&mut Heap`: the object heap for reading/writing objects
-/// - `&mut dyn Write`: output sink (stdout in production, Vec<u8> in tests)
+/// - `&mut dyn Write`: output sink (stdout in production, `Vec<u8>` in tests)
 pub type NativeHandler = fn(&[Slot], &mut duke_gc::Heap, &mut dyn Write) -> VmResult<Option<Slot>>;
 
 /// A native handler that can call back into the interpreter to invoke Java methods.
@@ -7952,7 +7952,7 @@ struct CallFrame {
     class_name: String,
 }
 
-/// Build a [`ClassContext`] from a parsed [`ClassFile`].
+/// Build a [`ClassContext`] from a parsed [`duke_classfile::ClassFile`].
 ///
 /// Decodes all methods with a Code attribute and extracts field metadata.
 /// Methods without Code (abstract, native) are silently skipped.

--- a/crates/duke-loader/src/jimage.rs
+++ b/crates/duke-loader/src/jimage.rs
@@ -74,7 +74,7 @@ pub struct ResourceInfo {
 ///
 /// On [`open`](JImageReader::open), reads the entire file into memory and
 /// scans the locations table to build a path→resource index.  All subsequent
-/// [`find_resource`] and [`read_resource`] calls are O(1) hash lookups.
+/// [`JImageReader::find_resource`] and [`JImageReader::read_resource`] calls are O(1) hash lookups.
 pub struct JImageReader {
     data: Vec<u8>,
     resource_count: u32,


### PR DESCRIPTION
📖 Chapter: `duke-loader` and `duke-interpreter` documentation.
🔦 Insight: Several intra-doc links in the workspace were broken because they weren't fully qualified (`find_resource`, `read_resource`, `ClassFile`). An unescaped `u8` generic parameter in `Vec<u8>` was rendering as an invalid HTML tag.
🧪 Example: Qualified the methods with `JImageReader::` and the struct with `duke_classfile::`. Wrapped `Vec<u8>` in backticks.
🖼️ Preview: `cargo doc` now runs completely clean across the workspace with zero warnings.

---
*PR created automatically by Jules for task [11987736722949035785](https://jules.google.com/task/11987736722949035785) started by @madmax983*