### PR TITLE
🎸 Bard: [documentation update]

### DIFF
--- a/crates/duke-runtime/src/error.rs
+++ b/crates/duke-runtime/src/error.rs
@@ -199,7 +199,25 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Compatibility alias for [`enum@Error`], to avoid naming conflicts with `std::error::Error`.
+///
+/// # Examples
+///
+/// ```
+/// use duke_runtime::VmError;
+/// let e: VmError = duke_runtime::Error::StackOverflow;
+/// assert_eq!(e.to_string(), "operand stack overflow");
+/// ```
 pub type VmError = Error;
 
 /// Compatibility alias for [`Result`], a specialized `Result` type for `duke_runtime` operations.
+///
+/// # Examples
+///
+/// ```
+/// use duke_runtime::{VmError, VmResult};
+/// fn always_fails() -> VmResult<()> {
+///     Err(VmError::StackUnderflow)
+/// }
+/// assert!(always_fails().is_err());
+/// ```
 pub type VmResult<T> = Result<T>;

--- a/crates/duke-runtime/src/error.rs
+++ b/crates/duke-runtime/src/error.rs
@@ -197,5 +197,9 @@ pub enum Error {
 /// assert_eq!(might_fail(false).unwrap(), 42);
 /// ```
 pub type Result<T> = std::result::Result<T, Error>;
+
+/// Compatibility alias for [`enum@Error`], to avoid naming conflicts with `std::error::Error`.
 pub type VmError = Error;
+
+/// Compatibility alias for [`Result`], a specialized `Result` type for `duke_runtime` operations.
 pub type VmResult<T> = Result<T>;


### PR DESCRIPTION
📖 Chapter: `duke-runtime::error`
🔦 Insight: The type aliases `VmError` and `VmResult` were missing public docstrings, causing `cargo doc --missing-docs` to throw errors. We've added proper, concise explanations of their compatibility with standard results and aliasing of `Error`. Also resolved an ambiguous intra-doc link by explicitly using `[`enum@Error`]`.
🧪 Example: Verified via `cargo doc -p duke-runtime -- -D missing_docs`.
🖼️ Preview: No visible API change besides fully generated html files.

---
*PR created automatically by Jules for task [17676248517836716863](https://jules.google.com/task/17676248517836716863) started by @madmax983*