### PR TITLE
👺 Havoc: Initial Property Fuzzing Suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +239,7 @@ dependencies = [
 name = "duke-classfile"
 version = "0.1.0"
 dependencies = [
+ "arbitrary",
  "bitflags",
  "proptest",
  "thiserror",
@@ -244,6 +251,7 @@ version = "0.1.0"
 dependencies = [
  "duke-loader",
  "duke-runtime",
+ "proptest",
 ]
 
 [[package]]
@@ -274,6 +282,7 @@ dependencies = [
 name = "duke-runtime"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "thiserror",
 ]
 

--- a/crates/duke-bytecode/src/fuzz.rs
+++ b/crates/duke-bytecode/src/fuzz.rs
@@ -1,0 +1,12 @@
+#[cfg(test)]
+mod tests {
+    use crate::decoder::decode;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn no_panic_on_arbitrary_bytecode(data in any::<Vec<u8>>()) {
+            let _ = decode(&data);
+        }
+    }
+}

--- a/crates/duke-bytecode/src/lib.rs
+++ b/crates/duke-bytecode/src/lib.rs
@@ -727,3 +727,5 @@ mod tests {
         );
     }
 }
+#[cfg(test)]
+mod fuzz;

--- a/crates/duke-classfile/Cargo.toml
+++ b/crates/duke-classfile/Cargo.toml
@@ -9,6 +9,7 @@ thiserror.workspace = true
 bitflags.workspace = true
 
 [dev-dependencies]
+arbitrary = "1.4.2"
 proptest.workspace = true
 
 [lints]

--- a/crates/duke-classfile/src/fuzz.rs
+++ b/crates/duke-classfile/src/fuzz.rs
@@ -1,0 +1,22 @@
+#[cfg(test)]
+mod tests {
+    use crate::parse;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn does_not_crash_parse_random(data in any::<Vec<u8>>()) {
+            let _ = parse(&data);
+        }
+
+        #[test]
+        fn does_not_crash_parse_with_magic_and_version(data in any::<Vec<u8>>()) {
+            let mut prefix = vec![0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x41]; // magic + java 21
+            // Try to set constant pool count to 0xFFFF and see if it OOMs or hangs
+            prefix.push(0xFF);
+            prefix.push(0xFF);
+            prefix.extend(data);
+            let _ = parse(&prefix);
+        }
+    }
+}

--- a/crates/duke-classfile/src/lib.rs
+++ b/crates/duke-classfile/src/lib.rs
@@ -785,3 +785,5 @@ mod tests {
         assert!(found_bm);
     }
 }
+#[cfg(test)]
+mod fuzz;

--- a/crates/duke-gc/Cargo.toml
+++ b/crates/duke-gc/Cargo.toml
@@ -10,3 +10,6 @@ duke-runtime = { path = "../duke-runtime" }
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+proptest.workspace = true

--- a/crates/duke-gc/src/fuzz.rs
+++ b/crates/duke-gc/src/fuzz.rs
@@ -1,0 +1,19 @@
+#[cfg(test)]
+mod tests {
+    use crate::Heap;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn does_not_crash_heap_allocations(
+            size in 0usize..1000,
+            string_len in 0usize..1000,
+        ) {
+            let mut heap = Heap::new();
+            let _ = heap.allocate("java/lang/Object".to_string(), size);
+
+            let s = "a".repeat(string_len);
+            let _ = heap.allocate_string(s);
+        }
+    }
+}

--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -1925,3 +1925,5 @@ mod tests {
         ));
     }
 }
+#[cfg(test)]
+mod fuzz;

--- a/crates/duke-interpreter/src/fuzz.rs
+++ b/crates/duke-interpreter/src/fuzz.rs
@@ -1,0 +1,22 @@
+#[cfg(test)]
+mod tests {
+    use duke_runtime::{Slot, Frame};
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn does_not_crash_frame_methods(
+            push_count in 0usize..50,
+            pop_count in 0usize..50,
+            push_value in any::<i32>(),
+        ) {
+            let mut frame = Frame::new(100, 100, vec![]).unwrap();
+            for _ in 0..push_count {
+                let _ = frame.push(Slot::Int(push_value));
+            }
+            for _ in 0..pop_count {
+                let _ = frame.pop();
+            }
+        }
+    }
+}

--- a/crates/duke-interpreter/src/fuzz.rs
+++ b/crates/duke-interpreter/src/fuzz.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use duke_runtime::{Slot, Frame};
+    use duke_runtime::{Frame, Slot};
     use proptest::prelude::*;
 
     proptest! {

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -27092,3 +27092,5 @@ mod tests {
         assert_eq!(result, Some(Slot::Int(0xCA)));
     }
 }
+#[cfg(test)]
+mod fuzz;

--- a/crates/duke-runtime/Cargo.toml
+++ b/crates/duke-runtime/Cargo.toml
@@ -9,3 +9,6 @@ thiserror.workspace = true
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+proptest.workspace = true

--- a/crates/duke-runtime/src/fuzz.rs
+++ b/crates/duke-runtime/src/fuzz.rs
@@ -1,0 +1,32 @@
+#[cfg(test)]
+mod tests {
+    use crate::frame::Frame;
+    use crate::slot::Slot;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn does_not_crash_frame_creation(
+            max_stack in 0usize..1000,
+            max_locals in 0usize..1000,
+            args_len in 0usize..1000,
+        ) {
+            let mut args = Vec::new();
+            for _ in 0..args_len {
+                args.push(Slot::Int(0));
+            }
+            let _ = Frame::new(max_stack, max_locals, args);
+        }
+
+        #[test]
+        fn does_not_crash_frame_pop_underflow(
+            max_stack in 0usize..10,
+            max_locals in 0usize..10,
+        ) {
+            let mut frame = Frame::new(max_stack, max_locals, vec![]).unwrap();
+            let _ = frame.pop(); // Expected to safely error if empty
+            let _ = frame.pop_int();
+            let _ = frame.pop_ref();
+        }
+    }
+}

--- a/crates/duke-runtime/src/lib.rs
+++ b/crates/duke-runtime/src/lib.rs
@@ -226,3 +226,5 @@ mod tests {
         }
     }
 }
+#[cfg(test)]
+mod fuzz;

--- a/test_plan.sh
+++ b/test_plan.sh
@@ -1,0 +1,1 @@
+cargo test --workspace


### PR DESCRIPTION
🧨 **The Trigger:** Lack of automated fuzzing/property testing across the VM components left the system vulnerable to unexpected input (e.g. malformed bytecode, massive class file headers, extreme stack pop operations).
📉 **The Stack Trace:** N/A - Proactively hunting.
🧪 **Reproduction:** Run `cargo test --workspace` to execute the new fuzz targets utilizing `proptest`.
😈 **Comment:** Added the basic chaos engineering infrastructure to verify boundaries across parser, runtime, and garbage collector components.

Note: No actual application crashes were found during this initial fuzzing implementation, fulfilling the "Red Phase" framework but verifying the current bounds are surprisingly resilient.

---
*PR created automatically by Jules for task [17712291164444550140](https://jules.google.com/task/17712291164444550140) started by @madmax983*