### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -5808,7 +5808,7 @@ impl ExecutionState {
     fn new(
         registry: &ClassRegistry,
         class_name: &str,
-        _method_name: &str,
+        #[cfg_attr(not(feature = "telemetry"), allow(unused_variables))] method_name: &str,
         entry_idx: usize,
         args: &[Slot],
     ) -> VmResult<Self> {
@@ -5842,7 +5842,7 @@ impl ExecutionState {
             idx: 0,
             string_intern: HashMap::new(),
             #[cfg(feature = "telemetry")]
-            current_method: _method_name.to_string(),
+            current_method: method_name.to_string(),
         })
     }
 }
@@ -17918,6 +17918,66 @@ mod tests {
         .unwrap();
         let s = String::from_utf8(out).unwrap();
         assert!(s.contains('3'), "expected '3' in '{s}'");
+    }
+
+    #[test]
+    fn native_print_int_value() {
+        let mut heap = duke_gc::Heap::new();
+        let mut out = Vec::new();
+        let mut control = NativeControl::default();
+        native_print_int(
+            &[Slot::Reference(None), Slot::Int(42)],
+            &mut heap,
+            &mut out,
+            &mut control,
+        )
+        .unwrap();
+        assert_eq!(String::from_utf8(out).unwrap(), "42");
+    }
+
+    #[test]
+    fn native_print_int_type_mismatch() {
+        let mut heap = duke_gc::Heap::new();
+        let mut out = Vec::new();
+        let mut control = NativeControl::default();
+        let err = native_print_int(
+            &[Slot::Reference(None), Slot::Long(42)],
+            &mut heap,
+            &mut out,
+            &mut control,
+        )
+        .unwrap_err();
+        assert!(matches!(err, VmError::TypeMismatch { .. }));
+    }
+
+    #[test]
+    fn native_println_int_value() {
+        let mut heap = duke_gc::Heap::new();
+        let mut out = Vec::new();
+        let mut control = NativeControl::default();
+        native_println_int(
+            &[Slot::Reference(None), Slot::Int(100)],
+            &mut heap,
+            &mut out,
+            &mut control,
+        )
+        .unwrap();
+        assert_eq!(String::from_utf8(out).unwrap(), "100\n");
+    }
+
+    #[test]
+    fn native_println_int_type_mismatch() {
+        let mut heap = duke_gc::Heap::new();
+        let mut out = Vec::new();
+        let mut control = NativeControl::default();
+        let err = native_println_int(
+            &[Slot::Reference(None), Slot::Float(100.0)],
+            &mut heap,
+            &mut out,
+            &mut control,
+        )
+        .unwrap_err();
+        assert!(matches!(err, VmError::TypeMismatch { .. }));
     }
 
     #[test]


### PR DESCRIPTION
🎯 **Target:** Added unit tests for `native_print_int` and `native_println_int` in `crates/duke-interpreter/src/lib.rs`.
💣 **Risk:** Prevented lack of coverage on primitive print boundaries, which could cause undetected regressions or unexpected `VmError::TypeMismatch` occurrences on malformed outputs during native execution.
🧪 **Strategy:** Implemented explicit "happy path" checks ensuring integer values get correctly formatted with or without newlines, and "error path" checks enforcing `VmError::TypeMismatch` when receiving unsupported or malformed inputs (e.g. `Slot::Long` or `Slot::Float`).
🔬 **Verification:** Run tests with `cargo test native_print_int` and `cargo test native_println_int`.

---
*PR created automatically by Jules for task [590467809725542436](https://jules.google.com/task/590467809725542436) started by @madmax983*