### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -1,0 +1,3 @@
+## 2026-03-24 - Tarpaulin output interpretation
+**Learning:** Lcov traces output by `cargo-tarpaulin` explicitly label covered lines as `DA:<line_number>,1` (or higher) and explicitly label uncovered lines as `DA:<line_number>,0`. It is easy to misinterpret grep results if not looking strictly for the `,0` suffix.
+**Action:** When parsing `lcov.info` for coverage gaps, always grep specifically for `DA:.*,0` and double-check the surrounding context lines to ensure the line is truly uncovered before planning to write a test. Always delete `lcov.info` before committing to avoid polluting the repo.

--- a/crates/duke-bytecode/src/verifier.rs
+++ b/crates/duke-bytecode/src/verifier.rs
@@ -589,6 +589,28 @@ mod tests {
     }
 
     #[test]
+    fn test_stack_effect_math() {
+        assert_eq!(stack_effect(&Instruction::Imul), (2, 1));
+    }
+
+    #[test]
+    fn test_check_locals_ret() {
+        let instructions = vec![(0, Instruction::Ret(5)), (2, Instruction::Return)];
+        let res = verify(&instructions, 1, 5); // max locals is 5, index 5 is out of bounds
+        assert!(matches!(
+            res,
+            Err(VerifyError::LocalOutOfBounds { index: 5, .. })
+        ));
+
+        let instructions_w = vec![(0, Instruction::RetW(10)), (3, Instruction::Return)];
+        let res_w = verify(&instructions_w, 1, 10);
+        assert!(matches!(
+            res_w,
+            Err(VerifyError::LocalOutOfBounds { index: 10, .. })
+        ));
+    }
+
+    #[test]
     fn test_verifier_local_oob() {
         let instructions = vec![(0, Instruction::Iload(5)), (2, Instruction::Return)];
         let res = verify(&instructions, 1, 5); // max locals is 5, index 5 is out of bounds


### PR DESCRIPTION
🎯 Target: `duke-bytecode::verifier` module.
💣 Risk: `VerifyError::LocalOutOfBounds` paths for `Ret`/`RetW` and stack effect calculations for `Imul` math instructions were previously untested.
🧪 Strategy: Added `test_stack_effect_math` to ensure math instructions are calculated correctly (push 1, pop 2) and `test_check_locals_ret` to assert out-of-bounds locals behavior on `Ret`/`RetW`.
🔬 Verification: Run `cargo test` in `crates/duke-bytecode` and observe improved coverage via `cargo tarpaulin`.

---
*PR created automatically by Jules for task [18360403764251723849](https://jules.google.com/task/18360403764251723849) started by @madmax983*