### PR TITLE
⚡ Bolt: Pre-allocate jimage HashMap to avoid reallocation bottlenecks

### DIFF
--- a/crates/duke-loader/src/jimage.rs
+++ b/crates/duke-loader/src/jimage.rs
@@ -148,7 +148,13 @@ impl JImageReader {
             });
         }
 
-        let index = build_index(&data, locations_offset, ls, strings_offset);
+        let index = build_index(
+            &data,
+            locations_offset,
+            ls,
+            strings_offset,
+            resource_count as usize,
+        );
 
         Ok(Self {
             data,
@@ -303,8 +309,9 @@ fn build_index(
     locs_offset: usize,
     locs_size: usize,
     str_offset: usize,
+    resource_count: usize,
 ) -> HashMap<String, ResourceInfo> {
-    let mut index = HashMap::new();
+    let mut index = HashMap::with_capacity(resource_count);
     let mut pos = locs_offset;
     let locs_end = locs_offset + locs_size;
 
@@ -512,7 +519,7 @@ mod tests {
         locs.push(attr_end());
 
         let (data, locs_offset, locs_size, str_offset) = make_build_index_data(&locs);
-        let index = build_index(&data, locs_offset, locs_size, str_offset);
+        let index = build_index(&data, locs_offset, locs_size, str_offset, 1);
 
         assert_eq!(index.len(), 1);
         let info = index.get("/mod/Foo").expect("expected /mod/Foo in index");
@@ -536,7 +543,7 @@ mod tests {
         locs.push(attr_end());
 
         let (data, locs_offset, locs_size, str_offset) = make_build_index_data(&locs);
-        let index = build_index(&data, locs_offset, locs_size, str_offset);
+        let index = build_index(&data, locs_offset, locs_size, str_offset, 1);
 
         let info = index.get("/mod/Foo").expect("expected /mod/Foo in index");
         assert_eq!(info.compressed, 5, "compressed attribute must be stored");
@@ -557,7 +564,7 @@ mod tests {
         locs.push(attr_end());
 
         let (data, locs_offset, locs_size, str_offset) = make_build_index_data(&locs);
-        let index = build_index(&data, locs_offset, locs_size, str_offset);
+        let index = build_index(&data, locs_offset, locs_size, str_offset, 1);
         assert!(
             index.is_empty(),
             "entry with uncompressed=0 should be skipped"
@@ -592,7 +599,7 @@ mod tests {
         // data.len() = 9 + 6 = 15; pos+len for last attr = (9+4+1) + 1 = 15 == data.len()
         let (locs_offset, locs_size, str_offset) = (9, 6, 0);
 
-        let index = build_index(&data, locs_offset, locs_size, str_offset);
+        let index = build_index(&data, locs_offset, locs_size, str_offset, 1);
         let info = index
             .get("/mod/Foo")
             .expect("exact-fit attribute must be read into index");
@@ -623,7 +630,7 @@ mod tests {
         let (locs_offset, locs_size, str_offset) = (9, locs.len(), 0);
 
         // Must not panic, and entry must not be indexed (BASE never set → path empty)
-        let index = build_index(&data, locs_offset, locs_size, str_offset);
+        let index = build_index(&data, locs_offset, locs_size, str_offset, 0);
         assert!(
             index.is_empty(),
             "truncated attribute stream should produce empty index"
@@ -640,7 +647,7 @@ mod tests {
         //   header_byte = 0x09 = (ATTR_MODULE<<3)|(2-1) = 0x08|0x01 → kind=1, len=2
         // locs_offset=0, locs_size=2, str_offset=2, data.len()=2
         let data = vec![0x09u8, 0x42];
-        let index = build_index(&data, 0, 2, 2);
+        let index = build_index(&data, 0, 2, 2, 0);
         assert!(
             index.is_empty(),
             "truncated len=2 at pos=1 must not panic and should be empty"


### PR DESCRIPTION
💡 **What:** Modified `build_index` in `crates/duke-loader/src/jimage.rs` to take `resource_count` as an argument and initialize the resource index with `HashMap::with_capacity(resource_count)` instead of `HashMap::new()`.

🎯 **Why:** The OpenJDK `lib/modules` jimage file contains tens of thousands of resources. Using `HashMap::new()` causes the underlying hash table to repeatedly reallocate and rehash its contents as resources are inserted during the initial parsing phase. Since the exact total number of resources is provided upfront in the jimage header, pre-allocating the capacity avoids this entirely.

📊 **Impact:** Eliminates all dynamic memory reallocation overhead and rehashing for the jimage resource index construction, significantly speeding up the critical path of JVM classloader initialization.

🔬 **Measurement:** Verify by running standard startup or classloading benchmarks, or observing reduced peak memory/allocation count during the `JImageReader::open` call using a profiler.

---
*PR created automatically by Jules for task [11057165605915405797](https://jules.google.com/task/11057165605915405797) started by @madmax983*