### PR TITLE
👺 Havoc: [Integer Overflow in JImage String Parsing]

### DIFF
--- a/crates/duke-loader/src/jimage.rs
+++ b/crates/duke-loader/src/jimage.rs
@@ -426,7 +426,9 @@ fn read_str(data: &[u8], str_offset: usize, idx: u64) -> &str {
     let Ok(idx_usize) = usize::try_from(idx) else {
         return "";
     };
-    let start = str_offset + idx_usize;
+    let Some(start) = str_offset.checked_add(idx_usize) else {
+        return "";
+    };
     if start >= data.len() {
         return "";
     }
@@ -475,6 +477,16 @@ mod tests {
 
     fn attr_end() -> u8 {
         0x00
+    }
+
+    #[test]
+    fn read_str_rejects_index_overflow() {
+        let data = b"some data here ";
+        let str_offset = usize::MAX;
+        let idx = 1;
+        // Should return empty string, not panic on `str_offset + idx_usize`.
+        let s = read_str(data, str_offset, idx);
+        assert_eq!(s, "");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
🧨 **The Trigger:** Passing a `str_offset` and an `idx` such that `str_offset + idx_usize > usize::MAX`. This causes a panic when parsing JImage files with maliciously crafted string table offsets.
📉 **The Stack Trace:**
```
thread 'jimage::tests::read_str_rejects_index_overflow' panicked at crates/duke-loader/src/jimage.rs:429:17:
attempt to add with overflow
```
🧪 **Reproduction:** Run `cargo test -p duke-loader read_str_rejects_index_overflow`.
😈 **Comment:** You assumed the string table offset plus the index would always fit in memory. You were wrong. An attacker could trivially crash the VM by feeding it a corrupted JImage file. It is now safely bounds-checked with `checked_add`.

---
*PR created automatically by Jules for task [1489949745416537258](https://jules.google.com/task/1489949745416537258) started by @madmax983*