### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/crates/duke-bytecode/src/cfg.rs
+++ b/crates/duke-bytecode/src/cfg.rs
@@ -1,3 +1,10 @@
+//! Control Flow Graph Generation.
+//!
+//! This module provides utilities to convert decoded JVM instructions into a visual
+//! representation using [Mermaid JS](https://mermaid.js.org/). It models branches, gotos,
+//! returns, and switch statements to create a comprehensible Control Flow Graph (CFG)
+//! of method bytecode logic.
+
 use std::fmt::Write;
 
 use crate::Instruction;

--- a/crates/duke-classfile/src/types.rs
+++ b/crates/duke-classfile/src/types.rs
@@ -1,3 +1,14 @@
+//! Structural types representing a parsed JVM Class File.
+//!
+//! This module contains the typed structures resulting from parsing a `.class` file.
+//! These structures strictly adhere to the JVM SE 21 Specification (§4), representing
+//! the constant pool, class hierarchy, fields, methods, and attributes.
+//!
+//! # Concepts
+//! - [`ClassFile`]: The root structure containing all parsed data for a single class.
+//! - [`CpEntry`]: The variants of a constant pool entry (e.g., `Utf8`, `Methodref`).
+//! - [`AttributeInfo`]: The typed and untyped attributes attached to classes, methods, and fields.
+
 use crate::access_flags::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 
 /// Newtype wrapper for constant pool indices (1-based per JVM spec).

--- a/crates/duke-gc/src/mermaid.rs
+++ b/crates/duke-gc/src/mermaid.rs
@@ -1,3 +1,10 @@
+//! Heap Serialization to Mermaid JS format.
+//!
+//! This module exports the JVM's memory object graph into a [Mermaid JS](https://mermaid.js.org/)
+//! directed graph (`graph TD`). The visualization explicitly captures both generational regions
+//! (young vs. old generation) and the edges formed by object fields referencing other objects,
+//! providing a visual overview of allocations and reference structures.
+
 use crate::{Heap, OLD_BIT};
 use duke_runtime::Slot;
 use std::fmt::Write;


### PR DESCRIPTION
📖 Chapter: Module Level Documentation (`types.rs`, `cfg.rs`, `mermaid.rs`)
🔦 Insight: Several core modules were missing high-level summaries (`//!`), making it difficult for users to understand what role they played in the JVM architecture without reading the code. This PR adds descriptive overviews and conceptual outlines.
🧪 Example: N/A - Module level docs focus on concept explanation.
🖼️ Preview: (Run `cargo doc --open` to view the beautiful module index).

---
*PR created automatically by Jules for task [18408607679889983567](https://jules.google.com/task/18408607679889983567) started by @madmax983*