### PR TITLE
⚒️ Forge: Refactor decoder switch loops to iterator chains

### DIFF
--- a/crates/duke-bytecode/src/decoder.rs
+++ b/crates/duke-bytecode/src/decoder.rs
@@ -313,10 +313,9 @@ fn decode_one(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> DecodeResult<Instruc
                 return Err(DecodeError::InvalidTableswitch { pc, low, high });
             }
             let count = usize::try_from(count_i64).unwrap_or(0);
-            let mut offsets = Vec::with_capacity(count);
-            for _ in 0..count {
-                offsets.push(c.read_i32()?);
-            }
+            let offsets = (0..count)
+                .map(|_| c.read_i32())
+                .collect::<Result<Vec<_>, _>>()?;
             Instruction::Tableswitch {
                 default,
                 low,
@@ -337,12 +336,14 @@ fn decode_one(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> DecodeResult<Instruc
             if usize::try_from(npairs).unwrap_or(usize::MAX) > remaining_pairs {
                 return Err(DecodeError::InvalidLookupswitch { pc, npairs });
             }
-            let mut pairs = Vec::with_capacity(usize::try_from(npairs).unwrap_or(0));
-            for _ in 0..npairs {
-                let match_val = c.read_i32()?;
-                let offset = c.read_i32()?;
-                pairs.push((match_val, offset));
-            }
+            let npairs_usize = usize::try_from(npairs).unwrap_or(0);
+            let pairs = (0..npairs_usize)
+                .map(|_| {
+                    let match_val = c.read_i32()?;
+                    let offset = c.read_i32()?;
+                    Ok((match_val, offset))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
             Instruction::Lookupswitch { default, pairs }
         }
 


### PR DESCRIPTION
🚮 Smell: Manual `for` loops with pre-allocated `Vec::with_capacity` pushing parsed elements are verbose and less idiomatic in Rust.

✨ Solution: Replaced the manual loops in `Tableswitch` and `Lookupswitch` decoding (`crates/duke-bytecode/src/decoder.rs`) with idiomatic iterator chains `(0..count).map(|_| ...).collect::<Result<Vec<_>, _>>()?`.

🧼 Benefit: Improves readability and strictly propagates errors seamlessly without mutable state for the vectors. Relies on `collect` to infer capacity from the `ExactSizeIterator`.

🛡️ Verification: `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` passed. No logic changed.

---
*PR created automatically by Jules for task [14537152464713131187](https://jules.google.com/task/14537152464713131187) started by @madmax983*