### PR TITLE
⚡ Bolt: Optimize JVM stack argument extraction

### DIFF
--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -6117,10 +6117,14 @@ fn run_execution(
                         match handler_kind {
                             Some(HandlerKind::Simple(handler)) => {
                                 let arg_count = parse_arg_count(&callee_desc);
-                                let mut native_args: Vec<Slot> = (0..arg_count)
-                                    .map(|_| frame.pop())
-                                    .collect::<VmResult<Vec<_>>>()?;
-                                native_args.reverse();
+                                // PERF: Pre-allocate args and populate backwards to avoid intermediate .collect() and .reverse() allocs.
+
+                                let mut native_args = vec![Slot::Int(0); arg_count];
+
+                                for i in (0..arg_count).rev() {
+                                    native_args[i] = frame.pop()?;
+                                }
+
                                 #[cfg(feature = "telemetry")]
                                 let _native_start = std::time::Instant::now();
                                 let mut native_control = NativeControl::default();
@@ -6155,10 +6159,13 @@ fn run_execution(
                             }
                             Some(HandlerKind::Callback(handler)) => {
                                 let arg_count = parse_arg_count(&callee_desc);
-                                let mut native_args: Vec<Slot> = (0..arg_count)
-                                    .map(|_| frame.pop())
-                                    .collect::<VmResult<Vec<_>>>()?;
-                                native_args.reverse();
+                                // PERF: Pre-allocate args and populate backwards to avoid intermediate .collect() and .reverse() allocs.
+
+                                let mut native_args = vec![Slot::Int(0); arg_count];
+
+                                for i in (0..arg_count).rev() {
+                                    native_args[i] = frame.pop()?;
+                                }
                                 #[cfg(feature = "telemetry")]
                                 let _native_start = std::time::Instant::now();
                                 let mut invoke_cb = create_invoke_cb!(registry, loader);
@@ -7107,10 +7114,13 @@ fn run_execution(
                                     registry.get_lambda(actual_class).cloned()
                                 && callee_name == lambda_info.sam_method
                             {
-                                let mut sam_args: Vec<Slot> = (0..arg_count)
-                                    .map(|_| frame.pop())
-                                    .collect::<VmResult<Vec<_>>>()?;
-                                sam_args.reverse();
+                                // PERF: Pre-allocate args and populate backwards to avoid intermediate .collect() and .reverse() allocs.
+
+                                let mut sam_args = vec![Slot::Int(0); arg_count];
+
+                                for i in (0..arg_count).rev() {
+                                    sam_args[i] = frame.pop()?;
+                                }
                                 let this_slot = frame.pop()?;
                                 let this_ref = match &this_slot {
                                     Slot::Reference(Some(r)) => *r,
@@ -7209,10 +7219,14 @@ fn run_execution(
                         match native_handler_kind {
                             Some(HandlerKind::Simple(handler)) => {
                                 let arg_count = parse_arg_count(&callee_desc);
-                                let mut native_args: Vec<Slot> = (0..arg_count)
-                                    .map(|_| frame.pop())
-                                    .collect::<VmResult<Vec<_>>>()?;
-                                native_args.reverse();
+                                // PERF: Pre-allocate args and populate backwards to avoid intermediate .collect() and .reverse() allocs.
+
+                                let mut native_args = vec![Slot::Int(0); arg_count];
+
+                                for i in (0..arg_count).rev() {
+                                    native_args[i] = frame.pop()?;
+                                }
+
                                 let this_slot = frame.pop()?; // pop `this`
                                 native_args.insert(0, this_slot);
                                 #[cfg(feature = "telemetry")]
@@ -7261,10 +7275,13 @@ fn run_execution(
                             }
                             Some(HandlerKind::Callback(handler)) => {
                                 let arg_count = parse_arg_count(&callee_desc);
-                                let mut native_args: Vec<Slot> = (0..arg_count)
-                                    .map(|_| frame.pop())
-                                    .collect::<VmResult<Vec<_>>>()?;
-                                native_args.reverse();
+                                // PERF: Pre-allocate args and populate backwards to avoid intermediate .collect() and .reverse() allocs.
+
+                                let mut native_args = vec![Slot::Int(0); arg_count];
+
+                                for i in (0..arg_count).rev() {
+                                    native_args[i] = frame.pop()?;
+                                }
                                 let this_slot = frame.pop()?; // pop `this`
                                 native_args.insert(0, this_slot);
                                 #[cfg(feature = "telemetry")]
@@ -7855,10 +7872,13 @@ fn run_execution(
                     // --- StringConcatFactory.makeConcatWithConstants ---
                     let arg_count = parse_arg_count(&call_desc);
                     let arg_types = parse_arg_types(&call_desc);
-                    let mut dynamic_args: Vec<Slot> = (0..arg_count)
-                        .map(|_| frame.pop())
-                        .collect::<VmResult<Vec<_>>>()?;
-                    dynamic_args.reverse();
+                    // PERF: Pre-allocate args and populate backwards to avoid intermediate .collect() and .reverse() allocs.
+
+                    let mut dynamic_args = vec![Slot::Int(0); arg_count];
+
+                    for i in (0..arg_count).rev() {
+                        dynamic_args[i] = frame.pop()?;
+                    }
 
                     // Resolve recipe (first bootstrap arg) and constants (remaining).
                     let (recipe, constants) = {
@@ -7928,10 +7948,13 @@ fn run_execution(
 
                     // Pop captured variables from the stack.
                     let captured_count = parse_arg_count(&call_desc);
-                    let mut captured_args: Vec<Slot> = (0..captured_count)
-                        .map(|_| frame.pop())
-                        .collect::<VmResult<Vec<_>>>()?;
-                    captured_args.reverse();
+                    // PERF: Pre-allocate args and populate backwards to avoid intermediate .collect() and .reverse() allocs.
+
+                    let mut captured_args = vec![Slot::Int(0); captured_count];
+
+                    for i in (0..captured_count).rev() {
+                        captured_args[i] = frame.pop()?;
+                    }
 
                     let lambda_info = LambdaInfo {
                         impl_class: impl_class.clone(),
@@ -8040,10 +8063,14 @@ fn run_execution(
                                 Some(HandlerKind::Simple(handler)) => {
                                     // Native path: collect args + this into a Vec<Slot>
                                     // for the handler(&[Slot], ...) signature.
-                                    let mut callee_args: Vec<Slot> = (0..arg_count)
-                                        .map(|_| frame.pop())
-                                        .collect::<VmResult<Vec<_>>>()?;
-                                    callee_args.reverse();
+                                    // PERF: Pre-allocate args and populate backwards to avoid intermediate .collect() and .reverse() allocs.
+
+                                    let mut callee_args = vec![Slot::Int(0); arg_count];
+
+                                    for i in (0..arg_count).rev() {
+                                        callee_args[i] = frame.pop()?;
+                                    }
+
                                     let this_slot = frame.pop()?;
                                     callee_args.insert(0, this_slot);
                                     #[cfg(feature = "telemetry")]
@@ -8093,10 +8120,13 @@ fn run_execution(
                                     continue;
                                 }
                                 Some(HandlerKind::Callback(handler)) => {
-                                    let mut callee_args: Vec<Slot> = (0..arg_count)
-                                        .map(|_| frame.pop())
-                                        .collect::<VmResult<Vec<_>>>()?;
-                                    callee_args.reverse();
+                                    // PERF: Pre-allocate args and populate backwards to avoid intermediate .collect() and .reverse() allocs.
+
+                                    let mut callee_args = vec![Slot::Int(0); arg_count];
+
+                                    for i in (0..arg_count).rev() {
+                                        callee_args[i] = frame.pop()?;
+                                    }
                                     let this_slot = frame.pop()?;
                                     callee_args.insert(0, this_slot);
                                     #[cfg(feature = "telemetry")]
@@ -8156,10 +8186,13 @@ fn run_execution(
                                 && callee_name == lambda_info.sam_method
                             {
                                 // Lambda path: collect args + this into a Vec<Slot>.
-                                let mut callee_args: Vec<Slot> = (0..arg_count)
-                                    .map(|_| frame.pop())
-                                    .collect::<VmResult<Vec<_>>>()?;
-                                callee_args.reverse();
+                                // PERF: Pre-allocate args and populate backwards to avoid intermediate .collect() and .reverse() allocs.
+
+                                let mut callee_args = vec![Slot::Int(0); arg_count];
+
+                                for i in (0..arg_count).rev() {
+                                    callee_args[i] = frame.pop()?;
+                                }
                                 let this_slot = frame.pop()?;
                                 callee_args.insert(0, this_slot);
                                 let this_ref = match &callee_args[0] {


### PR DESCRIPTION
💡 **What**: Replaced intermediate `.collect::<VmResult<Vec<_>>>()` allocation chains and subsequent `.reverse()` passes when popping function arguments from the execution frame in `duke-interpreter` with direct pre-allocation (`vec![...; arg_count]`) and an imperative reverse-iteration loop.

🎯 **Why**: The previous approach involved mapping over an iterator, collecting into a dynamically resizing `Vec`, and then iterating again to reverse it. This created unnecessary intermediate allocations and overhead on a very hot path (every method/native invocation).

📊 **Impact**: Reduces heap allocations and completely removes the `.reverse()` pass cost for every argument extraction from the stack. The vector is allocated exactly once per call with the correct capacity.

🔬 **Measurement**: Verified via `cargo test` that the argument extraction behaves identically (maintains correct argument order and stack semantics). Checked with `cargo clippy` to ensure no safety or style regressions were introduced.

---
*PR created automatically by Jules for task [7608981734459476167](https://jules.google.com/task/7608981734459476167) started by @madmax983*