### PR TITLE
👺 Havoc: Fix panic on malformed descriptor string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ dependencies = [
  "duke-loader",
  "duke-runtime",
  "duke-telemetry",
+ "proptest",
 ]
 
 [[package]]

--- a/crates/duke-interpreter/Cargo.toml
+++ b/crates/duke-interpreter/Cargo.toml
@@ -16,6 +16,7 @@ duke-telemetry = { path = "../duke-telemetry", optional = true }
 telemetry = ["dep:duke-telemetry", "duke-telemetry/telemetry"]
 
 [dev-dependencies]
+proptest.workspace = true
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]

--- a/crates/duke-interpreter/proptest-regressions/lib.txt
+++ b/crates/duke-interpreter/proptest-regressions/lib.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc e13a6ca98eeefce0e82db6f98c1f9fed34d9e85c958026e2d3cc46080f4149c6 # shrinks to ref s = "🉐)"
+cc b744bb68fa2055f64ceb0f3b71a246f823b39fea9d893d833acdb9a976fa118d # shrinks to ref s = "ල)"

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -8264,7 +8264,11 @@ fn resolve_methodref(cp: &[Option<CpEntry>], idx: usize) -> VmResult<(String, St
 
 /// Count argument slots in a JVM method descriptor like `(ILjava/lang/String;[I)V`.
 fn parse_arg_count(descriptor: &str) -> usize {
-    let params = descriptor.find(')').map_or("", |i| &descriptor[1..i]);
+    let params = descriptor
+        .strip_prefix('(')
+        .and_then(|s| s.split_once(')'))
+        .map(|(p, _)| p)
+        .unwrap_or("");
     let mut count = 0;
     let mut chars = params.chars().peekable();
     while let Some(c) = chars.next() {
@@ -8403,7 +8407,11 @@ fn resolve_cp_string(cp: &[Option<CpEntry>], cp_idx: usize) -> VmResult<String> 
 /// Parse argument type descriptors from a JVM method descriptor like `(IZLjava/lang/String;)V`.
 /// Returns a Vec of single-char type codes: 'I', 'Z', 'L' (for object refs), '[' (for arrays), etc.
 fn parse_arg_types(descriptor: &str) -> Vec<char> {
-    let params = descriptor.find(')').map_or("", |i| &descriptor[1..i]);
+    let params = descriptor
+        .strip_prefix('(')
+        .and_then(|s| s.split_once(')'))
+        .map(|(p, _)| p)
+        .unwrap_or("");
     let mut types = Vec::new();
     let mut chars = params.chars().peekable();
     while let Some(c) = chars.next() {
@@ -22653,6 +22661,22 @@ mod tests {
         .unwrap()
         .unwrap();
         assert_eq!(r, Slot::Int(1));
+    }
+
+    // ---- parse_arg_count/parse_arg_types fuzzing ----
+
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn fuzz_parse_arg_count(ref s in "\\PC*") {
+            let _ = parse_arg_count(s);
+        }
+
+        #[test]
+        fn fuzz_parse_arg_types(ref s in "\\PC*") {
+            let _ = parse_arg_types(s);
+        }
     }
 
     // ---- parse_arg_count: array arm deletion (line 8295) ----

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -17993,6 +17993,14 @@ mod tests {
     }
 
     #[test]
+    fn parse_arg_count_malformed() {
+        assert_eq!(parse_arg_count("invalid"), 0);
+        assert_eq!(parse_arg_count("("), 0);
+        assert_eq!(parse_arg_count(")"), 0);
+        assert_eq!(parse_arg_count("(I"), 0);
+    }
+
+    #[test]
     fn parse_arg_types_primitives() {
         assert_eq!(parse_arg_types("(I)V"), vec!['I']);
         assert_eq!(parse_arg_types("(IZB)V"), vec!['I', 'Z', 'B']);
@@ -18008,6 +18016,14 @@ mod tests {
             parse_arg_types("(ILjava/lang/String;[I)V"),
             vec!['I', 'L', '[']
         );
+    }
+
+    #[test]
+    fn parse_arg_types_malformed() {
+        assert_eq!(parse_arg_types("invalid"), vec![]);
+        assert_eq!(parse_arg_types("("), vec![]);
+        assert_eq!(parse_arg_types(")"), vec![]);
+        assert_eq!(parse_arg_types("(I"), vec![]);
     }
 
     // ===========================================================================

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -8267,8 +8267,7 @@ fn parse_arg_count(descriptor: &str) -> usize {
     let params = descriptor
         .strip_prefix('(')
         .and_then(|s| s.split_once(')'))
-        .map(|(p, _)| p)
-        .unwrap_or("");
+        .map_or("", |(p, _)| p);
     let mut count = 0;
     let mut chars = params.chars().peekable();
     while let Some(c) = chars.next() {
@@ -8410,8 +8409,7 @@ fn parse_arg_types(descriptor: &str) -> Vec<char> {
     let params = descriptor
         .strip_prefix('(')
         .and_then(|s| s.split_once(')'))
-        .map(|(p, _)| p)
-        .unwrap_or("");
+        .map_or("", |(p, _)| p);
     let mut types = Vec::new();
     let mut chars = params.chars().peekable();
     while let Some(c) = chars.next() {


### PR DESCRIPTION
👺 Havoc: Fix panic on malformed descriptor string

🧨 **The Trigger:** Providing an invalid method descriptor string (like `")"` or one with multi-byte characters before `)`) to `parse_arg_count` or `parse_arg_types` caused a panic due to invalid char boundary string slicing.
📉 **The Stack Trace:** `thread 'main' panicked at 'byte index 1 is not a char boundary; it is inside...'`
🧪 **Reproduction:** Run the newly added `cargo test -p duke-interpreter havoc` fuzzing proptest.
😈 **Comment:** Never trust that the character at index 1 is exactly 1 byte. Your assumptions caused a system panic. Replaced manual indexing with safe `strip_prefix` and `split_once`.

---
*PR created automatically by Jules for task [5130107304624440359](https://jules.google.com/task/5130107304624440359) started by @madmax983*