### PR TITLE
⚡ Bolt: Avoid unnecessary allocations in Frame

### DIFF
--- a/crates/duke-runtime/src/frame.rs
+++ b/crates/duke-runtime/src/frame.rs
@@ -58,13 +58,14 @@ impl Frame {
                 max_locals,
             });
         }
-        let mut locals = vec![Slot::Int(0); max_locals];
-        for (i, arg) in args.into_iter().enumerate() {
-            locals[i] = arg;
-        }
+        // ⚡ Bolt: Re-use the existing `args` vector for `locals` to avoid an allocation
+        // and explicit copy loop. `resize` extends it with zeroes if needed.
+        let mut locals = args;
+        locals.resize(max_locals, Slot::Int(0));
         Ok(Self {
             locals,
-            stack: Vec::new(),
+            // ⚡ Bolt: Pre-allocate `stack` capacity to avoid reallocations during execution.
+            stack: Vec::with_capacity(max_stack),
             max_stack,
         })
     }


### PR DESCRIPTION
💡 What: Reused `args` Vec in `Frame::new` and pre-allocated `stack` capacity.
🎯 Why: To reduce memory allocations on the hot path of method invocation, avoiding unnecessary heap allocations and explicit copy loops.
📊 Impact: Fewer heap allocations and improved execution speed, particularly evident in method-heavy workloads.
🔬 Measurement: Verified with `cargo bench --bench interpreter`.

---
*PR created automatically by Jules for task [16909751642812212357](https://jules.google.com/task/16909751642812212357) started by @madmax983*