### PR TITLE
👺 Havoc: Fix detached thread panic in wait_for_all_java_threads

### DIFF
--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -18935,6 +18935,7 @@ mod tests {
 
     #[test]
     fn threading_havoc_fast_fail_slow_thread_does_not_panic() {
+        static COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
         let ctx = load_class_context("ThreadingTest.class");
         let entry_class = ctx.class_name.clone();
         let mut registry = ClassRegistry::new();
@@ -18944,7 +18945,6 @@ mod tests {
         let loader = fixtures_loader();
         let mut out: Vec<u8> = Vec::new();
 
-        static COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
         COUNTER.store(0, std::sync::atomic::Ordering::SeqCst);
 
         registry

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -9919,11 +9919,12 @@ fn join_java_thread(
 fn wait_for_all_java_threads(
     runtime: &std::sync::Arc<std::sync::Mutex<CompletionRuntime>>,
 ) -> VmResult<()> {
+    let mut first_error = None;
     loop {
         let handles = {
             let mut runtime = runtime.lock().unwrap();
             if runtime.handles.is_empty() {
-                return Ok(());
+                return first_error.unwrap_or(Ok(()));
             }
             runtime
                 .handles
@@ -9934,7 +9935,11 @@ fn wait_for_all_java_threads(
 
         for handle in handles {
             match handle.join() {
-                Ok(result) => result?,
+                Ok(result) => {
+                    if let Err(e) = result {
+                        first_error.get_or_insert(Err(e));
+                    }
+                }
                 Err(payload) => std::panic::resume_unwind(payload),
             }
         }
@@ -18927,6 +18932,56 @@ mod tests {
     }
 
     // ---- Phase 28: Threading ----
+
+    #[test]
+    fn threading_havoc_fast_fail_slow_thread_does_not_panic() {
+        let ctx = load_class_context("ThreadingTest.class");
+        let entry_class = ctx.class_name.clone();
+        let mut registry = ClassRegistry::new();
+        registry.register(ctx);
+        let mut heap = duke_gc::Heap::new();
+        bootstrap_stdlib(&mut registry, &mut heap);
+        let loader = fixtures_loader();
+        let mut out: Vec<u8> = Vec::new();
+
+        static COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        COUNTER.store(0, std::sync::atomic::Ordering::SeqCst);
+
+        registry
+            .natives_mut()
+            .register("java/lang/Thread", "sleep", "(J)V", |_, _, _, _| {
+                let count = COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                if count == 0 {
+                    // First thread to call sleep fails immediately
+                    Err(VmError::Unimplemented {
+                        mnemonic: "Test early failure",
+                    })
+                } else {
+                    // Other threads take a long time to sleep, so they will be still running
+                    // if wait_for_all_java_threads returns early.
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    Ok(None)
+                }
+            });
+
+        let result = execute_class_to_completion(
+            &mut registry,
+            loader,
+            &mut heap,
+            &mut out,
+            &entry_class,
+            "spawnAndJoinTen",
+            "()I",
+            &[],
+        );
+
+        assert!(matches!(
+            result,
+            Err(VmError::Unimplemented {
+                mnemonic: "Test early failure"
+            })
+        ));
+    }
 
     #[test]
     fn threading_havoc_wait_for_all_java_threads_error_path() {


### PR DESCRIPTION
🧨 **The Trigger:** If a Java thread spawns multiple other Java threads and one of them fails (returning an `Err(VmError)` or panicking) before the others finish, `wait_for_all_java_threads` would return early due to `?` propagation. The remaining threads are left running with shared `Arc` references to `CompletionVm`. When the runtime attempts to drop or unwrap these `Arc`s, it panics due to the detached threads still holding references.
📉 **The Stack Trace:**
```
thread '<unnamed>' panicked at crates/duke-interpreter/src/lib.rs:10186:9:
completion runtime released shared VM state
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
🧪 **Reproduction:** I've added a test `threading_havoc_fast_fail_slow_thread_does_not_panic` which mocks `java/lang/Thread.sleep` to error on the first thread but sleep correctly on the others. This triggered the crash on the `main` branch. Run `cargo test -p duke-interpreter` to see the test pass now.
😈 **Comment:** You assumed that a thread crashing meant you could pack up and leave immediately. You were wrong. The other threads will haunt you and hold your memory hostage. Now we patiently wait for everyone to die before returning the error.

---
*PR created automatically by Jules for task [14036075567113535135](https://jules.google.com/task/14036075567113535135) started by @madmax983*