### PR TITLE
⚒️ Forge: [refactor decode_one]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -16,3 +16,7 @@
 **[Extracting Repeated Code]
 **Learning:** Found identical `while i + 1 < fields.len()` loops used to iterate over key-value pairs in HashMap natives, and similar logic in HashSet.
 **Action:** Extracted these loops into simple helper functions `find_hashmap_entry_index` and `find_hashset_entry_index` which return `Option<usize>`, simplifying five separate native functions and removing `mut i` boilerplate.
+
+**[Preserving Jump Tables in Refactors]
+**Learning:** Breaking a massive `match` statement in a hot path (like a bytecode decoder) into multiple sequential helper functions ruins the compiler's ability to generate an O(1) jump table, causing a severe performance regression.
+**Action:** When fixing `clippy::too_many_lines` on a massive `match`, keep the massive `match` statement intact and use `#[allow(clippy::too_many_lines)]`. Only extract the complex logic *inside* specific arms (like `TABLESWITCH` or `LOOKUPSWITCH`) into helper functions.

--- a/crates/duke-bytecode/src/decoder.rs
+++ b/crates/duke-bytecode/src/decoder.rs
@@ -297,58 +297,10 @@ fn decode_one(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> DecodeResult<Instruc
         op::RET => Instruction::Ret(c.read_u8()?),
 
         // -- Tableswitch (§6.5 tableswitch) ----------------------------------
-        op::TABLESWITCH => {
-            // `pc` is the offset of the tableswitch opcode byte.
-            // After reading the opcode, cursor is at pc+1.
-            // Align to 4-byte boundary from start of code array.
-            c.align4();
-            let default = c.read_i32()?;
-            let low = c.read_i32()?;
-            let high = c.read_i32()?;
-            if high < low {
-                return Err(DecodeError::InvalidTableswitch { pc, low, high });
-            }
-            // Use i64 to avoid i32 overflow when low is very negative.
-            let count_i64 = i64::from(high) - i64::from(low) + 1;
-            // Sanity cap: each entry needs 4 bytes; reject if more than remaining data.
-            let max_possible = c.data.len().saturating_sub(c.pos) / 4;
-            if count_i64 < 0 || usize::try_from(count_i64).unwrap_or(usize::MAX) > max_possible {
-                return Err(DecodeError::InvalidTableswitch { pc, low, high });
-            }
-            let count = usize::try_from(count_i64).unwrap_or(0);
-            let offsets = (0..count)
-                .map(|_| c.read_i32())
-                .collect::<Result<Vec<_>, _>>()?;
-            Instruction::Tableswitch {
-                default,
-                low,
-                high,
-                offsets,
-            }
-        }
+        op::TABLESWITCH => decode_tableswitch(c, pc)?,
 
         // -- Lookupswitch (§6.5 lookupswitch) --------------------------------
-        op::LOOKUPSWITCH => {
-            c.align4();
-            let default = c.read_i32()?;
-            let npairs = c.read_i32()?;
-            if npairs < 0 {
-                return Err(DecodeError::InvalidLookupswitch { pc, npairs });
-            }
-            let remaining_pairs = c.data.len().saturating_sub(c.pos) / 8;
-            if usize::try_from(npairs).unwrap_or(usize::MAX) > remaining_pairs {
-                return Err(DecodeError::InvalidLookupswitch { pc, npairs });
-            }
-            let npairs_usize = usize::try_from(npairs).unwrap_or(0);
-            let pairs = (0..npairs_usize)
-                .map(|_| {
-                    let match_val = c.read_i32()?;
-                    let offset = c.read_i32()?;
-                    Ok((match_val, offset))
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            Instruction::Lookupswitch { default, pairs }
-        }
+        op::LOOKUPSWITCH => decode_lookupswitch(c, pc)?,
 
         // -- Returns ---------------------------------------------------------
         op::IRETURN => Instruction::Ireturn,
@@ -426,6 +378,58 @@ fn decode_one(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> DecodeResult<Instruc
 }
 
 // ---------------------------------------------------------------------------
+fn decode_tableswitch(c: &mut Cursor<'_>, pc: usize) -> DecodeResult<Instruction> {
+    // `pc` is the offset of the tableswitch opcode byte.
+    // After reading the opcode, cursor is at pc+1.
+    // Align to 4-byte boundary from start of code array.
+    c.align4();
+    let default = c.read_i32()?;
+    let low = c.read_i32()?;
+    let high = c.read_i32()?;
+    if high < low {
+        return Err(DecodeError::InvalidTableswitch { pc, low, high });
+    }
+    // Use i64 to avoid i32 overflow when low is very negative.
+    let count_i64 = i64::from(high) - i64::from(low) + 1;
+    // Sanity cap: each entry needs 4 bytes; reject if more than remaining data.
+    let max_possible = c.data.len().saturating_sub(c.pos) / 4;
+    if count_i64 < 0 || usize::try_from(count_i64).unwrap_or(usize::MAX) > max_possible {
+        return Err(DecodeError::InvalidTableswitch { pc, low, high });
+    }
+    let count = usize::try_from(count_i64).unwrap_or(0);
+    let offsets = (0..count)
+        .map(|_| c.read_i32())
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Instruction::Tableswitch {
+        default,
+        low,
+        high,
+        offsets,
+    })
+}
+
+fn decode_lookupswitch(c: &mut Cursor<'_>, pc: usize) -> DecodeResult<Instruction> {
+    c.align4();
+    let default = c.read_i32()?;
+    let npairs = c.read_i32()?;
+    if npairs < 0 {
+        return Err(DecodeError::InvalidLookupswitch { pc, npairs });
+    }
+    let remaining_pairs = c.data.len().saturating_sub(c.pos) / 8;
+    if usize::try_from(npairs).unwrap_or(usize::MAX) > remaining_pairs {
+        return Err(DecodeError::InvalidLookupswitch { pc, npairs });
+    }
+    let npairs_usize = usize::try_from(npairs).unwrap_or(0);
+    let pairs = (0..npairs_usize)
+        .map(|_| {
+            let match_val = c.read_i32()?;
+            let offset = c.read_i32()?;
+            Ok((match_val, offset))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Instruction::Lookupswitch { default, pairs })
+}
+
 // Wide prefix handler
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
⚒️ Forge: Refactor `decode_one` in `crates/duke-bytecode/src/decoder.rs`

**🚮 Smell:** 
The `decode_one` function had over 300 lines due to deeply nested logic inside the `TABLESWITCH` and `LOOKUPSWITCH` match arms. 

**✨ Solution:** 
Kept the highly optimized `match` jump-table intact for performance, but extracted the verbose inline logic for decoding `TABLESWITCH` and `LOOKUPSWITCH` instructions into two distinct, well-named helper functions (`decode_tableswitch` and `decode_lookupswitch`).

**🧼 Benefit:** 
Significantly reduces the cognitive load of `decode_one` by abstracting away the complex logic blocks, all while strictly preserving the O(1) performance characteristics of the massive `match` statement.

**🛡️ Verification:** 
`cargo check`, `cargo clippy`, and `cargo test` all passed. No logical behavior was altered.

---
*PR created automatically by Jules for task [2310170383341165201](https://jules.google.com/task/2310170383341165201) started by @madmax983*