### PR TITLE
🗺️ Atlas: [architectural change] Extract HostManager out of Heap God Struct

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -5,3 +5,7 @@
 **Refactoring the Duke Interpreter Blob**
 **Tangle:** The `crates/duke-interpreter/src/lib.rs` file had grown into a massive "Blob" anti-pattern (over 23,000 lines). It mixed JVM data structures, the registry, execution engine logic, and an enormous amount of standard library bootstrapping/tests, making it hard to navigate and violating the single responsibility principle.
 **Blueprint:** Extracted the core execution context data structures (`MethodEntry`, `FieldEntry`, `ExceptionEntry`, `ClassContext`) into a new `context` module, and the registry types (`ClassRegistry`, `NativeRegistry`, handler definitions) into a new `registry` module. These are now re-exported from `lib.rs` to maintain a clean public API while breaking up the physical file bloat.
+
+**Refactoring the Duke GC Blob**
+**Tangle:** The `crates/duke-gc/src/lib.rs` file was a God Struct, mixing garbage collection and memory allocation responsibilities with I/O subsystems, such as OS-level file handles, sockets, and subprocesses management.
+**Blueprint:** Extracted the core OS-level file, process, and socket management data structures (`HostFileHandle`, `HostProcessHandle`, `SpawnedProcessIds`) and related methods out of `Heap` into a separate `HostManager` struct within a new `host` module. The `Heap` struct now delegates I/O calls to a `host: HostManager` field, enforcing high cohesion and low coupling.

--- a/crates/duke-gc/src/host.rs
+++ b/crates/duke-gc/src/host.rs
@@ -1,0 +1,522 @@
+use duke_runtime::{VmError, VmResult};
+use std::collections::HashMap;
+use std::io::{Read, Write};
+
+#[derive(Debug)]
+pub struct HostProcessHandle {
+    pub child: std::process::Child,
+    pub exit_code: Option<i32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SpawnedProcessIds {
+    pub process_id: i32,
+    pub stdin_id: i32,
+    pub stdout_id: i32,
+    pub stderr_id: i32,
+}
+
+#[derive(Debug)]
+/// A handle to a native file managed by the VM on behalf of Java I/O classes.
+pub enum HostFileHandle {
+    /// A file opened for reading.
+    Reader(std::fs::File),
+    /// A file opened for writing.
+    Writer(std::fs::File),
+    /// A TCP server socket waiting for incoming connections.
+    TcpListener(std::net::TcpListener),
+    /// The read half of an accepted or connected TCP socket.
+    SocketReader(std::net::TcpStream),
+    /// The write half of an accepted or connected TCP socket.
+    SocketWriter(std::net::TcpStream),
+    /// An opened ZIP/JAR archive (parsed and indexed).
+    ZipArchive(duke_loader::ZipReader),
+    /// An in-memory byte buffer (e.g. decompressed ZIP entry for `InputStream`).
+    ByteBuffer(std::io::Cursor<Vec<u8>>),
+    /// An owned child process plus any cached exit status.
+    Process(HostProcessHandle),
+    /// The stdout pipe of a child process.
+    ProcessStdout(std::process::ChildStdout),
+    /// The stderr pipe of a child process.
+    ProcessStderr(std::process::ChildStderr),
+    /// The stdin pipe of a child process.
+    ProcessStdin(std::process::ChildStdin),
+}
+
+#[derive(Debug)]
+pub struct HostManager {
+    pub(crate) host_files: HashMap<i32, HostFileHandle>,
+    pub(crate) next_host_file_id: i32,
+}
+
+impl Default for HostManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HostManager {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            host_files: HashMap::new(),
+            next_host_file_id: 1,
+        }
+    }
+    /// Opens an input file on the host OS.
+    ///
+    /// # Errors
+    /// Returns `VmError::JavaException` if the file does not exist or an IO error occurs.
+    pub fn open_host_input_file(&mut self, path: &std::path::Path) -> VmResult<i32> {
+        let file = std::fs::File::open(path).map_err(|err| match err.kind() {
+            std::io::ErrorKind::NotFound => VmError::JavaException {
+                class_name: "java/io/FileNotFoundException".to_string(),
+            },
+            _ => VmError::JavaException {
+                class_name: "java/io/IOException".to_string(),
+            },
+        })?;
+        let id = self.next_host_file_id;
+        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
+        self.host_files.insert(id, HostFileHandle::Reader(file));
+        Ok(id)
+    }
+
+    /// Opens an output file on the host OS.
+    ///
+    /// # Errors
+    /// Returns `VmError::JavaException` if the file cannot be created.
+    pub fn open_host_output_file(&mut self, path: &std::path::Path) -> VmResult<i32> {
+        let file = std::fs::File::create(path).map_err(|_| VmError::JavaException {
+            class_name: "java/io/IOException".to_string(),
+        })?;
+        let id = self.next_host_file_id;
+        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
+        self.host_files.insert(id, HostFileHandle::Writer(file));
+        Ok(id)
+    }
+
+    /// Reads a single byte from a host file.
+    ///
+    /// # Errors
+    /// Returns `VmError::JavaException` if the file handle is invalid or an IO error occurs.
+    pub fn read_host_file_byte(&mut self, id: i32) -> VmResult<i32> {
+        let Some(handle) = self.host_files.get_mut(&id) else {
+            return Err(VmError::JavaException {
+                class_name: "java/io/IOException".to_string(),
+            });
+        };
+        let reader: &mut dyn Read = match handle {
+            HostFileHandle::Reader(f) => f,
+            HostFileHandle::SocketReader(s) => s,
+            HostFileHandle::ByteBuffer(cursor) => cursor,
+            HostFileHandle::ProcessStdout(stdout) => stdout,
+            HostFileHandle::ProcessStderr(stderr) => stderr,
+            _ => {
+                return Err(VmError::JavaException {
+                    class_name: "java/io/IOException".into(),
+                });
+            }
+        };
+        let mut buf = [0_u8; 1];
+        match reader.read(&mut buf) {
+            Ok(0) => Ok(-1),
+            Ok(_) => Ok(i32::from(buf[0])),
+            Err(_) => Err(VmError::JavaException {
+                class_name: "java/io/IOException".into(),
+            }),
+        }
+    }
+
+    /// Writes a single byte to a host file.
+    ///
+    /// # Errors
+    /// Returns `VmError::JavaException` if the file handle is invalid or an IO error occurs.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    pub fn write_host_file_byte(&mut self, id: i32, value: i32) -> VmResult<()> {
+        let Some(handle) = self.host_files.get_mut(&id) else {
+            return Err(VmError::JavaException {
+                class_name: "java/io/IOException".to_string(),
+            });
+        };
+        let writer: &mut dyn Write = match handle {
+            HostFileHandle::Writer(f) => f,
+            HostFileHandle::SocketWriter(s) => s,
+            HostFileHandle::ProcessStdin(stdin) => stdin,
+            _ => {
+                return Err(VmError::JavaException {
+                    class_name: "java/io/IOException".into(),
+                });
+            }
+        };
+        writer
+            .write_all(&[(value & 0xFF) as u8])
+            .map_err(|_| VmError::JavaException {
+                class_name: "java/io/IOException".into(),
+            })
+    }
+
+    /// Closes a host file handle previously opened via the registry.
+    ///
+    /// Silently ignores invalid or already-closed file descriptors.
+    pub fn close_host_file(&mut self, id: i32) {
+        if id > 0 {
+            self.host_files.remove(&id);
+        }
+    }
+
+    const fn next_host_handle_id(&mut self) -> i32 {
+        let id = self.next_host_file_id;
+        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
+        id
+    }
+
+    /// Spawns a child process on the host OS with fully piped stdio.
+    ///
+    /// # Errors
+    /// Returns `IOException` if the command is empty, cannot be spawned, or any
+    /// of the expected pipes are unavailable.
+    pub fn spawn_host_process(
+        &mut self,
+        command: &[String],
+        cwd: Option<&std::path::Path>,
+    ) -> VmResult<SpawnedProcessIds> {
+        if command.is_empty() {
+            return Err(VmError::JavaException {
+                class_name: "java/io/IOException".into(),
+            });
+        }
+
+        let mut builder = std::process::Command::new(&command[0]);
+        builder.args(&command[1..]);
+        builder.stdin(std::process::Stdio::piped());
+        builder.stdout(std::process::Stdio::piped());
+        builder.stderr(std::process::Stdio::piped());
+        if let Some(cwd) = cwd {
+            builder.current_dir(cwd);
+        }
+
+        let mut child = builder.spawn().map_err(|_| VmError::JavaException {
+            class_name: "java/io/IOException".into(),
+        })?;
+        let Some(stdin) = child.stdin.take() else {
+            return Err(VmError::JavaException {
+                class_name: "java/io/IOException".into(),
+            });
+        };
+        let Some(stdout) = child.stdout.take() else {
+            return Err(VmError::JavaException {
+                class_name: "java/io/IOException".into(),
+            });
+        };
+        let Some(stderr) = child.stderr.take() else {
+            return Err(VmError::JavaException {
+                class_name: "java/io/IOException".into(),
+            });
+        };
+
+        let process_id = self.next_host_handle_id();
+        let stdin_id = self.next_host_handle_id();
+        let stdout_id = self.next_host_handle_id();
+        let stderr_id = self.next_host_handle_id();
+
+        self.host_files.insert(
+            process_id,
+            HostFileHandle::Process(HostProcessHandle {
+                child,
+                exit_code: None,
+            }),
+        );
+        self.host_files
+            .insert(stdin_id, HostFileHandle::ProcessStdin(stdin));
+        self.host_files
+            .insert(stdout_id, HostFileHandle::ProcessStdout(stdout));
+        self.host_files
+            .insert(stderr_id, HostFileHandle::ProcessStderr(stderr));
+
+        Ok(SpawnedProcessIds {
+            process_id,
+            stdin_id,
+            stdout_id,
+            stderr_id,
+        })
+    }
+
+    #[cfg(unix)]
+    fn exit_status_code(status: std::process::ExitStatus) -> i32 {
+        use std::os::unix::process::ExitStatusExt;
+
+        status
+            .code()
+            .unwrap_or_else(|| status.signal().map_or(-1, |signal| 128 + signal))
+    }
+
+    #[cfg(not(unix))]
+    fn exit_status_code(status: std::process::ExitStatus) -> i32 {
+        status.code().unwrap_or(-1)
+    }
+
+    fn process_handle_mut(&mut self, id: i32) -> VmResult<&mut HostProcessHandle> {
+        match self.host_files.get_mut(&id) {
+            Some(HostFileHandle::Process(process)) => Ok(process),
+            _ => Err(VmError::JavaException {
+                class_name: "java/io/IOException".into(),
+            }),
+        }
+    }
+
+    /// Blocks until the child process exits and returns its cached exit code.
+    ///
+    /// # Errors
+    /// Returns `IOException` if the process id is invalid or waiting fails.
+    pub fn wait_host_process(&mut self, id: i32) -> VmResult<i32> {
+        let process = self.process_handle_mut(id)?;
+        if let Some(code) = process.exit_code {
+            return Ok(code);
+        }
+        let status = process.child.wait().map_err(|_| VmError::JavaException {
+            class_name: "java/io/IOException".into(),
+        })?;
+        let code = Self::exit_status_code(status);
+        process.exit_code = Some(code);
+        Ok(code)
+    }
+
+    /// Returns the child's exit code if it has already terminated.
+    ///
+    /// # Errors
+    /// Returns `IOException` if the process id is invalid or querying status fails.
+    pub fn try_host_process_exit_value(&mut self, id: i32) -> VmResult<Option<i32>> {
+        let process = self.process_handle_mut(id)?;
+        if let Some(code) = process.exit_code {
+            return Ok(Some(code));
+        }
+        let status = process
+            .child
+            .try_wait()
+            .map_err(|_| VmError::JavaException {
+                class_name: "java/io/IOException".into(),
+            })?;
+        let Some(status) = status else {
+            return Ok(None);
+        };
+        let code = Self::exit_status_code(status);
+        process.exit_code = Some(code);
+        Ok(Some(code))
+    }
+
+    /// Requests child termination if the process is still alive.
+    ///
+    /// # Errors
+    /// Returns `IOException` if the process id is invalid or the kill operation fails.
+    pub fn destroy_host_process(&mut self, id: i32) -> VmResult<()> {
+        let process = self.process_handle_mut(id)?;
+        if process.exit_code.is_some() {
+            return Ok(());
+        }
+        if let Some(status) = process
+            .child
+            .try_wait()
+            .map_err(|_| VmError::JavaException {
+                class_name: "java/io/IOException".into(),
+            })?
+        {
+            process.exit_code = Some(Self::exit_status_code(status));
+            return Ok(());
+        }
+        process.child.kill().map_err(|_| VmError::JavaException {
+            class_name: "java/io/IOException".into(),
+        })
+    }
+
+    /// Opens a ZIP/JAR archive on the host OS, parses and indexes it.
+    ///
+    /// # Errors
+    /// Returns `ZipException` if the file is not a valid ZIP, or
+    /// `FileNotFoundException` if the path does not exist.
+    pub fn open_host_zip(&mut self, path: &std::path::Path) -> VmResult<i32> {
+        let reader = duke_loader::ZipReader::open(path).map_err(|err| match err {
+            duke_loader::LoadError::Io { .. } => VmError::JavaException {
+                class_name: "java/io/FileNotFoundException".to_string(),
+            },
+            _ => VmError::JavaException {
+                class_name: "java/util/zip/ZipException".to_string(),
+            },
+        })?;
+        let id = self.next_host_file_id;
+        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
+        self.host_files
+            .insert(id, HostFileHandle::ZipArchive(reader));
+        Ok(id)
+    }
+
+    /// Returns the number of entries in an opened ZIP archive.
+    ///
+    /// # Errors
+    /// Returns `IOException` if the handle is invalid or not a ZIP archive.
+    pub fn zip_entry_count(&self, id: i32) -> VmResult<usize> {
+        match self.host_files.get(&id) {
+            Some(HostFileHandle::ZipArchive(reader)) => Ok(reader.entry_count()),
+            _ => Err(VmError::JavaException {
+                class_name: "java/io/IOException".into(),
+            }),
+        }
+    }
+
+    /// Looks up a ZIP entry by name, returning a clone of its metadata.
+    ///
+    /// # Errors
+    /// Returns `IOException` if the handle is invalid or not a ZIP archive.
+    pub fn zip_get_entry_info(
+        &self,
+        id: i32,
+        name: &str,
+    ) -> VmResult<Option<duke_loader::ZipEntryInfo>> {
+        match self.host_files.get(&id) {
+            Some(HostFileHandle::ZipArchive(reader)) => Ok(reader.get_entry(name).cloned()),
+            _ => Err(VmError::JavaException {
+                class_name: "java/io/IOException".into(),
+            }),
+        }
+    }
+
+    /// Reads and decompresses a ZIP entry's bytes.
+    ///
+    /// # Errors
+    /// Returns `ZipException` on decompression failure, `IOException` for invalid handles.
+    pub fn zip_read_entry(&self, id: i32, name: &str) -> VmResult<Vec<u8>> {
+        match self.host_files.get(&id) {
+            Some(HostFileHandle::ZipArchive(reader)) => {
+                reader.read_entry(name).map_err(|_| VmError::JavaException {
+                    class_name: "java/util/zip/ZipException".into(),
+                })
+            }
+            _ => Err(VmError::JavaException {
+                class_name: "java/io/IOException".into(),
+            }),
+        }
+    }
+
+    /// Creates an in-memory byte buffer handle (for reading decompressed data
+    /// as an `InputStream`).
+    pub fn open_host_byte_buffer(&mut self, data: Vec<u8>) -> i32 {
+        let id = self.next_host_file_id;
+        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
+        self.host_files
+            .insert(id, HostFileHandle::ByteBuffer(std::io::Cursor::new(data)));
+        id
+    }
+
+    /// Binds a TCP listener to the given address string (e.g. `"0.0.0.0:8080"`).
+    ///
+    /// # Errors
+    /// Returns `BindException` if the address is already in use, `SocketException` for other errors.
+    pub fn bind_server_socket(&mut self, addr: &str) -> VmResult<i32> {
+        let listener = std::net::TcpListener::bind(addr).map_err(|err| match err.kind() {
+            std::io::ErrorKind::AddrInUse => VmError::JavaException {
+                class_name: "java/net/BindException".into(),
+            },
+            _ => VmError::JavaException {
+                class_name: "java/net/SocketException".into(),
+            },
+        })?;
+        let id = self.next_host_file_id;
+        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
+        self.host_files
+            .insert(id, HostFileHandle::TcpListener(listener));
+        Ok(id)
+    }
+
+    /// Accepts one incoming connection on the given listener id.
+    /// Returns `(reader_id, writer_id)` — two independent OS handles to the same socket.
+    ///
+    /// # Errors
+    /// Returns `IOException` if the id is invalid or the accept fails.
+    ///
+    /// Note: Handle IDs are allocated with `saturating_add`; extremely long-running
+    /// programs opening billions of handles would alias at `i32::MAX`. This is a
+    /// known limitation shared with the file I/O implementation.
+    pub fn accept_connection(&mut self, id: i32) -> VmResult<(i32, i32)> {
+        // Validate that the handle exists and is a TcpListener.
+        if !matches!(
+            self.host_files.get(&id),
+            Some(HostFileHandle::TcpListener(_))
+        ) {
+            return Err(VmError::JavaException {
+                class_name: "java/io/IOException".into(),
+            });
+        }
+        // Temporarily remove the listener to satisfy the borrow checker, then reinsert.
+        let Some(HostFileHandle::TcpListener(listener)) = self.host_files.remove(&id) else {
+            unreachable!()
+        };
+        let result = listener.accept();
+        self.host_files
+            .insert(id, HostFileHandle::TcpListener(listener));
+        let (stream, _addr) = result.map_err(|_| VmError::JavaException {
+            class_name: "java/io/IOException".into(),
+        })?;
+        let writer = stream.try_clone().map_err(|_| VmError::JavaException {
+            class_name: "java/io/IOException".into(),
+        })?;
+        let reader_id = self.next_host_file_id;
+        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
+        let writer_id = self.next_host_file_id;
+        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
+        self.host_files
+            .insert(reader_id, HostFileHandle::SocketReader(stream));
+        self.host_files
+            .insert(writer_id, HostFileHandle::SocketWriter(writer));
+        Ok((reader_id, writer_id))
+    }
+
+    /// Connects a TCP socket to the given address string (e.g. `"127.0.0.1:8080"`).
+    /// Returns `(reader_id, writer_id)` — two independent OS handles to the same socket.
+    ///
+    /// # Errors
+    /// Returns `ConnectException` if connection is refused, `SocketException` for other errors.
+    ///
+    /// Note: Handle IDs are allocated with `saturating_add`; extremely long-running
+    /// programs opening billions of handles would alias at `i32::MAX`. This is a
+    /// known limitation shared with the file I/O implementation.
+    pub fn connect_socket(&mut self, addr: &str) -> VmResult<(i32, i32)> {
+        let stream = std::net::TcpStream::connect(addr).map_err(|err| match err.kind() {
+            std::io::ErrorKind::ConnectionRefused => VmError::JavaException {
+                class_name: "java/net/ConnectException".into(),
+            },
+            _ => VmError::JavaException {
+                class_name: "java/net/SocketException".into(),
+            },
+        })?;
+        let writer = stream.try_clone().map_err(|_| VmError::JavaException {
+            class_name: "java/net/SocketException".into(),
+        })?;
+        let reader_id = self.next_host_file_id;
+        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
+        let writer_id = self.next_host_file_id;
+        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
+        self.host_files
+            .insert(reader_id, HostFileHandle::SocketReader(stream));
+        self.host_files
+            .insert(writer_id, HostFileHandle::SocketWriter(writer));
+        Ok((reader_id, writer_id))
+    }
+
+    /// Returns the local port of a bound server socket.
+    ///
+    /// # Errors
+    /// Returns `IOException` if the id is invalid.
+    pub fn server_socket_local_port(&self, id: i32) -> VmResult<i32> {
+        match self.host_files.get(&id) {
+            Some(HostFileHandle::TcpListener(l)) => l
+                .local_addr()
+                .map(|addr| i32::from(addr.port()))
+                .map_err(|_| VmError::JavaException {
+                    class_name: "java/io/IOException".into(),
+                }),
+            _ => Err(VmError::JavaException {
+                class_name: "java/io/IOException".into(),
+            }),
+        }
+    }
+}

--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -14,9 +14,10 @@
 //! need to know which gen an object lives in.
 
 use std::collections::{HashMap, HashSet};
-use std::io::{Read, Write};
 
 use duke_runtime::{Slot, VmError, VmResult};
+pub mod host;
+use crate::host::HostManager;
 
 mod mermaid;
 
@@ -64,47 +65,6 @@ pub struct HeapObject {
     /// `Some(new_ref)` means this object was already copied; `None` means not yet copied.
     #[allow(dead_code)] // used by minor_collect_prepare / apply_forward
     pub(crate) forward: Option<u64>,
-}
-
-#[derive(Debug)]
-pub struct HostProcessHandle {
-    child: std::process::Child,
-    exit_code: Option<i32>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SpawnedProcessIds {
-    pub process_id: i32,
-    pub stdin_id: i32,
-    pub stdout_id: i32,
-    pub stderr_id: i32,
-}
-
-#[derive(Debug)]
-/// A handle to a native file managed by the VM on behalf of Java I/O classes.
-pub enum HostFileHandle {
-    /// A file opened for reading.
-    Reader(std::fs::File),
-    /// A file opened for writing.
-    Writer(std::fs::File),
-    /// A TCP server socket waiting for incoming connections.
-    TcpListener(std::net::TcpListener),
-    /// The read half of an accepted or connected TCP socket.
-    SocketReader(std::net::TcpStream),
-    /// The write half of an accepted or connected TCP socket.
-    SocketWriter(std::net::TcpStream),
-    /// An opened ZIP/JAR archive (parsed and indexed).
-    ZipArchive(duke_loader::ZipReader),
-    /// An in-memory byte buffer (e.g. decompressed ZIP entry for `InputStream`).
-    ByteBuffer(std::io::Cursor<Vec<u8>>),
-    /// An owned child process plus any cached exit status.
-    Process(HostProcessHandle),
-    /// The stdout pipe of a child process.
-    ProcessStdout(std::process::ChildStdout),
-    /// The stderr pipe of a child process.
-    ProcessStderr(std::process::ChildStderr),
-    /// The stdin pipe of a child process.
-    ProcessStdin(std::process::ChildStdin),
 }
 
 /// The generational object heap.
@@ -176,8 +136,7 @@ pub struct Heap {
     /// `collect()` returns via [`Heap::apply_forward`].
     forward_map: HashMap<u64, u64>,
     /// Host OS file handles keyed by small integer ids stored in Java objects.
-    host_files: HashMap<i32, HostFileHandle>,
-    next_host_file_id: i32,
+    pub host: HostManager,
 }
 
 impl Heap {
@@ -206,8 +165,7 @@ impl Heap {
             live_count: 0,
             young_dropped: 0,
             forward_map: HashMap::new(),
-            host_files: HashMap::new(),
-            next_host_file_id: 1,
+            host: HostManager::new(),
         }
     }
 
@@ -268,463 +226,6 @@ impl Heap {
         self.young.push(Some(obj));
         self.young_top += 1;
         idx
-    }
-
-    /// Opens an input file on the host OS.
-    ///
-    /// # Errors
-    /// Returns `VmError::JavaException` if the file does not exist or an IO error occurs.
-    pub fn open_host_input_file(&mut self, path: &std::path::Path) -> VmResult<i32> {
-        let file = std::fs::File::open(path).map_err(|err| match err.kind() {
-            std::io::ErrorKind::NotFound => VmError::JavaException {
-                class_name: "java/io/FileNotFoundException".to_string(),
-            },
-            _ => VmError::JavaException {
-                class_name: "java/io/IOException".to_string(),
-            },
-        })?;
-        let id = self.next_host_file_id;
-        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
-        self.host_files.insert(id, HostFileHandle::Reader(file));
-        Ok(id)
-    }
-
-    /// Opens an output file on the host OS.
-    ///
-    /// # Errors
-    /// Returns `VmError::JavaException` if the file cannot be created.
-    pub fn open_host_output_file(&mut self, path: &std::path::Path) -> VmResult<i32> {
-        let file = std::fs::File::create(path).map_err(|_| VmError::JavaException {
-            class_name: "java/io/IOException".to_string(),
-        })?;
-        let id = self.next_host_file_id;
-        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
-        self.host_files.insert(id, HostFileHandle::Writer(file));
-        Ok(id)
-    }
-
-    /// Reads a single byte from a host file.
-    ///
-    /// # Errors
-    /// Returns `VmError::JavaException` if the file handle is invalid or an IO error occurs.
-    pub fn read_host_file_byte(&mut self, id: i32) -> VmResult<i32> {
-        let Some(handle) = self.host_files.get_mut(&id) else {
-            return Err(VmError::JavaException {
-                class_name: "java/io/IOException".to_string(),
-            });
-        };
-        let reader: &mut dyn Read = match handle {
-            HostFileHandle::Reader(f) => f,
-            HostFileHandle::SocketReader(s) => s,
-            HostFileHandle::ByteBuffer(cursor) => cursor,
-            HostFileHandle::ProcessStdout(stdout) => stdout,
-            HostFileHandle::ProcessStderr(stderr) => stderr,
-            _ => {
-                return Err(VmError::JavaException {
-                    class_name: "java/io/IOException".into(),
-                });
-            }
-        };
-        let mut buf = [0_u8; 1];
-        match reader.read(&mut buf) {
-            Ok(0) => Ok(-1),
-            Ok(_) => Ok(i32::from(buf[0])),
-            Err(_) => Err(VmError::JavaException {
-                class_name: "java/io/IOException".into(),
-            }),
-        }
-    }
-
-    /// Writes a single byte to a host file.
-    ///
-    /// # Errors
-    /// Returns `VmError::JavaException` if the file handle is invalid or an IO error occurs.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    pub fn write_host_file_byte(&mut self, id: i32, value: i32) -> VmResult<()> {
-        let Some(handle) = self.host_files.get_mut(&id) else {
-            return Err(VmError::JavaException {
-                class_name: "java/io/IOException".to_string(),
-            });
-        };
-        let writer: &mut dyn Write = match handle {
-            HostFileHandle::Writer(f) => f,
-            HostFileHandle::SocketWriter(s) => s,
-            HostFileHandle::ProcessStdin(stdin) => stdin,
-            _ => {
-                return Err(VmError::JavaException {
-                    class_name: "java/io/IOException".into(),
-                });
-            }
-        };
-        writer
-            .write_all(&[(value & 0xFF) as u8])
-            .map_err(|_| VmError::JavaException {
-                class_name: "java/io/IOException".into(),
-            })
-    }
-
-    /// Closes a host file handle previously opened via the registry.
-    ///
-    /// Silently ignores invalid or already-closed file descriptors.
-    pub fn close_host_file(&mut self, id: i32) {
-        if id > 0 {
-            self.host_files.remove(&id);
-        }
-    }
-
-    const fn next_host_handle_id(&mut self) -> i32 {
-        let id = self.next_host_file_id;
-        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
-        id
-    }
-
-    /// Spawns a child process on the host OS with fully piped stdio.
-    ///
-    /// # Errors
-    /// Returns `IOException` if the command is empty, cannot be spawned, or any
-    /// of the expected pipes are unavailable.
-    pub fn spawn_host_process(
-        &mut self,
-        command: &[String],
-        cwd: Option<&std::path::Path>,
-    ) -> VmResult<SpawnedProcessIds> {
-        if command.is_empty() {
-            return Err(VmError::JavaException {
-                class_name: "java/io/IOException".into(),
-            });
-        }
-
-        let mut builder = std::process::Command::new(&command[0]);
-        builder.args(&command[1..]);
-        builder.stdin(std::process::Stdio::piped());
-        builder.stdout(std::process::Stdio::piped());
-        builder.stderr(std::process::Stdio::piped());
-        if let Some(cwd) = cwd {
-            builder.current_dir(cwd);
-        }
-
-        let mut child = builder.spawn().map_err(|_| VmError::JavaException {
-            class_name: "java/io/IOException".into(),
-        })?;
-        let Some(stdin) = child.stdin.take() else {
-            return Err(VmError::JavaException {
-                class_name: "java/io/IOException".into(),
-            });
-        };
-        let Some(stdout) = child.stdout.take() else {
-            return Err(VmError::JavaException {
-                class_name: "java/io/IOException".into(),
-            });
-        };
-        let Some(stderr) = child.stderr.take() else {
-            return Err(VmError::JavaException {
-                class_name: "java/io/IOException".into(),
-            });
-        };
-
-        let process_id = self.next_host_handle_id();
-        let stdin_id = self.next_host_handle_id();
-        let stdout_id = self.next_host_handle_id();
-        let stderr_id = self.next_host_handle_id();
-
-        self.host_files.insert(
-            process_id,
-            HostFileHandle::Process(HostProcessHandle {
-                child,
-                exit_code: None,
-            }),
-        );
-        self.host_files
-            .insert(stdin_id, HostFileHandle::ProcessStdin(stdin));
-        self.host_files
-            .insert(stdout_id, HostFileHandle::ProcessStdout(stdout));
-        self.host_files
-            .insert(stderr_id, HostFileHandle::ProcessStderr(stderr));
-
-        Ok(SpawnedProcessIds {
-            process_id,
-            stdin_id,
-            stdout_id,
-            stderr_id,
-        })
-    }
-
-    #[cfg(unix)]
-    fn exit_status_code(status: std::process::ExitStatus) -> i32 {
-        use std::os::unix::process::ExitStatusExt;
-
-        status
-            .code()
-            .unwrap_or_else(|| status.signal().map_or(-1, |signal| 128 + signal))
-    }
-
-    #[cfg(not(unix))]
-    fn exit_status_code(status: std::process::ExitStatus) -> i32 {
-        status.code().unwrap_or(-1)
-    }
-
-    fn process_handle_mut(&mut self, id: i32) -> VmResult<&mut HostProcessHandle> {
-        match self.host_files.get_mut(&id) {
-            Some(HostFileHandle::Process(process)) => Ok(process),
-            _ => Err(VmError::JavaException {
-                class_name: "java/io/IOException".into(),
-            }),
-        }
-    }
-
-    /// Blocks until the child process exits and returns its cached exit code.
-    ///
-    /// # Errors
-    /// Returns `IOException` if the process id is invalid or waiting fails.
-    pub fn wait_host_process(&mut self, id: i32) -> VmResult<i32> {
-        let process = self.process_handle_mut(id)?;
-        if let Some(code) = process.exit_code {
-            return Ok(code);
-        }
-        let status = process.child.wait().map_err(|_| VmError::JavaException {
-            class_name: "java/io/IOException".into(),
-        })?;
-        let code = Self::exit_status_code(status);
-        process.exit_code = Some(code);
-        Ok(code)
-    }
-
-    /// Returns the child's exit code if it has already terminated.
-    ///
-    /// # Errors
-    /// Returns `IOException` if the process id is invalid or querying status fails.
-    pub fn try_host_process_exit_value(&mut self, id: i32) -> VmResult<Option<i32>> {
-        let process = self.process_handle_mut(id)?;
-        if let Some(code) = process.exit_code {
-            return Ok(Some(code));
-        }
-        let status = process
-            .child
-            .try_wait()
-            .map_err(|_| VmError::JavaException {
-                class_name: "java/io/IOException".into(),
-            })?;
-        let Some(status) = status else {
-            return Ok(None);
-        };
-        let code = Self::exit_status_code(status);
-        process.exit_code = Some(code);
-        Ok(Some(code))
-    }
-
-    /// Requests child termination if the process is still alive.
-    ///
-    /// # Errors
-    /// Returns `IOException` if the process id is invalid or the kill operation fails.
-    pub fn destroy_host_process(&mut self, id: i32) -> VmResult<()> {
-        let process = self.process_handle_mut(id)?;
-        if process.exit_code.is_some() {
-            return Ok(());
-        }
-        if let Some(status) = process
-            .child
-            .try_wait()
-            .map_err(|_| VmError::JavaException {
-                class_name: "java/io/IOException".into(),
-            })?
-        {
-            process.exit_code = Some(Self::exit_status_code(status));
-            return Ok(());
-        }
-        process.child.kill().map_err(|_| VmError::JavaException {
-            class_name: "java/io/IOException".into(),
-        })
-    }
-
-    /// Opens a ZIP/JAR archive on the host OS, parses and indexes it.
-    ///
-    /// # Errors
-    /// Returns `ZipException` if the file is not a valid ZIP, or
-    /// `FileNotFoundException` if the path does not exist.
-    pub fn open_host_zip(&mut self, path: &std::path::Path) -> VmResult<i32> {
-        let reader = duke_loader::ZipReader::open(path).map_err(|err| match err {
-            duke_loader::LoadError::Io { .. } => VmError::JavaException {
-                class_name: "java/io/FileNotFoundException".to_string(),
-            },
-            _ => VmError::JavaException {
-                class_name: "java/util/zip/ZipException".to_string(),
-            },
-        })?;
-        let id = self.next_host_file_id;
-        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
-        self.host_files
-            .insert(id, HostFileHandle::ZipArchive(reader));
-        Ok(id)
-    }
-
-    /// Returns the number of entries in an opened ZIP archive.
-    ///
-    /// # Errors
-    /// Returns `IOException` if the handle is invalid or not a ZIP archive.
-    pub fn zip_entry_count(&self, id: i32) -> VmResult<usize> {
-        match self.host_files.get(&id) {
-            Some(HostFileHandle::ZipArchive(reader)) => Ok(reader.entry_count()),
-            _ => Err(VmError::JavaException {
-                class_name: "java/io/IOException".into(),
-            }),
-        }
-    }
-
-    /// Looks up a ZIP entry by name, returning a clone of its metadata.
-    ///
-    /// # Errors
-    /// Returns `IOException` if the handle is invalid or not a ZIP archive.
-    pub fn zip_get_entry_info(
-        &self,
-        id: i32,
-        name: &str,
-    ) -> VmResult<Option<duke_loader::ZipEntryInfo>> {
-        match self.host_files.get(&id) {
-            Some(HostFileHandle::ZipArchive(reader)) => Ok(reader.get_entry(name).cloned()),
-            _ => Err(VmError::JavaException {
-                class_name: "java/io/IOException".into(),
-            }),
-        }
-    }
-
-    /// Reads and decompresses a ZIP entry's bytes.
-    ///
-    /// # Errors
-    /// Returns `ZipException` on decompression failure, `IOException` for invalid handles.
-    pub fn zip_read_entry(&self, id: i32, name: &str) -> VmResult<Vec<u8>> {
-        match self.host_files.get(&id) {
-            Some(HostFileHandle::ZipArchive(reader)) => {
-                reader.read_entry(name).map_err(|_| VmError::JavaException {
-                    class_name: "java/util/zip/ZipException".into(),
-                })
-            }
-            _ => Err(VmError::JavaException {
-                class_name: "java/io/IOException".into(),
-            }),
-        }
-    }
-
-    /// Creates an in-memory byte buffer handle (for reading decompressed data
-    /// as an `InputStream`).
-    pub fn open_host_byte_buffer(&mut self, data: Vec<u8>) -> i32 {
-        let id = self.next_host_file_id;
-        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
-        self.host_files
-            .insert(id, HostFileHandle::ByteBuffer(std::io::Cursor::new(data)));
-        id
-    }
-
-    /// Binds a TCP listener to the given address string (e.g. `"0.0.0.0:8080"`).
-    ///
-    /// # Errors
-    /// Returns `BindException` if the address is already in use, `SocketException` for other errors.
-    pub fn bind_server_socket(&mut self, addr: &str) -> VmResult<i32> {
-        let listener = std::net::TcpListener::bind(addr).map_err(|err| match err.kind() {
-            std::io::ErrorKind::AddrInUse => VmError::JavaException {
-                class_name: "java/net/BindException".into(),
-            },
-            _ => VmError::JavaException {
-                class_name: "java/net/SocketException".into(),
-            },
-        })?;
-        let id = self.next_host_file_id;
-        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
-        self.host_files
-            .insert(id, HostFileHandle::TcpListener(listener));
-        Ok(id)
-    }
-
-    /// Accepts one incoming connection on the given listener id.
-    /// Returns `(reader_id, writer_id)` — two independent OS handles to the same socket.
-    ///
-    /// # Errors
-    /// Returns `IOException` if the id is invalid or the accept fails.
-    ///
-    /// Note: Handle IDs are allocated with `saturating_add`; extremely long-running
-    /// programs opening billions of handles would alias at `i32::MAX`. This is a
-    /// known limitation shared with the file I/O implementation.
-    pub fn accept_connection(&mut self, id: i32) -> VmResult<(i32, i32)> {
-        // Validate that the handle exists and is a TcpListener.
-        if !matches!(
-            self.host_files.get(&id),
-            Some(HostFileHandle::TcpListener(_))
-        ) {
-            return Err(VmError::JavaException {
-                class_name: "java/io/IOException".into(),
-            });
-        }
-        // Temporarily remove the listener to satisfy the borrow checker, then reinsert.
-        let Some(HostFileHandle::TcpListener(listener)) = self.host_files.remove(&id) else {
-            unreachable!()
-        };
-        let result = listener.accept();
-        self.host_files
-            .insert(id, HostFileHandle::TcpListener(listener));
-        let (stream, _addr) = result.map_err(|_| VmError::JavaException {
-            class_name: "java/io/IOException".into(),
-        })?;
-        let writer = stream.try_clone().map_err(|_| VmError::JavaException {
-            class_name: "java/io/IOException".into(),
-        })?;
-        let reader_id = self.next_host_file_id;
-        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
-        let writer_id = self.next_host_file_id;
-        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
-        self.host_files
-            .insert(reader_id, HostFileHandle::SocketReader(stream));
-        self.host_files
-            .insert(writer_id, HostFileHandle::SocketWriter(writer));
-        Ok((reader_id, writer_id))
-    }
-
-    /// Connects a TCP socket to the given address string (e.g. `"127.0.0.1:8080"`).
-    /// Returns `(reader_id, writer_id)` — two independent OS handles to the same socket.
-    ///
-    /// # Errors
-    /// Returns `ConnectException` if connection is refused, `SocketException` for other errors.
-    ///
-    /// Note: Handle IDs are allocated with `saturating_add`; extremely long-running
-    /// programs opening billions of handles would alias at `i32::MAX`. This is a
-    /// known limitation shared with the file I/O implementation.
-    pub fn connect_socket(&mut self, addr: &str) -> VmResult<(i32, i32)> {
-        let stream = std::net::TcpStream::connect(addr).map_err(|err| match err.kind() {
-            std::io::ErrorKind::ConnectionRefused => VmError::JavaException {
-                class_name: "java/net/ConnectException".into(),
-            },
-            _ => VmError::JavaException {
-                class_name: "java/net/SocketException".into(),
-            },
-        })?;
-        let writer = stream.try_clone().map_err(|_| VmError::JavaException {
-            class_name: "java/net/SocketException".into(),
-        })?;
-        let reader_id = self.next_host_file_id;
-        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
-        let writer_id = self.next_host_file_id;
-        self.next_host_file_id = self.next_host_file_id.saturating_add(1);
-        self.host_files
-            .insert(reader_id, HostFileHandle::SocketReader(stream));
-        self.host_files
-            .insert(writer_id, HostFileHandle::SocketWriter(writer));
-        Ok((reader_id, writer_id))
-    }
-
-    /// Returns the local port of a bound server socket.
-    ///
-    /// # Errors
-    /// Returns `IOException` if the id is invalid.
-    pub fn server_socket_local_port(&self, id: i32) -> VmResult<i32> {
-        match self.host_files.get(&id) {
-            Some(HostFileHandle::TcpListener(l)) => l
-                .local_addr()
-                .map(|addr| i32::from(addr.port()))
-                .map_err(|_| VmError::JavaException {
-                    class_name: "java/io/IOException".into(),
-                }),
-            _ => Err(VmError::JavaException {
-                class_name: "java/io/IOException".into(),
-            }),
-        }
     }
 
     /// Promote a young-gen object to old gen. Returns `raw_old_idx | OLD_BIT`.
@@ -2005,7 +1506,10 @@ mod tests {
     #[test]
     fn bind_server_socket_returns_valid_id() {
         let mut heap = Heap::new();
-        let id = heap.bind_server_socket("127.0.0.1:0").expect("bind failed");
+        let id = heap
+            .host
+            .bind_server_socket("127.0.0.1:0")
+            .expect("bind failed");
         assert!(id > 0);
     }
 
@@ -2013,10 +1517,12 @@ mod tests {
     fn bind_server_socket_addr_in_use() {
         let mut heap = Heap::new();
         let id = heap
+            .host
             .bind_server_socket("127.0.0.1:0")
             .expect("first bind failed");
-        let port = heap.server_socket_local_port(id).expect("port failed");
+        let port = heap.host.server_socket_local_port(id).expect("port failed");
         let err = heap
+            .host
             .bind_server_socket(&format!("127.0.0.1:{port}"))
             .unwrap_err();
         assert!(matches!(
@@ -2037,6 +1543,7 @@ mod tests {
         let port = listener.local_addr().unwrap().port();
         drop(listener);
         let err = heap
+            .host
             .connect_socket(&format!("127.0.0.1:{port}"))
             .unwrap_err();
         assert!(matches!(
@@ -2050,24 +1557,37 @@ mod tests {
     #[test]
     fn server_socket_local_port() {
         let mut heap = Heap::new();
-        let id = heap.bind_server_socket("127.0.0.1:0").expect("bind failed");
-        let port = heap.server_socket_local_port(id).expect("port failed");
+        let id = heap
+            .host
+            .bind_server_socket("127.0.0.1:0")
+            .expect("bind failed");
+        let port = heap.host.server_socket_local_port(id).expect("port failed");
         assert!(port > 0);
     }
 
     #[test]
     fn accept_and_read_roundtrip() {
         let mut heap = Heap::new();
-        let server_id = heap.bind_server_socket("127.0.0.1:0").expect("bind failed");
+        let server_id = heap
+            .host
+            .bind_server_socket("127.0.0.1:0")
+            .expect("bind failed");
         let port = heap
+            .host
             .server_socket_local_port(server_id)
             .expect("port failed");
         let handle = std::thread::spawn(move || {
             let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
             std::io::Write::write_all(&mut stream, &[42]).unwrap();
         });
-        let (reader_id, _writer_id) = heap.accept_connection(server_id).expect("accept failed");
-        let byte = heap.read_host_file_byte(reader_id).expect("read failed");
+        let (reader_id, _writer_id) = heap
+            .host
+            .accept_connection(server_id)
+            .expect("accept failed");
+        let byte = heap
+            .host
+            .read_host_file_byte(reader_id)
+            .expect("read failed");
         assert_eq!(byte, 42);
         handle.join().unwrap();
     }
@@ -2084,29 +1604,38 @@ mod tests {
         });
         let mut heap = Heap::new();
         let (_reader_id, writer_id) = heap
+            .host
             .connect_socket(&format!("127.0.0.1:{port}"))
             .expect("connect failed");
-        heap.write_host_file_byte(writer_id, 99)
+        heap.host
+            .write_host_file_byte(writer_id, 99)
             .expect("write failed");
         // Drop the writer so the listener's read_exact completes.
-        heap.close_host_file(writer_id);
+        heap.host.close_host_file(writer_id);
         handle.join().unwrap();
     }
 
     #[test]
     fn close_then_read_returns_io_exception() {
         let mut heap = Heap::new();
-        let server_id = heap.bind_server_socket("127.0.0.1:0").expect("bind failed");
+        let server_id = heap
+            .host
+            .bind_server_socket("127.0.0.1:0")
+            .expect("bind failed");
         let port = heap
+            .host
             .server_socket_local_port(server_id)
             .expect("port failed");
         let handle = std::thread::spawn(move || {
             let _stream = std::net::TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
         });
-        let (reader_id, _writer_id) = heap.accept_connection(server_id).expect("accept failed");
+        let (reader_id, _writer_id) = heap
+            .host
+            .accept_connection(server_id)
+            .expect("accept failed");
         handle.join().unwrap();
-        heap.close_host_file(reader_id);
-        let err = heap.read_host_file_byte(reader_id).unwrap_err();
+        heap.host.close_host_file(reader_id);
+        let err = heap.host.read_host_file_byte(reader_id).unwrap_err();
         assert!(matches!(
             err,
             duke_runtime::VmError::JavaException { ref class_name }

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -2533,7 +2533,7 @@ fn native_file_input_stream_init(
         _ => return Err(VmError::NullPointerException),
     };
     let path = path_from_string_slot(args, 1, heap)?;
-    let file_id = heap.open_host_input_file(&path)?;
+    let file_id = heap.host.open_host_input_file(&path)?;
     let stream_obj = heap.get_mut(this_ref)?;
     let Some(fd_field) = stream_obj.fields.first_mut() else {
         return Err(VmError::InvalidRef { address: this_ref });
@@ -2549,7 +2549,7 @@ fn native_file_input_stream_read(
     _control: &mut NativeControl,
 ) -> VmResult<Option<Slot>> {
     let file_id = file_stream_id_from_this(args, heap)?;
-    Ok(Some(Slot::Int(heap.read_host_file_byte(file_id)?)))
+    Ok(Some(Slot::Int(heap.host.read_host_file_byte(file_id)?)))
 }
 
 fn native_file_input_stream_read_bytes(
@@ -2570,7 +2570,7 @@ fn native_file_input_stream_read_bytes(
 
     let mut count = 0_usize;
     for idx in 0..len {
-        let next = heap.read_host_file_byte(file_id)?;
+        let next = heap.host.read_host_file_byte(file_id)?;
         if next < 0 {
             break;
         }
@@ -2603,7 +2603,7 @@ fn native_file_input_stream_close(
             });
         }
     };
-    heap.close_host_file(file_id);
+    heap.host.close_host_file(file_id);
     let stream_obj = heap.get_mut(this_ref)?;
     let Some(fd_field) = stream_obj.fields.first_mut() else {
         return Err(VmError::InvalidRef { address: this_ref });
@@ -2623,7 +2623,7 @@ fn native_file_output_stream_init(
         _ => return Err(VmError::NullPointerException),
     };
     let path = path_from_string_slot(args, 1, heap)?;
-    let file_id = heap.open_host_output_file(&path)?;
+    let file_id = heap.host.open_host_output_file(&path)?;
     let stream_obj = heap.get_mut(this_ref)?;
     let Some(fd_field) = stream_obj.fields.first_mut() else {
         return Err(VmError::InvalidRef { address: this_ref });
@@ -2648,7 +2648,7 @@ fn native_file_output_stream_write(
             });
         }
     };
-    heap.write_host_file_byte(file_id, value)?;
+    heap.host.write_host_file_byte(file_id, value)?;
     Ok(None)
 }
 
@@ -2671,7 +2671,7 @@ fn native_file_output_stream_write_bytes(
                 got: "other",
             });
         };
-        heap.write_host_file_byte(file_id, value)?;
+        heap.host.write_host_file_byte(file_id, value)?;
     }
     Ok(None)
 }
@@ -2694,7 +2694,7 @@ fn native_file_output_stream_close(
             });
         }
     };
-    heap.close_host_file(file_id);
+    heap.host.close_host_file(file_id);
     let stream_obj = heap.get_mut(this_ref)?;
     let Some(fd_field) = stream_obj.fields.first_mut() else {
         return Err(VmError::InvalidRef { address: this_ref });
@@ -2726,8 +2726,8 @@ fn native_server_socket_init(
         }
     };
     let addr = format!("0.0.0.0:{port}");
-    let server_id = heap.bind_server_socket(&addr)?;
-    let actual_port = heap.server_socket_local_port(server_id)?;
+    let server_id = heap.host.bind_server_socket(&addr)?;
+    let actual_port = heap.host.server_socket_local_port(server_id)?;
     let obj = heap.get_mut(this_ref)?;
     if obj.fields.len() < 2 {
         return Err(VmError::InvalidRef { address: this_ref });
@@ -2756,7 +2756,7 @@ fn native_server_socket_accept(
             });
         }
     };
-    let (reader_id, writer_id) = heap.accept_connection(server_fd)?;
+    let (reader_id, writer_id) = heap.host.accept_connection(server_fd)?;
     // Allocate a new Socket object with fdRead=reader_id, fdWrite=writer_id
     let socket_ref = heap.allocate("java/net/Socket".to_string(), 2);
     heap.get_mut(socket_ref)?.fields[0] = Slot::Int(reader_id);
@@ -2803,7 +2803,7 @@ fn native_server_socket_close(
             });
         }
     };
-    heap.close_host_file(fd);
+    heap.host.close_host_file(fd);
     let obj = heap.get_mut(this_ref)?;
     obj.fields[0] = Slot::Int(0);
     obj.fields[1] = Slot::Int(0); // also zero cached port so getLocalPort() returns 0 after close
@@ -2839,7 +2839,7 @@ fn native_socket_init(
         }
     };
     let addr = format!("{host}:{port}");
-    let (reader_id, writer_id) = heap.connect_socket(&addr)?;
+    let (reader_id, writer_id) = heap.host.connect_socket(&addr)?;
     let obj = heap.get_mut(this_ref)?;
     if obj.fields.len() < 2 {
         return Err(VmError::InvalidRef { address: this_ref });
@@ -2924,8 +2924,8 @@ fn native_socket_close(
             });
         }
     };
-    heap.close_host_file(fd_read);
-    heap.close_host_file(fd_write);
+    heap.host.close_host_file(fd_read);
+    heap.host.close_host_file(fd_write);
     let obj = heap.get_mut(this_ref)?;
     obj.fields[0] = Slot::Int(0);
     obj.fields[1] = Slot::Int(0);
@@ -2955,7 +2955,7 @@ fn native_zip_file_init(
         .as_deref()
         .ok_or(VmError::NullPointerException)?
         .to_string();
-    let fd = heap.open_host_zip(std::path::Path::new(&path_str))?;
+    let fd = heap.host.open_host_zip(std::path::Path::new(&path_str))?;
     let obj = heap.get_mut(this_ref)?;
     obj.fields[0] = Slot::Int(fd);
     Ok(None)
@@ -2991,7 +2991,7 @@ fn native_zip_file_get_entry(
         .as_deref()
         .ok_or(VmError::NullPointerException)?
         .to_string();
-    let info = heap.zip_get_entry_info(fd, &entry_name)?;
+    let info = heap.host.zip_get_entry_info(fd, &entry_name)?;
     let Some(info) = info else {
         return Ok(Some(Slot::Reference(None)));
     };
@@ -3043,8 +3043,8 @@ fn native_zip_file_get_input_stream(
         .ok_or(VmError::NullPointerException)?
         .to_string();
     // Decompress the entry and wrap in a ByteBuffer.
-    let data = heap.zip_read_entry(fd, &entry_name)?;
-    let buf_fd = heap.open_host_byte_buffer(data);
+    let data = heap.host.zip_read_entry(fd, &entry_name)?;
+    let buf_fd = heap.host.open_host_byte_buffer(data);
     let is_ref = heap.allocate("duke/zip/ByteBufferInputStream".to_string(), 1);
     let is_obj = heap.get_mut(is_ref)?;
     is_obj.fields[0] = Slot::Int(buf_fd);
@@ -3066,7 +3066,7 @@ fn native_zip_file_close(
         Some(Slot::Int(id)) => *id,
         _ => return Ok(None),
     };
-    heap.close_host_file(fd);
+    heap.host.close_host_file(fd);
     let obj = heap.get_mut(this_ref)?;
     obj.fields[0] = Slot::Int(0);
     Ok(None)
@@ -3092,7 +3092,7 @@ fn native_zip_file_size(
             });
         }
     };
-    let count = heap.zip_entry_count(fd)?;
+    let count = heap.host.zip_entry_count(fd)?;
     Ok(Some(Slot::Int(count as i32)))
 }
 
@@ -12919,7 +12919,7 @@ fn optional_file_path_from_slot(
 
 fn allocate_process_impl(
     heap: &mut duke_gc::Heap,
-    ids: duke_gc::SpawnedProcessIds,
+    ids: duke_gc::host::SpawnedProcessIds,
 ) -> VmResult<Option<Slot>> {
     let process_ref = heap.allocate("java/lang/ProcessImpl".to_string(), 4);
     let process_obj = heap.get_mut(process_ref)?;
@@ -12935,7 +12935,7 @@ fn spawn_process_impl(
     command: &[String],
     cwd: Option<&std::path::Path>,
 ) -> VmResult<Option<Slot>> {
-    let ids = heap.spawn_host_process(command, cwd)?;
+    let ids = heap.host.spawn_host_process(command, cwd)?;
     allocate_process_impl(heap, ids)
 }
 
@@ -13111,7 +13111,7 @@ fn native_process_wait_for(
     _control: &mut NativeControl,
 ) -> VmResult<Option<Slot>> {
     let process_id = process_field_id_from_this(args, heap, PROCESS_ID_FIELD)?;
-    Ok(Some(Slot::Int(heap.wait_host_process(process_id)?)))
+    Ok(Some(Slot::Int(heap.host.wait_host_process(process_id)?)))
 }
 
 fn native_process_exit_value(
@@ -13121,7 +13121,7 @@ fn native_process_exit_value(
     _control: &mut NativeControl,
 ) -> VmResult<Option<Slot>> {
     let process_id = process_field_id_from_this(args, heap, PROCESS_ID_FIELD)?;
-    let Some(exit_code) = heap.try_host_process_exit_value(process_id)? else {
+    let Some(exit_code) = heap.host.try_host_process_exit_value(process_id)? else {
         return Err(VmError::JavaException {
             class_name: "java/lang/IllegalThreadStateException".into(),
         });
@@ -13136,7 +13136,7 @@ fn native_process_destroy(
     _control: &mut NativeControl,
 ) -> VmResult<Option<Slot>> {
     let process_id = process_field_id_from_this(args, heap, PROCESS_ID_FIELD)?;
-    heap.destroy_host_process(process_id)?;
+    heap.host.destroy_host_process(process_id)?;
     Ok(None)
 }
 


### PR DESCRIPTION
🕸️ **Tangle**: The `Heap` struct in `crates/duke-gc/src/lib.rs` had evolved into a "God Struct" that handled both JVM memory allocation/garbage collection *and* OS-level I/O abstractions (files, processes, sockets). This violated the Single Responsibility Principle and made the codebase tightly coupled.
    
📐 **Blueprint**: Extracted the I/O management structures (`HostFileHandle`, `HostProcessHandle`, `SpawnedProcessIds`) and all related methods out of `Heap` and into a new `HostManager` struct within a new `crates/duke-gc/src/host.rs` module. The `Heap` struct now delegates these responsibilities through a `pub host: HostManager` field.

🧱 **Stability**: Reduced coupling between garbage collection and host OS interaction. The architecture now cleanly delineates memory management from file and socket tracking.

🔬 **Verification**:
- `cargo test` passes for the entire workspace.
- `cargo clippy --all-targets --all-features -- -D warnings` passes.
- No `patch_*.py` files were left in the tree.
- `host_files` map correctly encapsulated via `pub(crate)`.

---
*PR created automatically by Jules for task [2129313933407485822](https://jules.google.com/task/2129313933407485822) started by @madmax983*