### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -536,6 +536,29 @@ impl Heap {
         })
     }
 
+    /// Write multiple bytes to the host file at once.
+    pub fn write_host_file_bytes(&mut self, id: i32, buf: &[u8]) -> VmResult<()> {
+        let Some(handle) = self.host_files.get_mut(&id) else {
+            return Err(VmError::JavaException {
+                class_name: "java/io/IOException".to_string(),
+            });
+        };
+        let writer: &mut dyn Write = match handle {
+            HostFileHandle::Writer(f) => f,
+            HostFileHandle::SocketWriter(s) => s,
+            HostFileHandle::ProcessStdin(stdin) => stdin,
+            _ => {
+                return Err(VmError::JavaException {
+                    class_name: "java/io/IOException".to_string(),
+                });
+            }
+        };
+
+        writer.write_all(buf).map_err(|_| VmError::JavaException {
+            class_name: "java/io/IOException".to_string(),
+        })
+    }
+
     /// Opens a ZIP/JAR archive on the host OS, parses and indexes it.
     ///
     /// # Errors

--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -2213,6 +2213,36 @@ mod tests {
             if class_name == "java/io/IOException"
         ));
     }
+
+    #[test]
+    fn write_host_file_bytes_writes_to_file() {
+        let mut heap = Heap::new();
+        let path = std::env::temp_dir().join("duke_gc_test_write_bytes.txt");
+        let file_id = heap
+            .open_host_output_file(&path)
+            .expect("open output file");
+
+        let buf = b"Hello, World!";
+        heap.write_host_file_bytes(file_id, buf)
+            .expect("write host file bytes");
+        heap.close_host_file(file_id);
+
+        let content = std::fs::read_to_string(&path).expect("read file");
+        assert_eq!(content, "Hello, World!");
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn write_host_file_bytes_invalid_fd_returns_error() {
+        let mut heap = Heap::new();
+        let buf = b"Test";
+        let err = heap.write_host_file_bytes(9999, buf).unwrap_err();
+        assert!(matches!(
+            err,
+            duke_runtime::VmError::JavaException { ref class_name }
+            if class_name == "java/io/IOException"
+        ));
+    }
 }
 #[cfg(test)]
 mod fuzz;

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -4033,16 +4033,24 @@ fn native_file_output_stream_write_bytes(
 ) -> VmResult<Option<Slot>> {
     let file_id = file_stream_id_from_this(args, heap)?;
     let array_ref = extract_ref_arg(args, 1)?;
-    let bytes = heap.get(array_ref)?.fields.clone();
-    for byte in bytes {
-        let Slot::Int(value) = byte else {
+    // ⚡ Bolt: Removed unnecessary `.clone()` on the byte array and drastically
+    // reduced heap lookups/writes.
+    // We fetch the values once, map them to a small byte array, and then call
+    // `write_host_file_bytes` to perform a single IO write syscall.
+    let mut out_buf = Vec::new();
+    let fields = &heap.get(array_ref)?.fields;
+    out_buf.reserve_exact(fields.len());
+    for slot in fields {
+        let Slot::Int(value) = *slot else {
             return Err(VmError::TypeMismatch {
                 expected: "Int",
                 got: "other",
             });
         };
-        heap.write_host_file_byte(file_id, value)?;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        out_buf.push(value as u8);
     }
+    heap.write_host_file_bytes(file_id, &out_buf)?;
     Ok(None)
 }
 


### PR DESCRIPTION
💡 **What**: Optimized `native_file_output_stream_write_bytes` by removing the `.clone()` on the byte array (`fields`). Additionally, it now fetches values inside a single loop, maps them to a tightly-sized `Vec<u8>`, and performs a single bulk IO write syscall via the newly added `write_host_file_bytes` method in `Heap`.

🎯 **Why**: Previously, the code cloned a potentially massive `Vec<Slot>` (which represents Java byte arrays) just to iterate through it and write bytes. Furthermore, calling `heap.get()` *and* a system call for every individual byte is extremely expensive inside a tight loop.

📊 **Impact**: Eliminates a huge heap allocation (`Vec<Slot>`) on file writes. Drastically reduces the number of `heap.get()` hashmap/vector lookups and the number of OS syscalls by batching writes.

🔬 **Measurement**: Verified the application passes `cargo clippy`, `cargo fmt`, and `cargo test` to ensure borrow checker rules and logic correctly remain intact.

---
*PR created automatically by Jules for task [9944866246341445185](https://jules.google.com/task/9944866246341445185) started by @madmax983*