### PR TITLE
⚒️ Forge: Flatten manual match args.get boilerplate

### DIFF
--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -3764,10 +3764,7 @@ fn path_from_string_slot(
     idx: usize,
     heap: &duke_gc::Heap,
 ) -> VmResult<std::path::PathBuf> {
-    let path_ref = match args.get(idx) {
-        Some(Slot::Reference(Some(r))) => *r,
-        _ => return Err(VmError::NullPointerException),
-    };
+    let path_ref = extract_ref_arg(args, idx)?;
     let path = heap
         .get(path_ref)?
         .string_value
@@ -4158,14 +4155,12 @@ fn native_socket_init(
     _control: &mut NativeControl,
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let host = match args.get(1) {
-        Some(Slot::Reference(Some(r))) => heap
-            .get(*r)?
-            .string_value
-            .clone()
-            .ok_or(VmError::NullPointerException)?,
-        _ => return Err(VmError::NullPointerException),
-    };
+    let host_ref = extract_ref_arg(args, 1)?;
+    let host = heap
+        .get(host_ref)?
+        .string_value
+        .clone()
+        .ok_or(VmError::NullPointerException)?;
     let port = extract_int_arg(args, 2)?;
     let addr = format!("{host}:{port}");
     let (reader_id, writer_id) = heap.connect_socket(&addr)?;
@@ -4607,9 +4602,8 @@ fn native_string_equals(
     _control: &mut NativeControl,
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let other_ref = match args.get(1) {
-        Some(Slot::Reference(Some(r))) => *r,
-        _ => return Ok(Some(Slot::Int(0))),
+    let Ok(other_ref) = extract_ref_arg(args, 1) else {
+        return Ok(Some(Slot::Int(0)));
     };
     // Fetch objects from heap in one go to keep borrows short
     let this_obj = heap.get(this_ref)?;
@@ -4673,10 +4667,7 @@ fn native_object_equals(
     _control: &mut NativeControl,
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let equal = match args.get(1) {
-        Some(Slot::Reference(Some(other_ref))) => this_ref == *other_ref,
-        _ => false,
-    };
+    let equal = extract_ref_arg(args, 1) == Ok(this_ref);
     Ok(Some(Slot::Int(i32::from(equal))))
 }
 
@@ -6193,15 +6184,7 @@ fn native_reflection_member_set_accessible(
     _control: &mut NativeControl,
 ) -> VmResult<Option<Slot>> {
     let member_ref = extract_ref_arg(args, 0)?;
-    let accessible = match args.get(1) {
-        Some(Slot::Int(value)) => *value != 0,
-        _ => {
-            return Err(VmError::TypeMismatch {
-                expected: "Int",
-                got: "other",
-            });
-        }
-    };
+    let accessible = extract_int_arg(args, 1)? != 0;
     heap.write_field(
         member_ref,
         REFLECTION_MEMBER_ACCESSIBLE_FIELD,
@@ -7039,10 +7022,7 @@ fn native_string_compareto_object(
         Some(s) => str_val(s)?,
         None => return Err(VmError::NullPointerException),
     };
-    let b = match args.get(1) {
-        Some(s) => str_val(s)?,
-        None => return Err(VmError::NullPointerException),
-    };
+    let b = str_val(args.get(1).ok_or(VmError::NullPointerException)?)?;
     Ok(Some(Slot::Int(ordering_to_int(a.as_str().cmp(b.as_str())))))
 }
 
@@ -7293,10 +7273,7 @@ fn native_integer_compareto(
         Some(s) => int_val(s)?,
         None => return Err(VmError::NullPointerException),
     };
-    let b = match args.get(1) {
-        Some(s) => int_val(s)?,
-        None => return Err(VmError::NullPointerException),
-    };
+    let b = int_val(args.get(1).ok_or(VmError::NullPointerException)?)?;
     Ok(Some(Slot::Int(ordering_to_int(a.cmp(&b)))))
 }
 
@@ -7615,24 +7592,8 @@ fn native_string_replace_char(
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
     let s = heap.get(this_ref)?.string_value.clone().unwrap_or_default();
-    let old_char = match args.get(1) {
-        Some(Slot::Int(v)) => char::from_u32((*v).cast_unsigned()).unwrap_or('?'),
-        _ => {
-            return Err(VmError::TypeMismatch {
-                expected: "Int",
-                got: "other",
-            });
-        }
-    };
-    let new_char = match args.get(2) {
-        Some(Slot::Int(v)) => char::from_u32((*v).cast_unsigned()).unwrap_or('?'),
-        _ => {
-            return Err(VmError::TypeMismatch {
-                expected: "Int",
-                got: "other",
-            });
-        }
-    };
+    let old_char = char::from_u32(extract_int_arg(args, 1)?.cast_unsigned()).unwrap_or('?');
+    let new_char = char::from_u32(extract_int_arg(args, 2)?.cast_unsigned()).unwrap_or('?');
     let result = s.replace(old_char, &new_char.to_string());
     let r = heap.allocate_string(result);
     Ok(Some(Slot::Reference(Some(r))))
@@ -8255,10 +8216,7 @@ fn native_long_compareto(
         Some(s) => long_val(s)?,
         None => return Err(VmError::NullPointerException),
     };
-    let b = match args.get(1) {
-        Some(s) => long_val(s)?,
-        None => return Err(VmError::NullPointerException),
-    };
+    let b = long_val(args.get(1).ok_or(VmError::NullPointerException)?)?;
     Ok(Some(Slot::Int(ordering_to_int(a.cmp(&b)))))
 }
 
@@ -8373,10 +8331,7 @@ fn native_float_compareto(
         Some(s) => float_val(s)?,
         None => return Err(VmError::NullPointerException),
     };
-    let b = match args.get(1) {
-        Some(s) => float_val(s)?,
-        None => return Err(VmError::NullPointerException),
-    };
+    let b = float_val(args.get(1).ok_or(VmError::NullPointerException)?)?;
     Ok(Some(Slot::Int(ordering_to_int(a.total_cmp(&b)))))
 }
 
@@ -8448,10 +8403,7 @@ fn native_boolean_compareto(
         Some(s) => bool_val(s)?,
         None => return Err(VmError::NullPointerException),
     };
-    let b = match args.get(1) {
-        Some(s) => bool_val(s)?,
-        None => return Err(VmError::NullPointerException),
-    };
+    let b = bool_val(args.get(1).ok_or(VmError::NullPointerException)?)?;
     Ok(Some(Slot::Int(ordering_to_int(a.cmp(&b)))))
 }
 
@@ -8712,10 +8664,7 @@ fn native_byte_compareto(
         Some(s) => byte_val(s)?,
         None => return Err(VmError::NullPointerException),
     };
-    let b = match args.get(1) {
-        Some(s) => byte_val(s)?,
-        None => return Err(VmError::NullPointerException),
-    };
+    let b = byte_val(args.get(1).ok_or(VmError::NullPointerException)?)?;
     Ok(Some(Slot::Int(ordering_to_int(a.cmp(&b)))))
 }
 
@@ -8817,10 +8766,7 @@ fn native_short_compareto(
         Some(s) => short_val(s)?,
         None => return Err(VmError::NullPointerException),
     };
-    let b = match args.get(1) {
-        Some(s) => short_val(s)?,
-        None => return Err(VmError::NullPointerException),
-    };
+    let b = short_val(args.get(1).ok_or(VmError::NullPointerException)?)?;
     Ok(Some(Slot::Int(ordering_to_int(a.cmp(&b)))))
 }
 
@@ -8843,10 +8789,7 @@ fn native_char_compareto(
         Some(s) => char_val(s)?,
         None => return Err(VmError::NullPointerException),
     };
-    let b = match args.get(1) {
-        Some(s) => char_val(s)?,
-        None => return Err(VmError::NullPointerException),
-    };
+    let b = char_val(args.get(1).ok_or(VmError::NullPointerException)?)?;
     Ok(Some(Slot::Int(ordering_to_int(a.cmp(&b)))))
 }
 
@@ -16925,10 +16868,7 @@ fn native_double_compareto(
         Some(s) => double_val(s)?,
         None => return Err(VmError::NullPointerException),
     };
-    let b = match args.get(1) {
-        Some(s) => double_val(s)?,
-        None => return Err(VmError::NullPointerException),
-    };
+    let b = double_val(args.get(1).ok_or(VmError::NullPointerException)?)?;
     // Use total_cmp: implements Java's total order where NaN > +∞ > … > -∞.
     Ok(Some(Slot::Int(ordering_to_int(a.total_cmp(&b)))))
 }

--- a/match_args_linter.py
+++ b/match_args_linter.py
@@ -1,0 +1,34 @@
+import re
+
+with open("crates/duke-interpreter/src/lib.rs", "r") as f:
+    text = f.read()
+
+count = 0
+for match in re.finditer(r'let\s+(\w+)\s*=\s*match\s+args\.get\(\s*(\d+)\s*\)\s*\{([^}]*TypeMismatch[^}]*)\};', text, re.DOTALL):
+    var = match.group(1)
+    idx = match.group(2)
+    body = match.group(3)
+    full_match = match.group(0)
+
+    if "Some(Slot::Int" in body:
+        print(f"Match block at args.get({idx}) for {var} returns Err:")
+        print(match.group(0))
+        print("-" * 40)
+        count += 1
+    elif "Some(Slot::Double" in body:
+        print(f"Match block at args.get({idx}) for {var} returns Err:")
+        print(match.group(0))
+        print("-" * 40)
+        count += 1
+    elif "Some(Slot::Long" in body:
+        print(f"Match block at args.get({idx}) for {var} returns Err:")
+        print(match.group(0))
+        print("-" * 40)
+        count += 1
+    elif "Some(Slot::Float" in body:
+        print(f"Match block at args.get({idx}) for {var} returns Err:")
+        print(match.group(0))
+        print("-" * 40)
+        count += 1
+
+print(f"Total found: {count}")

--- a/patch_a.py
+++ b/patch_a.py
@@ -1,0 +1,20 @@
+import re
+
+with open("crates/duke-interpreter/src/lib.rs", "r") as f:
+    text = f.read()
+
+# I also noticed there are blocks like:
+# let a = match args.get(0) {
+#     Some(s) => ...val(s)?,
+#     None => return Err(VmError::NullPointerException),
+# };
+for val_fn in ["str_val", "int_val", "long_val", "float_val", "bool_val", "byte_val", "short_val", "char_val", "double_val"]:
+    old_a = f"""let a = match args.get(0) {{
+        Some(s) => {val_fn}(s)?,
+        None => return Err(VmError::NullPointerException),
+    }};"""
+    new_a = f"let a = {val_fn}(args.get(0).ok_or(VmError::NullPointerException)?)?;"
+    text = text.replace(old_a, new_a)
+
+with open("crates/duke-interpreter/src/lib.rs", "w") as f:
+    f.write(text)

--- a/patch_a2.py
+++ b/patch_a2.py
@@ -1,0 +1,18 @@
+import re
+
+with open("crates/duke-interpreter/src/lib.rs", "r") as f:
+    text = f.read()
+
+count = 0
+for match in re.finditer(r'let\s+a\s*=\s*match\s+args\.get\(\s*(\d+)\s*\)\s*\{([^}]*)\};', text, re.DOTALL):
+    var = match.group(1)
+    idx = match.group(2)
+    body = match.group(2)
+
+    if "NullPointerException" in body:
+        print(f"Match block at args.get({idx}) for a returns Err:")
+        print(match.group(0))
+        print("-" * 40)
+        count += 1
+
+print(f"Total found: {count}")


### PR DESCRIPTION
🚮 Smell: Manual `match args.get(X)` boilerplate across the codebase returning null pointer exceptions and type mismatches.
✨ Solution: Used `extract_int_arg` and `extract_ref_arg` helpers to flatten logic and leverage `ok_or` to propagate errors properly for primitive extraction functions like `str_val` and `int_val`.
🧼 Benefit: Significantly flattens nesting, improves readability, and adheres to idiomatic error handling in Rust without behavior changes.
🛡️ Verification: `cargo test` and `cargo clippy` run successfully, proving no regressions and enforcing the Red-Green-Refactor process for Refactoring only.

---
*PR created automatically by Jules for task [1132345136297149249](https://jules.google.com/task/1132345136297149249) started by @madmax983*