### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/crates/duke-bytecode/src/decoder.rs
+++ b/crates/duke-bytecode/src/decoder.rs
@@ -447,3 +447,89 @@ fn decode_wide(c: &mut Cursor<'_>, pc: usize) -> DecodeResult<Instruction> {
     };
     Ok(instr)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decoder_truncated_operands() {
+        // Sipush needs 2 bytes, only 1 provided
+        let code = [op::SIPUSH, 0x01];
+        let err = decode(&code).unwrap_err();
+        assert!(matches!(err, DecodeError::UnexpectedEof { pc: 2 }));
+    }
+
+    #[test]
+    fn test_decoder_unknown_opcode() {
+        let code = [0xFF];
+        let err = decode(&code).unwrap_err();
+        assert!(matches!(
+            err,
+            DecodeError::UnknownOpcode {
+                pc: 0,
+                opcode: 0xFF
+            }
+        ));
+    }
+
+    #[test]
+    fn test_decoder_invalid_wide_prefix() {
+        // Wide followed by an invalid opcode (e.g. NOP)
+        let code = [op::WIDE, op::NOP];
+        let err = decode(&code).unwrap_err();
+        assert!(matches!(
+            err,
+            DecodeError::InvalidWideTarget {
+                pc: 0,
+                opcode: op::NOP
+            }
+        ));
+    }
+
+    #[test]
+    fn test_decoder_bad_array_type() {
+        let code = [op::NEWARRAY, 0xFF]; // 0xFF is not a valid ArrayType code
+        let err = decode(&code).unwrap_err();
+        assert!(matches!(
+            err,
+            DecodeError::InvalidNewarrayType {
+                pc: 0,
+                type_code: 0xFF
+            }
+        ));
+    }
+
+    #[test]
+    fn test_decoder_invalid_tableswitch() {
+        // high < low
+        // tableswitch, padding(3), default(4), low(4), high(4)
+        let code = [
+            op::TABLESWITCH,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0, // default
+            0,
+            0,
+            0,
+            5, // low = 5
+            0,
+            0,
+            0,
+            1, // high = 1
+        ];
+        let err = decode(&code).unwrap_err();
+        assert!(matches!(
+            err,
+            DecodeError::InvalidTableswitch {
+                pc: 0,
+                low: 5,
+                high: 1
+            }
+        ));
+    }
+}

--- a/crates/duke-bytecode/src/instruction.rs
+++ b/crates/duke-bytecode/src/instruction.rs
@@ -556,3 +556,90 @@ impl Instruction {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_array_type_from_u8() {
+        assert_eq!(ArrayType::from_u8(4), Some(ArrayType::Boolean));
+        assert_eq!(ArrayType::from_u8(5), Some(ArrayType::Char));
+        assert_eq!(ArrayType::from_u8(6), Some(ArrayType::Float));
+        assert_eq!(ArrayType::from_u8(7), Some(ArrayType::Double));
+        assert_eq!(ArrayType::from_u8(8), Some(ArrayType::Byte));
+        assert_eq!(ArrayType::from_u8(9), Some(ArrayType::Short));
+        assert_eq!(ArrayType::from_u8(10), Some(ArrayType::Int));
+        assert_eq!(ArrayType::from_u8(11), Some(ArrayType::Long));
+        assert_eq!(ArrayType::from_u8(0), None);
+        assert_eq!(ArrayType::from_u8(12), None);
+    }
+
+    #[test]
+    fn test_instruction_mnemonics() {
+        // Just spot check a few major ones to ensure we don't crash
+        // and that they're populated. Table driven approach.
+        let cases = vec![
+            (Instruction::Nop, "nop"),
+            (Instruction::AconstNull, "aconst_null"),
+            (Instruction::IconstM1, "iconst_m1"),
+            (Instruction::Bipush(10), "bipush"),
+            (Instruction::Sipush(10), "sipush"),
+            (Instruction::Ldc(1), "ldc"),
+            (Instruction::Iload(1), "iload"),
+            (Instruction::Iload0, "iload_0"),
+            (Instruction::Laload, "laload"),
+            (Instruction::Istore(1), "istore"),
+            (Instruction::Istore0, "istore_0"),
+            (Instruction::Iastore, "iastore"),
+            (Instruction::Pop, "pop"),
+            (Instruction::Dup, "dup"),
+            (Instruction::Iadd, "iadd"),
+            (Instruction::Iinc { index: 1, value: 1 }, "iinc"),
+            (Instruction::I2l, "i2l"),
+            (Instruction::Lcmp, "lcmp"),
+            (Instruction::Ifeq(10), "ifeq"),
+            (Instruction::IfIcmpeq(10), "if_icmpeq"),
+            (Instruction::Goto(10), "goto"),
+            (
+                Instruction::Tableswitch {
+                    default: 0,
+                    low: 0,
+                    high: 0,
+                    offsets: vec![],
+                },
+                "tableswitch",
+            ),
+            (
+                Instruction::Lookupswitch {
+                    default: 0,
+                    pairs: vec![],
+                },
+                "lookupswitch",
+            ),
+            (Instruction::Ireturn, "ireturn"),
+            (Instruction::Return, "return"),
+            (Instruction::Getstatic(CpIndex(1)), "getstatic"),
+            (
+                Instruction::Invokeinterface {
+                    index: CpIndex(1),
+                    count: 1,
+                },
+                "invokeinterface",
+            ),
+            (Instruction::Newarray(ArrayType::Int), "newarray"),
+            (
+                Instruction::Multianewarray {
+                    index: CpIndex(1),
+                    dimensions: 1,
+                },
+                "multianewarray",
+            ),
+            (Instruction::IloadW(1), "wide iload"),
+        ];
+
+        for (instr, expected) in cases {
+            assert_eq!(instr.mnemonic(), expected);
+        }
+    }
+}

--- a/crates/duke-bytecode/src/verifier.rs
+++ b/crates/duke-bytecode/src/verifier.rs
@@ -436,3 +436,109 @@ const fn check_locals(instr: &Instruction, pc: usize, max_locals: usize) -> Veri
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::instruction::ArrayType;
+
+    #[test]
+    fn test_stack_effect_coverage() {
+        assert_eq!(stack_effect(&Instruction::Nop), (0, 0));
+        assert_eq!(stack_effect(&Instruction::Lload0), (0, 1));
+        assert_eq!(stack_effect(&Instruction::Daload), (2, 1));
+        assert_eq!(stack_effect(&Instruction::Dstore0), (1, 0));
+        assert_eq!(stack_effect(&Instruction::Lastore), (3, 0));
+        assert_eq!(stack_effect(&Instruction::Pop2), (2, 0));
+        assert_eq!(stack_effect(&Instruction::Dup2X2), (4, 6));
+        assert_eq!(stack_effect(&Instruction::Swap), (2, 2));
+        assert_eq!(stack_effect(&Instruction::Iadd), (2, 1));
+        assert_eq!(stack_effect(&Instruction::Dneg), (1, 1));
+        assert_eq!(
+            stack_effect(&Instruction::Iinc { index: 0, value: 1 }),
+            (0, 0)
+        );
+        assert_eq!(stack_effect(&Instruction::I2l), (1, 1));
+        assert_eq!(stack_effect(&Instruction::Lcmp), (2, 1));
+        assert_eq!(stack_effect(&Instruction::Ifeq(0)), (1, 0));
+        assert_eq!(stack_effect(&Instruction::IfIcmpne(0)), (2, 0));
+        assert_eq!(stack_effect(&Instruction::Goto(0)), (0, 0));
+        assert_eq!(stack_effect(&Instruction::Jsr(0)), (0, 1));
+        assert_eq!(stack_effect(&Instruction::Ret(0)), (0, 0));
+        assert_eq!(stack_effect(&Instruction::Return), (0, 0));
+        assert_eq!(stack_effect(&Instruction::Ireturn), (1, 0));
+        assert_eq!(
+            stack_effect(&Instruction::Getstatic(duke_classfile::CpIndex(1))),
+            (0, 1)
+        );
+        assert_eq!(
+            stack_effect(&Instruction::Putstatic(duke_classfile::CpIndex(1))),
+            (1, 0)
+        );
+        assert_eq!(
+            stack_effect(&Instruction::Getfield(duke_classfile::CpIndex(1))),
+            (1, 1)
+        );
+        assert_eq!(
+            stack_effect(&Instruction::Putfield(duke_classfile::CpIndex(1))),
+            (2, 0)
+        );
+        assert_eq!(
+            stack_effect(&Instruction::Invokevirtual(duke_classfile::CpIndex(1))),
+            (1, 0)
+        );
+        assert_eq!(
+            stack_effect(&Instruction::Invokestatic(duke_classfile::CpIndex(1))),
+            (0, 0)
+        );
+        assert_eq!(
+            stack_effect(&Instruction::New(duke_classfile::CpIndex(1))),
+            (0, 1)
+        );
+        assert_eq!(stack_effect(&Instruction::Newarray(ArrayType::Int)), (1, 1));
+        assert_eq!(
+            stack_effect(&Instruction::Multianewarray {
+                index: duke_classfile::CpIndex(1),
+                dimensions: 2
+            }),
+            (2, 1)
+        );
+        assert_eq!(stack_effect(&Instruction::Arraylength), (1, 1));
+        assert_eq!(stack_effect(&Instruction::Athrow), (1, 0));
+        assert_eq!(
+            stack_effect(&Instruction::Checkcast(duke_classfile::CpIndex(1))),
+            (1, 1)
+        );
+        assert_eq!(stack_effect(&Instruction::Monitorenter), (1, 0));
+    }
+
+    #[test]
+    fn test_verifier_athrow_resets_stack() {
+        let instructions = vec![
+            (0, Instruction::Iconst0),
+            (1, Instruction::Iconst0),
+            (2, Instruction::Athrow),
+            (3, Instruction::Return), // stack is 0 here after athrow
+        ];
+        // Athrow pops 1 but then stack is reset to 0
+        let res = verify(&instructions, 2, 0);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_verifier_local_oob() {
+        let instructions = vec![(0, Instruction::Iload(5)), (2, Instruction::Return)];
+        let res = verify(&instructions, 1, 5); // max locals is 5, index 5 is out of bounds
+        assert!(matches!(
+            res,
+            Err(VerifyError::LocalOutOfBounds { index: 5, .. })
+        ));
+
+        let instructions_store = vec![(0, Instruction::IstoreW(10)), (3, Instruction::Return)];
+        let res = verify(&instructions_store, 1, 10);
+        assert!(matches!(
+            res,
+            Err(VerifyError::LocalOutOfBounds { index: 10, .. })
+        ));
+    }
+}


### PR DESCRIPTION
🎯 Target: `duke-bytecode` crate (`instruction.rs`, `decoder.rs`, `verifier.rs`)
💣 Risk: Untested instruction mnemonics, stack-effect bounds mappings, and byte-sequence decoding error branches could silently break or incorrectly parse valid/invalid class files without test warnings.
🧪 Strategy: Added specific unit tests at the bottom of the files, avoiding arbitrary coverage. Used table-driven tests for properties like `stack_effect` and `mnemonic`, and isolated byte arrays for specific `DecodeError` branches.
🔬 Verification: `cargo test -p duke-bytecode` and verified with `cargo clippy`.

---
*PR created automatically by Jules for task [1593217657549930208](https://jules.google.com/task/1593217657549930208) started by @madmax983*