### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -45,7 +45,9 @@ const DEFAULT_PROMOTION_AGE: u8 = 4;
 /// ```
 #[derive(Debug, Clone)]
 pub struct HeapObject {
+    /// The runtime class name of this object (e.g. `"java/lang/String"`).
     pub class_name: String,
+    /// Storage for all instance fields of this object.
     pub fields: Vec<Slot>,
     /// String content for `java/lang/String` objects. `None` for non-string objects.
     pub string_value: Option<String>,
@@ -63,8 +65,11 @@ pub struct HeapObject {
 }
 
 #[derive(Debug)]
+/// A handle to a native file managed by the VM on behalf of Java I/O classes.
 pub enum HostFileHandle {
+    /// A file opened for reading.
     Reader(std::fs::File),
+    /// A file opened for writing.
     Writer(std::fs::File),
 }
 
@@ -311,6 +316,9 @@ impl Heap {
             })
     }
 
+    /// Closes a host file handle previously opened via the registry.
+    ///
+    /// Silently ignores invalid or already-closed file descriptors.
     pub fn close_host_file(&mut self, id: i32) {
         if id > 0 {
             self.host_files.remove(&id);

--- a/crates/duke-interpreter/src/context.rs
+++ b/crates/duke-interpreter/src/context.rs
@@ -1,40 +1,143 @@
+//! Core execution context types for methods and classes.
+//!
+//! This module defines the structural components required to execute loaded classes,
+//! such as parsed methods, field layouts, and exception handler tables.
+
 use duke_bytecode::Instruction;
 use duke_classfile::types::CpEntry;
 use duke_runtime::Slot;
 
 /// A decoded method ready for execution.
+///
+/// This is the engine room of the JVM. It contains not just the raw bytecode
+/// instructions, but the pre-computed control flow mapping (`pc_to_idx`) and
+/// stack sizing requirements needed to rapidly execute a method invocation.
+///
+/// # Examples
+///
+/// ```
+/// use duke_interpreter::context::MethodEntry;
+/// use std::sync::Arc;
+/// use std::collections::HashMap;
+///
+/// let method = MethodEntry {
+///     name: "add".to_string(),
+///     descriptor: "(II)I".to_string(),
+///     instructions: Arc::new([]),
+///     max_stack: 2,
+///     max_locals: 2,
+///     exception_table: vec![],
+///     pc_to_idx: Arc::new(HashMap::new()),
+/// };
+/// assert_eq!(method.max_stack, 2);
+/// ```
 pub struct MethodEntry {
+    /// The identifier used for method resolution (e.g. `"main"` or `"<init>"`).
     pub name: String,
+    /// The signature defining argument types and return type (e.g. `"([Ljava/lang/String;)V"`).
     pub descriptor: String,
+    /// The linear sequence of executable instructions, paired with their original byte offset
+    /// in the `.class` file to allow for accurate branch resolution and stack trace generation.
     pub instructions: std::sync::Arc<[(usize, Instruction)]>,
+    /// The exact maximum depth the operand stack will reach during execution,
+    /// used to pre-allocate memory safely without growing the stack dynamically.
     pub max_stack: u16,
+    /// The number of local variable slots required, including arguments and `this`.
     pub max_locals: u16,
+    /// A list of active exception handlers that dictate where control flow should jump
+    /// if a specific error is thrown within their designated PC bounds.
     pub exception_table: Vec<ExceptionEntry>,
-    /// Precomputed PC → instruction-index map, shared cheaply via Arc.
+    /// Precomputed PC → instruction-index map, shared cheaply via Arc to ensure
+    /// `GOTO` and branch instructions resolve in O(1) time.
     pub pc_to_idx: std::sync::Arc<std::collections::HashMap<usize, usize>>,
 }
 
 /// A field declaration extracted from a parsed class.
+///
+/// This represents the structural definition of a field as declared in the `.class` file,
+/// mapping exactly to how the Java compiler saw the field layout. It does not hold
+/// runtime values, but rather acts as the blueprint for creating [`duke_runtime::Slot`]s
+/// during object allocation.
+///
+/// # Examples
+///
+/// ```
+/// use duke_interpreter::context::FieldEntry;
+///
+/// // A blueprint for `private int x;`
+/// let field = FieldEntry {
+///     name: "x".to_string(),
+///     descriptor: "I".to_string(),
+///     is_static: false,
+/// };
+/// assert_eq!(field.name, "x");
+/// ```
 pub struct FieldEntry {
+    /// The exact identifier used in the source code (e.g., `"MAX_VALUE"` or `"counter"`).
     pub name: String,
+    /// The JVM type descriptor dictating the field's size and type (e.g., `"I"` for int,
+    /// or `"Ljava/lang/String;"` for object references).
     pub descriptor: String,
-    /// True if declared `static`.
+    /// If `true`, this field belongs to the class itself and its value is stored in
+    /// [`ClassContext::static_fields`]. If `false`, it's an instance field stored inside
+    /// a `HeapObject`.
     pub is_static: bool,
 }
 
 /// A resolved exception table entry for handler dispatch.
 ///
 /// Built from `duke_classfile::types::ExceptionTableEntry` with `catch_type`
-/// resolved from a CP index to a class name string.
+/// resolved from a CP index to a class name string. It acts as a safety net,
+/// defining the exact boundaries where a `try` block is active.
+///
+/// # Examples
+///
+/// ```
+/// use duke_interpreter::context::ExceptionEntry;
+///
+/// let handler = ExceptionEntry {
+///     start_pc: 0,
+///     end_pc: 10,
+///     handler_pc: 15,
+///     catch_type: Some("java/lang/NullPointerException".to_string()),
+/// };
+/// assert!(handler.catch_type.is_some());
+/// ```
 pub struct ExceptionEntry {
+    /// Inclusive start PC of the try block where this handler becomes active.
     pub start_pc: u16,
+    /// Exclusive end PC of the try block where this handler deactivates.
     pub end_pc: u16,
+    /// The program counter offset where execution should jump to if the exception matches.
     pub handler_pc: u16,
-    /// `None` for catch-all (finally). `Some(class_name)` for typed catches.
+    /// The specific class of exception to catch (e.g. `"java/io/IOException"`).
+    /// If `None`, this handler catches *all* exceptions (typically used for `finally` blocks).
     pub catch_type: Option<String>,
 }
 
 /// A parsed class with all methods decoded — the unit of execution for Phase 5+.
+///
+/// This struct takes the raw data from a `.class` file and fully realizes it into
+/// memory, linking the constant pool, method bytecode, and static field states.
+///
+/// # Examples
+///
+/// ```
+/// use duke_interpreter::context::ClassContext;
+///
+/// let context = ClassContext {
+///     class_name: "java/lang/Object".to_string(),
+///     super_class: None,
+///     interfaces: vec![],
+///     constant_pool: vec![],
+///     methods: vec![],
+///     fields: vec![],
+///     static_fields: vec![],
+///     instance_field_count: 0,
+///     bootstrap_methods: vec![],
+/// };
+/// assert_eq!(context.class_name, "java/lang/Object");
+/// ```
 pub struct ClassContext {
     /// Internal JVM class name (e.g. `"Point"`).
     pub class_name: String,
@@ -42,13 +145,17 @@ pub struct ClassContext {
     pub super_class: Option<String>,
     /// Directly implemented interfaces (used by checkcast / instanceof).
     pub interfaces: Vec<String>,
+    /// The fully resolved constant pool, allowing instructions like `ldc` to fetch
+    /// strings, classes, and method handles without re-parsing.
     pub constant_pool: Vec<Option<CpEntry>>,
+    /// Decoded methods available on this class, ready for execution dispatch.
     pub methods: Vec<MethodEntry>,
     /// All field declarations (static and instance), in class file order.
     pub fields: Vec<FieldEntry>,
     /// Values of static fields, indexed by position among static-only fields.
     pub static_fields: Vec<Slot>,
-    /// Number of instance (non-static) fields — used to size heap objects at `new`.
+    /// Number of instance (non-static) fields — used to quickly calculate the size
+    /// of new heap objects when a `new` instruction is encountered.
     pub instance_field_count: usize,
     /// `BootstrapMethods` entries from the class attribute (needed for invokedynamic).
     pub bootstrap_methods: Vec<duke_classfile::types::BootstrapMethodEntry>,

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -4,7 +4,9 @@
 //! float, and double arithmetic, control flow, and local variables.  Heap
 //! allocation, field access, and method invocation are not yet implemented.
 
+/// Core execution context types for methods and classes.
 pub mod context;
+/// Repositories for loaded classes and registered native methods.
 pub mod registry;
 
 pub use context::*;

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -1,3 +1,9 @@
+//! Repositories for loaded classes and registered native methods.
+//!
+//! Provides the execution environment with access to classes, handles class loading and
+//! initialization on demand, and maintains the mapping between `native` methods
+//! and their Rust implementations.
+
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
 
@@ -19,6 +25,7 @@ pub(crate) struct LambdaInfo {
     pub captured_count: usize,
 }
 
+/// A registry managing loaded classes, their initialization state, and associated native methods.
 pub struct ClassRegistry {
     classes: HashMap<String, ClassContext>,
     natives: NativeRegistry,
@@ -232,7 +239,9 @@ pub type InvokeFn<'a> = dyn FnMut(&mut duke_gc::Heap, &mut dyn Write, &str, &str
 /// Stored in `NativeRegistry` — all existing handlers stay `Simple`.
 #[derive(Copy, Clone, Debug)]
 pub enum HandlerKind {
+    /// A simple stateless native method handler.
     Simple(NativeHandler),
+    /// A handler that delegates back to a callback trait or closure.
     Callback(CallbackNativeHandler),
 }
 

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -1,3 +1,8 @@
+//! Main entry point for the Duke JVM executable.
+//!
+//! Handles command-line argument parsing, environment initialization,
+//! class loading, and the main execution loop for the JVM.
+
 use std::process;
 
 use duke_bytecode::decode;


### PR DESCRIPTION
📖 Chapter: The `duke-interpreter` context and `duke-gc` memory models.
🔦 Insight: Explained the `MethodEntry`, `ClassContext`, `ExceptionEntry`, and `FieldEntry` structures in depth, detailing their role in JVM execution and how they map to raw bytecode constructs. Added module-level documentation (`//!`) to clarify the architectural boundaries of `context.rs`, `registry.rs`, and the `main.rs` entrypoint. Clarified `HeapObject` layout and native `HostFileHandle` usage in the GC layer.
🧪 Example: Added 4 executable doctests for `FieldEntry`, `MethodEntry`, `ExceptionEntry`, and `ClassContext` to demonstrate construction and architectural intent.
🖼️ Preview: Resolved all `missing_docs` errors under strict pedantic checking.

---
*PR created automatically by Jules for task [4685456072257105572](https://jules.google.com/task/4685456072257105572) started by @madmax983*