### PR TITLE
⚒️ Forge: deduplicate native arg extraction boilerplate

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -24,3 +24,7 @@
 **[Extracting Native Print Boilerplate]
 **Learning:** Generating full function signatures inside `macro_rules!` (e.g. `define_native_print!`) breaks IDE navigability ("Go to Definition") and readability, even if it saves lines.
 **Action:** When deduplicating boilerplate across multiple functions in Rust (e.g., argument extraction in `duke-interpreter` native functions), prefer using inline `macro_rules!` macros (e.g., `extract_print_arg!`) to handle the repetitive inner logic rather than generating entire function signatures. This preserves IDE features and keeps function signatures explicit.
+
+**[Extracting Native Argument Boilerplate]
+**Learning:** Found widespread, repetitive `match args.get(X)` blocks in native functions (e.g., `native_file_output_stream_write`) used to extract integers or references, returning `VmError::TypeMismatch` or `NullPointerException` on failure. This creates unnecessary pyramids of doom.
+**Action:** Replace manual `match` blocks with the existing `extract_int_arg(args, X)?` and `extract_ref_arg(args, X)?` helpers to flatten logic and enforce idiomatic error propagation.

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -2703,15 +2703,7 @@ fn native_server_socket_init(
     _control: &mut NativeControl,
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let port = match args.get(1) {
-        Some(Slot::Int(p)) => *p,
-        _ => {
-            return Err(VmError::TypeMismatch {
-                expected: "Int",
-                got: "other",
-            });
-        }
-    };
+    let port = extract_int_arg(args, 1)?;
     let addr = format!("0.0.0.0:{port}");
     let server_id = heap.bind_server_socket(&addr)?;
     let actual_port = heap.server_socket_local_port(server_id)?;
@@ -2804,15 +2796,7 @@ fn native_socket_init(
             .ok_or(VmError::NullPointerException)?,
         _ => return Err(VmError::NullPointerException),
     };
-    let port = match args.get(2) {
-        Some(Slot::Int(p)) => *p,
-        _ => {
-            return Err(VmError::TypeMismatch {
-                expected: "Int",
-                got: "other",
-            });
-        }
-    };
+    let port = extract_int_arg(args, 2)?;
     let addr = format!("{host}:{port}");
     let (reader_id, writer_id) = heap.connect_socket(&addr)?;
     let obj = heap.get_mut(this_ref)?;
@@ -3110,15 +3094,7 @@ fn native_string_char_at(
     _control: &mut NativeControl,
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let index = match args.get(1) {
-        Some(Slot::Int(i)) => *i,
-        _ => {
-            return Err(VmError::TypeMismatch {
-                expected: "Int",
-                got: "other",
-            });
-        }
-    };
+    let index = extract_int_arg(args, 1)?;
     let obj = heap.get(this_ref)?;
     let s = obj.string_value.as_deref().unwrap_or("");
     let ch = s
@@ -3859,15 +3835,7 @@ fn native_string_substring(
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
 
-    let begin = match args.get(1) {
-        Some(Slot::Int(v)) => *v as usize,
-        _ => {
-            return Err(VmError::TypeMismatch {
-                expected: "Int",
-                got: "other",
-            });
-        }
-    };
+    let begin = extract_int_arg(args, 1)? as usize;
     let sub = {
         let obj = heap.get(this_ref)?;
         let s = obj.string_value.as_deref().unwrap_or_default();
@@ -3894,24 +3862,8 @@ fn native_string_substring_range(
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
 
-    let begin = match args.get(1) {
-        Some(Slot::Int(v)) => *v as usize,
-        _ => {
-            return Err(VmError::TypeMismatch {
-                expected: "Int",
-                got: "other",
-            });
-        }
-    };
-    let end = match args.get(2) {
-        Some(Slot::Int(v)) => *v as usize,
-        _ => {
-            return Err(VmError::TypeMismatch {
-                expected: "Int",
-                got: "other",
-            });
-        }
-    };
+    let begin = extract_int_arg(args, 1)? as usize;
+    let end = extract_int_arg(args, 2)? as usize;
     let sub = {
         let obj = heap.get(this_ref)?;
         let s = obj.string_value.as_deref().unwrap_or_default();
@@ -3937,16 +3889,7 @@ fn native_string_indexof(
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
 
-    let target_ref = match args.get(1) {
-        Some(Slot::Reference(Some(r))) => *r,
-        Some(Slot::Reference(None)) => return Err(VmError::NullPointerException),
-        _ => {
-            return Err(VmError::TypeMismatch {
-                expected: "Reference",
-                got: "other",
-            });
-        }
-    };
+    let target_ref = extract_ref_arg(args, 1)?;
     // Fetch objects from heap in one go to keep borrows short
     let this_obj = heap.get(this_ref)?;
     let target_obj = heap.get(target_ref)?;
@@ -3967,16 +3910,7 @@ fn native_string_contains(
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
 
-    let target_ref = match args.get(1) {
-        Some(Slot::Reference(Some(r))) => *r,
-        Some(Slot::Reference(None)) => return Err(VmError::NullPointerException),
-        _ => {
-            return Err(VmError::TypeMismatch {
-                expected: "Reference",
-                got: "other",
-            });
-        }
-    };
+    let target_ref = extract_ref_arg(args, 1)?;
     // Fetch objects from heap in one go to keep borrows short
     let this_obj = heap.get(this_ref)?;
     let target_obj = heap.get(target_ref)?;
@@ -4346,16 +4280,7 @@ fn native_string_concat(
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
     let s1 = heap.get(this_ref)?.string_value.clone().unwrap_or_default();
-    let other_ref = match args.get(1) {
-        Some(Slot::Reference(Some(r))) => *r,
-        Some(Slot::Reference(None)) => return Err(VmError::NullPointerException),
-        _ => {
-            return Err(VmError::TypeMismatch {
-                expected: "Reference",
-                got: "other",
-            });
-        }
-    };
+    let other_ref = extract_ref_arg(args, 1)?;
     let s2 = heap
         .get(other_ref)?
         .string_value
@@ -4565,31 +4490,13 @@ fn native_string_replace_charsequence(
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
     let s = heap.get(this_ref)?.string_value.clone().unwrap_or_default();
-    let target_ref = match args.get(1) {
-        Some(Slot::Reference(Some(r))) => *r,
-        Some(Slot::Reference(None)) => return Err(VmError::NullPointerException),
-        _ => {
-            return Err(VmError::TypeMismatch {
-                expected: "Reference",
-                got: "other",
-            });
-        }
-    };
+    let target_ref = extract_ref_arg(args, 1)?;
     let target = heap
         .get(target_ref)?
         .string_value
         .clone()
         .unwrap_or_default();
-    let replacement_ref = match args.get(2) {
-        Some(Slot::Reference(Some(r))) => *r,
-        Some(Slot::Reference(None)) => return Err(VmError::NullPointerException),
-        _ => {
-            return Err(VmError::TypeMismatch {
-                expected: "Reference",
-                got: "other",
-            });
-        }
-    };
+    let replacement_ref = extract_ref_arg(args, 2)?;
     let replacement = heap
         .get(replacement_ref)?
         .string_value
@@ -4609,16 +4516,7 @@ fn native_string_split(
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
     let s = heap.get(this_ref)?.string_value.clone().unwrap_or_default();
-    let delim_ref = match args.get(1) {
-        Some(Slot::Reference(Some(r))) => *r,
-        Some(Slot::Reference(None)) => return Err(VmError::NullPointerException),
-        _ => {
-            return Err(VmError::TypeMismatch {
-                expected: "Reference",
-                got: "other",
-            });
-        }
-    };
+    let delim_ref = extract_ref_arg(args, 1)?;
     let delim = heap
         .get(delim_ref)?
         .string_value
@@ -11761,15 +11659,7 @@ fn native_arraylist_get(
     _control: &mut NativeControl,
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let idx = match args.get(1) {
-        Some(Slot::Int(i)) => *i as usize,
-        _ => {
-            return Err(VmError::TypeMismatch {
-                expected: "Int",
-                got: "other",
-            });
-        }
-    };
+    let idx = extract_int_arg(args, 1)? as usize;
     let obj = heap.get(this_ref)?;
     obj.fields.get(idx + 1).map_or_else(
         || {


### PR DESCRIPTION
🚮 **Smell:** Widespread, repetitive `match args.get(X)` boilerplate ("Pyramid of Doom") across `duke-interpreter` native functions (e.g., `native_file_output_stream_write`, `native_string_substring`, etc) used to extract integers or references from the `args` array, returning `VmError::TypeMismatch` or `NullPointerException` on failure. This created unnecessary nesting and verbose code.

✨ **Solution:** Replaced these manual `match` blocks with the existing `extract_int_arg(args, X)?` and `extract_ref_arg(args, X)?` helper functions.

🧼 **Benefit:** Dramatically reduces boilerplate and flattens the execution flow. Enforces idiomatic error propagation via `?` operator. Makes the codebase much easier to read and maintain while abstracting away the exact same error handling logic safely.

🛡️ **Verification:** Tests passed. No logic changed. All native functions still propagate the correct `VmError::TypeMismatch` and `VmError::NullPointerException` exactly as before. Ran `cargo test`, `cargo clippy`, and `cargo fmt`.

---
*PR created automatically by Jules for task [3545769045141293054](https://jules.google.com/task/3545769045141293054) started by @madmax983*