### PR TITLE
👺 Havoc: [Panic] Thread early-return panics Arc unwrap

### DIFF
--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -9553,11 +9553,13 @@ fn join_java_thread(
 fn wait_for_all_java_threads(
     runtime: &std::sync::Arc<std::sync::Mutex<CompletionRuntime>>,
 ) -> VmResult<()> {
+    let mut first_error = None;
+
     loop {
         let handles = {
             let mut runtime = runtime.lock().unwrap();
             if runtime.handles.is_empty() {
-                return Ok(());
+                break;
             }
             runtime
                 .handles
@@ -9568,10 +9570,21 @@ fn wait_for_all_java_threads(
 
         for handle in handles {
             match handle.join() {
-                Ok(result) => result?,
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    if first_error.is_none() {
+                        first_error = Some(e);
+                    }
+                }
                 Err(payload) => std::panic::resume_unwind(payload),
             }
         }
+    }
+
+    if let Some(e) = first_error {
+        Err(e)
+    } else {
+        Ok(())
     }
 }
 
@@ -25971,6 +25984,49 @@ mod tests {
         );
         let output = String::from_utf8(out).unwrap();
         assert!(output.contains("Hello, World!"), "output was: {output}");
+    }
+
+    #[test]
+    fn havoc_wait_for_threads_panic() {
+        let ctx = load_class_context("ThreadingTest.class");
+        let entry_class = ctx.class_name.clone();
+        let mut registry = ClassRegistry::new();
+        registry.register(ctx);
+        let mut heap = duke_gc::Heap::new();
+        bootstrap_stdlib(&mut registry, &mut heap);
+
+        fn mock_sleep(
+            _args: &[Slot],
+            _heap: &mut duke_gc::Heap,
+            _stdout: &mut dyn std::io::Write,
+            _control: &mut NativeControl,
+        ) -> VmResult<Option<Slot>> {
+            Err(VmError::Unimplemented {
+                mnemonic: "mock error",
+            })
+        }
+
+        // Mock java.lang.Thread.sleep
+        registry.natives_mut().register("java/lang/Thread", "sleep", "(J)V", mock_sleep);
+
+        let loader = fixtures_loader();
+        let mut out: Vec<u8> = Vec::new();
+
+        let result = execute_class_to_completion(
+            &mut registry,
+            loader,
+            &mut heap,
+            &mut out,
+            &entry_class,
+            "fireAndForgetStillFinishes",
+            "()I",
+            &[],
+        );
+
+        match result {
+            Err(VmError::Unimplemented { mnemonic }) if mnemonic == "mock error" => {}
+            other => panic!("Expected mock error, got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
🧨 **The Trigger:**
A Java thread calling a native method (e.g., `Thread.sleep`) throws an unexpected `VmError`. The interpreter's wait loop `wait_for_all_java_threads` encountered this `Err` result and immediately propagated it using the `?` operator.

📉 **The Stack Trace:**
```text
thread 'tests::havoc_wait_for_threads_panic' panicked at crates/duke-interpreter/src/lib.rs:9807:9:
completion runtime released shared VM state
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

🧪 **Reproduction:**
Run the new internal integration test:
```bash
cargo test havoc_wait_for_threads_panic -p duke-interpreter
```
This test intentionally registers a chaotic `mock_sleep` native callback that returns an `Err(VmError)`. It then executes a Java class (`ThreadingTest.fireAndForgetStillFinishes`) which spawns three background threads that eventually call `sleep`. The first thread to reach the mocked method fails, and the main thread attempts to unwind the JVM state while the other two threads are still executing.

😈 **Comment:**
You assumed `?` was a clean way to handle errors in a batch processing loop. You forgot that `drain()` already took ownership of the background thread handles. By returning early, you orphaned the remaining threads, leaving them holding strong references to the shared `Arc<CompletionVm>`. When the VM tried to shut down via `Arc::try_unwrap(shared)`, it exploded because the reference count was > 1. 

The fix accumulates the first error encountered, but guarantees all threads from the current batch are fully `.join()`ed before returning the error.

---
*PR created automatically by Jules for task [15313189336474465363](https://jules.google.com/task/15313189336474465363) started by @madmax983*