### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/crates/duke-bytecode/src/verifier.rs
+++ b/crates/duke-bytecode/src/verifier.rs
@@ -604,4 +604,33 @@ mod tests {
             Err(VerifyError::LocalOutOfBounds { index: 10, .. })
         ));
     }
+
+    #[test]
+    fn test_verifier_local_oob_iinc() {
+        let instructions = vec![
+            (0, Instruction::Iinc { index: 5, value: 1 }),
+            (3, Instruction::Return),
+        ];
+        let res = verify(&instructions, 1, 5);
+        assert!(matches!(
+            res,
+            Err(VerifyError::LocalOutOfBounds { index: 5, .. })
+        ));
+
+        let instructions_wide = vec![
+            (
+                0,
+                Instruction::IincW {
+                    index: 10,
+                    value: 1,
+                },
+            ),
+            (4, Instruction::Return),
+        ];
+        let res = verify(&instructions_wide, 1, 10);
+        assert!(matches!(
+            res,
+            Err(VerifyError::LocalOutOfBounds { index: 10, .. })
+        ));
+    }
 }


### PR DESCRIPTION
🎯 Target: `verifier::verify` and `verifier::check_locals` function in `crates/duke-bytecode/src/verifier.rs` for `Instruction::Iinc` and `Instruction::IincW`.
💣 Risk: The bytecode verifier lacked tests to guarantee that `Iinc` and `IincW` fail when attempting to access a local variable index equal to or greater than `max_locals`, potentially allowing malformed bytecode to cause unverified accesses during runtime. 
🧪 Strategy: Added a new test function `test_verifier_local_oob_iinc` to the unit tests, which generates instructions containing invalid local indices and asserts that they produce the expected `VerifyError::LocalOutOfBounds`.
🔬 Verification: Run `cargo test -p duke-bytecode test_verifier_local_oob_iinc`

---
*PR created automatically by Jules for task [13968658064312967026](https://jules.google.com/task/13968658064312967026) started by @madmax983*