### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - The Missing ClassLoader Guides
+**Confusion:** The `ClassLoader` implementations (`BootstrapLoader`, `DirectoryLoader`, and `JImageReader`) had no executable examples explaining how to instantiate them. Users were left guessing how `java/lang/Object` translates to a path under the hood.
+**Clarification:** Added executable `/// # Examples` doc-tests for `new` and `open` methods on each struct demonstrating correct usage and error handling.

--- a/crates/duke-loader/src/bootstrap.rs
+++ b/crates/duke-loader/src/bootstrap.rs
@@ -21,6 +21,22 @@ impl BootstrapLoader {
     /// # Errors
     ///
     /// Returns [`LoadError`] if the jimage file cannot be opened.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use duke_loader::{ClassLoader, BootstrapLoader};
+    /// use std::path::PathBuf;
+    ///
+    /// // In practice, `modules_path` points to a real JDK 21 `lib/modules` file.
+    /// // If the file is missing or invalid, it returns a LoadError.
+    /// let result = BootstrapLoader::new(
+    ///     &PathBuf::from("/invalid/path/to/lib/modules"),
+    ///     vec!["my_classes", "other_classes"]
+    /// );
+    ///
+    /// assert!(result.is_err());
+    /// ```
     pub fn new(modules_path: &Path, classpath_dirs: Vec<impl AsRef<Path>>) -> LoadResult<Self> {
         let jimage = JImageReader::open(modules_path)?;
         let classpath = classpath_dirs

--- a/crates/duke-loader/src/directory.rs
+++ b/crates/duke-loader/src/directory.rs
@@ -11,6 +11,23 @@ pub struct DirectoryLoader {
 }
 
 impl DirectoryLoader {
+    /// Creates a new `DirectoryLoader` rooted at the given directory.
+    ///
+    /// The loader will resolve internal class names (like `java/lang/Object`)
+    /// by searching for `{root}/java/lang/Object.class`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use duke_loader::{ClassLoader, DirectoryLoader};
+    /// use std::path::PathBuf;
+    ///
+    /// let loader = DirectoryLoader::new(PathBuf::from("my_classes"));
+    ///
+    /// // This will look for "my_classes/com/example/Main.class"
+    /// let _result = loader.find_class("com/example/Main");
+    /// ```
+    #[must_use]
     pub fn new(root: impl AsRef<Path>) -> Self {
         Self {
             root: root.as_ref().to_path_buf(),

--- a/crates/duke-loader/src/jimage.rs
+++ b/crates/duke-loader/src/jimage.rs
@@ -94,6 +94,20 @@ impl JImageReader {
     ///
     /// Returns [`LoadError::Io`] if the file cannot be read, or
     /// [`LoadError::JImageFormat`] if the file is not a valid jimage.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::path::Path;
+    /// use duke_loader::JImageReader;
+    ///
+    /// // Example of opening a potentially non-existent JDK `lib/modules` file.
+    /// // In production, this path comes from the `JAVA_HOME` environment variable.
+    /// let result = JImageReader::open(Path::new("/usr/lib/jvm/java-21-openjdk/lib/modules"));
+    ///
+    /// // It will gracefully return an Io error if the file is not found.
+    /// assert!(result.is_err());
+    /// ```
     pub fn open(path: &Path) -> LoadResult<Self> {
         let data = std::fs::read(path).map_err(|e| LoadError::Io {
             path: path.display().to_string(),


### PR DESCRIPTION
📖 Chapter: `duke-loader` ClassLoaders instantiation
🔦 Insight: The `ClassLoader` implementations (`BootstrapLoader`, `DirectoryLoader`, and `JImageReader`) had no executable examples explaining how to instantiate them or how they handle errors. 
🧪 Example: Added `/// # Examples` doc-tests demonstrating correct instantiation and error handling across all three.
🖼️ Preview: Ran `cargo doc --open` and `cargo test --doc -p duke-loader` verifying the examples pass perfectly.

---
*PR created automatically by Jules for task [13445471613953881923](https://jules.google.com/task/13445471613953881923) started by @madmax983*