### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -539,3 +539,18 @@ pub(crate) fn cp_utf8(pool: &[Option<CpEntry>], idx: CpIndex) -> ParseResult<&st
         }),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_return_error_when_cp_index_is_zero() {
+        let pool = vec![];
+        let result = cp_utf8(&pool, CpIndex(0));
+        assert!(
+            matches!(result, Err(ParseError::CpIndexZero)),
+            "Expected ParseError::CpIndexZero, got {result:?}"
+        );
+    }
+}


### PR DESCRIPTION
🎯 **Target:** `crates/duke-classfile/src/parser.rs` (`cp_utf8` function)
💣 **Risk:** The condition where a `CpIndex(0)` is requested from the constant pool was uncovered in testing. While caught and handled as a `ParseError::CpIndexZero`, failure to test this explicitly risks future regressions that could allow a reserved index to be incorrectly processed, leading to undefined behavior or panics elsewhere when a valid entry is expected.
🧪 **Strategy:** Appended a unit test `should_return_error_when_cp_index_is_zero` in a `#[cfg(test)] mod tests` block at the bottom of the `parser.rs` file. The test supplies an empty constant pool and index `0`, asserting that `cp_utf8` predictably and safely returns `Err(ParseError::CpIndexZero)` instead of attempting a lookup.
🔭 **Verification:** `cargo test -p duke-classfile`

---
*PR created automatically by Jules for task [11305675398915197013](https://jules.google.com/task/11305675398915197013) started by @madmax983*