### PR TITLE
Fix compile error due to duplicate `extract_slot_arg`

### DIFF
--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -3736,11 +3736,6 @@ fn extract_double_arg(args: &[Slot], idx: usize) -> VmResult<f64> {
     }
 }
 
-#[inline]
-fn extract_slot_arg(args: &[Slot], idx: usize) -> Slot {
-    args.get(idx).copied().unwrap_or(Slot::Reference(None))
-}
-
 macro_rules! extract_print_arg {
     ($args:expr, $pat:pat => $expr:expr, $expected:literal) => {
         match $args.get(1) {


### PR DESCRIPTION
Fix compile error due to duplicate `extract_slot_arg`

The `crates/duke-interpreter/src/lib.rs` file contained a duplicate `extract_slot_arg` function block that caused `cargo check` to fail. This commit removes the duplicate block, resolving the E0428 compilation error. No architectural/PR changes were necessary.

---
*PR created automatically by Jules for task [2846236971144344331](https://jules.google.com/task/2846236971144344331) started by @madmax983*