### PR TITLE
⚒️ Forge: [Eliminate constant pool clone via disjoint borrowing]

### DIFF
--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -132,17 +132,17 @@ pub fn parse(bytes: &[u8]) -> ParseResult<ClassFile> {
     let mut class_file = parse_class_file(&mut cursor)?;
 
     // Resolve raw attribute bytes into typed variants now that we have the full CP.
-    let pool = class_file.constant_pool.clone();
-    resolve_attributes(&mut class_file.attributes, &pool)?;
+    let pool = &class_file.constant_pool;
+    resolve_attributes(&mut class_file.attributes, pool)?;
     for field in &mut class_file.fields {
-        resolve_attributes(&mut field.attributes, &pool)?;
+        resolve_attributes(&mut field.attributes, pool)?;
     }
     for method in &mut class_file.methods {
-        resolve_attributes(&mut method.attributes, &pool)?;
+        resolve_attributes(&mut method.attributes, pool)?;
         // Also resolve Code sub-attributes.
         for attr in &mut method.attributes {
             if let AttributeData::Code(code) = &mut attr.data {
-                resolve_attributes(&mut code.attributes, &pool)?;
+                resolve_attributes(&mut code.attributes, pool)?;
             }
         }
     }


### PR DESCRIPTION
🚮 Smell: `parse` in `crates/duke-classfile/src/parser.rs` cloned the entire `constant_pool` vector to pass it to `resolve_attributes` because of perceived borrow checker conflicts.
✨ Solution: Eliminated the `.clone()` by taking a reference to `class_file.constant_pool`. Rust's disjoint field borrowing allows us to immutably borrow the pool while mutably borrowing the attributes, fields, and methods of the same struct.
🧼 Benefit: Eliminates an O(N) heap allocation and copy on every class file parsed, making the parsing process significantly faster and more memory efficient, while remaining perfectly safe and idiomatic Rust.
🛡️ Verification: `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` passed cleanly. Behavior is identical.

---
*PR created automatically by Jules for task [13584655601136931538](https://jules.google.com/task/13584655601136931538) started by @madmax983*