### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -114,6 +114,17 @@ impl<'a> Cursor<'a> {
 ///
 /// Returns an error if the input is truncated, has an invalid magic number,
 /// an unsupported version, or any structural inconsistency.
+///
+/// # Examples
+///
+/// ```
+/// use duke_classfile::parse;
+///
+/// // Create a minimal but invalid class file (wrong magic)
+/// let bytes = [0x00, 0x00, 0x00, 0x00];
+/// let result = parse(&bytes);
+/// assert!(result.is_err());
+/// ```
 pub fn parse(bytes: &[u8]) -> ParseResult<ClassFile> {
     let mut cursor = Cursor::new(bytes);
     let mut class_file = parse_class_file(&mut cursor)?;

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -9418,7 +9418,7 @@ fn slots_equal(a: &Slot, b: &Slot, heap: &duke_gc::Heap) -> bool {
     }
 }
 
-/// Native: `HashMap.<init>()V` — initialises size counter at fields[0] to 0.
+/// Native: `HashMap.<init>()V` — initialises size counter at fields\[0\] to 0.
 fn native_hashmap_init(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
@@ -9516,7 +9516,7 @@ fn native_hashmap_contains_key(
     Ok(Some(Slot::Int(0)))
 }
 
-/// Native: `HashMap.size()I` — returns entry count from fields[0].
+/// Native: `HashMap.size()I` — returns entry count from fields\[0\].
 fn native_hashmap_size(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
@@ -9610,7 +9610,7 @@ fn native_hashmap_get_or_default(
 // HashSet natives
 // ---------------------------------------------------------------------------
 
-/// Native: `HashSet.<init>()V` — initialises size counter at fields[0] to 0.
+/// Native: `HashSet.<init>()V` — initialises size counter at fields\[0\] to 0.
 fn native_hashset_init(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
@@ -9707,7 +9707,7 @@ fn native_hashset_remove(
     Ok(Some(Slot::Int(0)))
 }
 
-/// Native: `HashSet.size()I` — returns element count from fields[0].
+/// Native: `HashSet.size()I` — returns element count from fields\[0\].
 fn native_hashset_size(
     args: &[Slot],
     heap: &mut duke_gc::Heap,


### PR DESCRIPTION
📖 Chapter: The `duke-interpreter` and `duke-classfile` modules.
🔦 Insight: Fixed broken intra-doc links caused by unescaped array brackets and added an executable doctest for the class parser to demonstrate error handling.
🧪 Example: Added 1 executable doctest.
🖼️ Preview: Resolved cargo doc warnings.

---
*PR created automatically by Jules for task [13711693958691839518](https://jules.google.com/task/13711693958691839518) started by @madmax983*