### PR TITLE
⚒️ Forge: Fix used_underscore_binding on method_name parameter

### DIFF
--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -5808,7 +5808,7 @@ impl ExecutionState {
     fn new(
         registry: &ClassRegistry,
         class_name: &str,
-        _method_name: &str,
+        #[cfg_attr(not(feature = "telemetry"), allow(unused_variables))] method_name: &str,
         entry_idx: usize,
         args: &[Slot],
     ) -> VmResult<Self> {
@@ -5842,7 +5842,7 @@ impl ExecutionState {
             idx: 0,
             string_intern: HashMap::new(),
             #[cfg(feature = "telemetry")]
-            current_method: _method_name.to_string(),
+            current_method: method_name.to_string(),
         })
     }
 }


### PR DESCRIPTION
🚮 Smell: The argument `_method_name` in `ExecutionState::new` was prefixed with an underscore, traditionally denoting an unused variable, but was actually evaluated and used when the `telemetry` feature was enabled. This triggered `clippy::used_underscore_binding`.
✨ Solution: Renamed the variable to `method_name` to accurately reflect its usage. To prevent `unused_variables` warnings when compiling without telemetry, the parameter is annotated with `#[cfg_attr(not(feature = "telemetry"), allow(unused_variables))]`.
🧼 Benefit: Improves readability and aligns with Rust idioms for conditional compilation, removing the misleading underscore prefix while resolving compiler warnings cleanly.
🛡️ Verification: Tests passed. No logic changed. All clippy pedantic and nursery warnings resolve cleanly.

---
*PR created automatically by Jules for task [80064011716166865](https://jules.google.com/task/80064011716166865) started by @madmax983*