### PR TITLE
👺 Havoc: Fix Arc::try_unwrap panic on early error in wait_for_all_java_threads

### DIFF
--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -9919,10 +9919,14 @@ fn join_java_thread(
 fn wait_for_all_java_threads(
     runtime: &std::sync::Arc<std::sync::Mutex<CompletionRuntime>>,
 ) -> VmResult<()> {
+    let mut errors: Vec<VmError> = Vec::new();
     loop {
         let handles = {
             let mut runtime = runtime.lock().unwrap();
             if runtime.handles.is_empty() {
+                if let Some(first_err) = errors.into_iter().next() {
+                    return Err(first_err);
+                }
                 return Ok(());
             }
             runtime
@@ -9934,7 +9938,8 @@ fn wait_for_all_java_threads(
 
         for handle in handles {
             match handle.join() {
-                Ok(result) => result?,
+                Ok(Err(err)) => errors.push(err),
+                Ok(Ok(())) => {}
                 Err(payload) => std::panic::resume_unwind(payload),
             }
         }
@@ -27634,3 +27639,35 @@ mod tests {
 }
 #[cfg(test)]
 mod fuzz;
+
+#[cfg(test)]
+mod havoc_tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn threading_havoc_wait_for_all_java_threads_arc_panic() {
+        let runtime = Arc::new(Mutex::new(CompletionRuntime::default()));
+
+        // We use thread::spawn that returns VmResult<()>
+        let handle1 = thread::spawn(|| -> VmResult<()> { Err(VmError::DivisionByZero) });
+
+        let handle2 = thread::spawn(|| -> VmResult<()> {
+            thread::sleep(Duration::from_millis(100));
+            Ok(())
+        });
+
+        // Add handles to the runtime map
+        runtime.lock().unwrap().handles.insert(1, handle1);
+        runtime.lock().unwrap().handles.insert(2, handle2);
+
+        // Run wait_for_all_java_threads
+        let result = wait_for_all_java_threads(&runtime);
+        assert!(result.is_err());
+
+        // Check that handles map is indeed empty
+        assert!(runtime.lock().unwrap().handles.is_empty());
+    }
+}

--- a/test_plan.sh
+++ b/test_plan.sh
@@ -1,1 +1,3 @@
-cargo test --workspace
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test
+cargo fmt --all


### PR DESCRIPTION
🧨 **The Trigger:** One of multiple running Java threads encounters a VM Error (like `DivisionByZero`) while others are still running.
📉 **The Stack Trace:** `thread '...' panicked at crates/duke-interpreter/src/lib.rs:10187:9: completion runtime released shared VM state` or `Arc::try_unwrap` panic.
🧪 **Reproduction:** Run the `threading_havoc_wait_for_all_java_threads_arc_panic` test case in `crates/duke-interpreter/src/lib.rs` without the fix.
😈 **Comment:** You assumed threads failing means you can immediately pack up and leave. You were wrong. Unhandled threads held `Arc`s hostage.

---
*PR created automatically by Jules for task [8431332997761917364](https://jules.google.com/task/8431332997761917364) started by @madmax983*