### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/crates/duke-bytecode/src/decoder.rs
+++ b/crates/duke-bytecode/src/decoder.rs
@@ -989,4 +989,72 @@ mod tests {
             }
         ));
     }
+
+    #[test]
+    fn test_decoder_tableswitch_too_many_entries() {
+        // count = high - low + 1 = 10 - 0 + 1 = 11, but only 4 bytes of offsets provided.
+        let code = [
+            op::TABLESWITCH,
+            0,
+            0,
+            0, // padding
+            0,
+            0,
+            0,
+            0, // default
+            0,
+            0,
+            0,
+            0, // low = 0
+            0,
+            0,
+            0,
+            10, // high = 10
+            0,
+            0,
+            0,
+            0, // 1 entry provided, need 11
+        ];
+        let err = decode(&code).unwrap_err();
+        assert!(matches!(
+            err,
+            DecodeError::InvalidTableswitch {
+                pc: 0,
+                low: 0,
+                high: 10
+            }
+        ));
+    }
+
+    #[test]
+    fn test_decoder_lookupswitch_too_many_pairs() {
+        // npairs = 10, but only 8 bytes of pairs provided.
+        let code = [
+            op::LOOKUPSWITCH,
+            0,
+            0,
+            0, // padding
+            0,
+            0,
+            0,
+            0, // default
+            0,
+            0,
+            0,
+            10, // npairs = 10
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0, // 1 pair provided, need 10
+        ];
+        let err = decode(&code).unwrap_err();
+        assert!(matches!(
+            err,
+            DecodeError::InvalidLookupswitch { pc: 0, npairs: 10 }
+        ));
+    }
 }


### PR DESCRIPTION
🎯 Target: `duke-bytecode/src/decoder.rs` (`decode` function)
💣 Risk: Prevent out-of-memory (OOM) / capacity overflow panics by ensuring that `TABLESWITCH` and `LOOKUPSWITCH` reject instructions that declare more elements/pairs than there are bytes left in the buffer. The underlying implementation has correct checks already, this just increases confidence via test coverage.
🧪 Strategy: Added two specific unit tests using table-driven error match asserting on `DecodeError::InvalidTableswitch` and `DecodeError::InvalidLookupswitch` when provided with invalid huge lengths.
🔬 Verification: Run `cargo test -p duke-bytecode`

---
*PR created automatically by Jules for task [12889436411658080095](https://jules.google.com/task/12889436411658080095) started by @madmax983*