### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/crates/duke-bytecode/src/error.rs
+++ b/crates/duke-bytecode/src/error.rs
@@ -6,6 +6,18 @@
 
 use thiserror::Error;
 
+/// General error enumeration encompassing both decoding and structural verification errors.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Wrapping a [`DecodeError`].
+    #[error("Decode error: {0}")]
+    Decode(#[from] DecodeError),
+
+    /// Wrapping a [`VerifyError`].
+    #[error("Verify error: {0}")]
+    Verify(#[from] VerifyError),
+}
+
 /// Errors produced by the bytecode decoder.
 ///
 /// These errors occur when the raw bytes of a method's `Code` attribute
@@ -19,18 +31,6 @@ use thiserror::Error;
 /// let err = DecodeError::UnexpectedEof { pc: 10 };
 /// assert_eq!(err.to_string(), "unexpected end of bytecode at pc=10");
 /// ```
-/// General error enumeration encompassing both decoding and structural verification errors.
-#[derive(Debug, Error)]
-pub enum Error {
-    /// Wrapping a [`DecodeError`].
-    #[error("Decode error: {0}")]
-    Decode(#[from] DecodeError),
-
-    /// Wrapping a [`VerifyError`].
-    #[error("Verify error: {0}")]
-    Verify(#[from] VerifyError),
-}
-
 #[derive(Debug, Error)]
 pub enum DecodeError {
     /// Reached end of bytecode unexpectedly.

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -3673,11 +3673,6 @@ fn extract_ref_arg(args: &[Slot], idx: usize) -> VmResult<u64> {
 }
 
 #[inline]
-fn extract_slot_arg(args: &[Slot], idx: usize) -> Slot {
-    args.get(idx).copied().unwrap_or(Slot::Reference(None))
-}
-
-#[inline]
 fn extract_io_fd(heap: &duke_gc::Heap, obj_ref: u64) -> VmResult<i32> {
     match heap.get(obj_ref)?.fields.first() {
         Some(Slot::Int(id)) => Ok(*id),


### PR DESCRIPTION
📖 Chapter: `duke-interpreter` and `duke-bytecode/error.rs`
🔦 Insight: The documentation build for the entire project was failing due to a redefined private function (`extract_slot_arg`) in `duke-interpreter`. After resolving this to unblock `cargo doc`, I found that in `duke-bytecode::error`, the documentation (including examples) for `DecodeError` was mistakenly placed above the generic `Error` enum.
🧪 Example: Cleaned up the file structure and restored the executable doctests to their correct home.
🖼️ Preview: Documentation renders smoothly and correctly!

---
*PR created automatically by Jules for task [9659182538813654475](https://jules.google.com/task/9659182538813654475) started by @madmax983*