### PR TITLE
👺 Havoc: Fix out-of-bounds byte slice panic in descriptor parsing

### DIFF
--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -8264,7 +8264,10 @@ fn resolve_methodref(cp: &[Option<CpEntry>], idx: usize) -> VmResult<(String, St
 
 /// Count argument slots in a JVM method descriptor like `(ILjava/lang/String;[I)V`.
 fn parse_arg_count(descriptor: &str) -> usize {
-    let params = descriptor.find(')').map_or("", |i| &descriptor[1..i]);
+    let params = descriptor
+        .strip_prefix('(')
+        .and_then(|s| s.split_once(')'))
+        .map_or("", |(p, _)| p);
     let mut count = 0;
     let mut chars = params.chars().peekable();
     while let Some(c) = chars.next() {
@@ -8403,7 +8406,10 @@ fn resolve_cp_string(cp: &[Option<CpEntry>], cp_idx: usize) -> VmResult<String> 
 /// Parse argument type descriptors from a JVM method descriptor like `(IZLjava/lang/String;)V`.
 /// Returns a Vec of single-char type codes: 'I', 'Z', 'L' (for object refs), '[' (for arrays), etc.
 fn parse_arg_types(descriptor: &str) -> Vec<char> {
-    let params = descriptor.find(')').map_or("", |i| &descriptor[1..i]);
+    let params = descriptor
+        .strip_prefix('(')
+        .and_then(|s| s.split_once(')'))
+        .map_or("", |(p, _)| p);
     let mut types = Vec::new();
     let mut chars = params.chars().peekable();
     while let Some(c) = chars.next() {


### PR DESCRIPTION
🧨 **The Trigger:**
Passing a malformed method descriptor like `"𑤉)"` or a string missing the closing parenthesis to `parse_arg_count` or `parse_arg_types`.

📉 **The Stack Trace:**
```
thread 'fuzz_tests::fuzz_parse_arg_count' panicked at crates/duke-interpreter/src/lib.rs:8267:65:
byte index 1 is not a char boundary; it is inside '𑤉' (bytes 0..4) of `𑤉)`
```

🧪 **Reproduction:**
Run a fuzzing target that feeds arbitrary random strings to `duke_interpreter::parse_arg_count` or `duke_interpreter::parse_arg_types`. The methods expected valid `(args)ret` descriptors and unsafely sliced `&descriptor[1..i]`.

😈 **Comment:**
"You assumed every descriptor starts with a 1-byte ASCII character and always contains a closing parenthesis. You were wrong."

---
*PR created automatically by Jules for task [8221731564895635215](https://jules.google.com/task/8221731564895635215) started by @madmax983*