### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -1,0 +1,3 @@
+## 2026-03-20 - Cross-platform File IO Testing
+**Learning:** Testing file IO errors (like write failures due to read-only permissions) using `std::os::unix::fs::PermissionsExt` breaks cross-platform compatibility on Windows.
+**Action:** Always use the standard library's `Permissions::set_readonly(true)` when simulating permission-based IO errors in tests to ensure they compile and run correctly on all targets.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ name = "duke-gc"
 version = "0.1.0"
 dependencies = [
  "duke-runtime",
+ "tempfile",
 ]
 
 [[package]]
@@ -803,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.1",

--- a/crates/duke-gc/Cargo.toml
+++ b/crates/duke-gc/Cargo.toml
@@ -6,3 +6,6 @@ description = "Duke JVM - Heap allocator and garbage collector"
 
 [dependencies]
 duke-runtime = { path = "../duke-runtime" }
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/crates/duke-gc/tests/io_errors.rs
+++ b/crates/duke-gc/tests/io_errors.rs
@@ -1,0 +1,101 @@
+use duke_gc::Heap;
+
+
+
+#[test]
+fn test_host_file_operations_invalid_handles() {
+    let mut heap = Heap::new();
+
+    // Test invalid read
+    let res = heap.read_host_file_byte(999);
+    assert!(res.is_err());
+
+    // Test invalid write
+    let res = heap.write_host_file_byte(999, 0);
+    assert!(res.is_err());
+
+    // Test invalid close (should silently ignore)
+    heap.close_host_file(999);
+}
+
+#[test]
+fn test_io_errors_via_permissions() {
+    let mut heap = Heap::new();
+
+    // Test write_host_file_byte IO error
+    let temp_dir = tempfile::tempdir().unwrap();
+    let file_path = temp_dir.path().join("read_only_file.txt");
+
+    std::fs::File::create(&file_path).unwrap();
+    let mut perms = std::fs::metadata(&file_path).unwrap().permissions();
+    perms.set_readonly(true);
+    std::fs::set_permissions(&file_path, perms).unwrap();
+
+    let out_res = heap.open_host_output_file(&file_path);
+    assert!(out_res.is_err());
+}
+
+#[test]
+fn test_read_host_file_byte_io_error_mock() {
+    let mut heap = Heap::new();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let file_path = temp_dir.path().join("dir");
+    std::fs::create_dir(&file_path).unwrap();
+
+    // Some OS might allow opening dir for read, some might error.
+    let in_res = heap.open_host_input_file(&file_path);
+    if let Ok(in_id) = in_res {
+        // trying to read from a directory usually fails with Is a directory
+        let res = heap.read_host_file_byte(in_id);
+        assert!(res.is_err());
+    }
+}
+
+#[test]
+fn test_open_host_input_file_not_found() {
+    let mut heap = Heap::new();
+    let res = heap.open_host_input_file(std::path::Path::new(
+        "/non/existent/file/path/that/should/not/exist",
+    ));
+    assert!(res.is_err());
+    match res.unwrap_err() {
+        duke_runtime::error::VmError::JavaException { class_name } => {
+            assert_eq!(class_name, "java/io/FileNotFoundException");
+        }
+        _ => panic!("Expected JavaException"),
+    }
+}
+
+#[test]
+fn test_write_host_file_wrong_handle() {
+    let mut heap = Heap::new();
+    let temp_in = tempfile::NamedTempFile::new().unwrap();
+    let in_id = heap.open_host_input_file(temp_in.path()).unwrap();
+
+    // This will hit the `let HostFileHandle::Writer(file) = handle else { return Err(...) }` branch
+    let res = heap.write_host_file_byte(in_id, b'a' as i32);
+    assert!(res.is_err());
+    match res.unwrap_err() {
+        duke_runtime::error::VmError::JavaException { class_name } => {
+            assert_eq!(class_name, "java/io/IOException");
+        }
+        _ => panic!("Expected JavaException"),
+    }
+}
+
+#[test]
+fn test_read_host_file_wrong_handle() {
+    let mut heap = Heap::new();
+    let temp_out = tempfile::NamedTempFile::new().unwrap();
+    let out_id = heap.open_host_output_file(temp_out.path()).unwrap();
+
+    // This will hit the `let HostFileHandle::Reader(file) = handle else { return Err(...) }` branch
+    let res = heap.read_host_file_byte(out_id);
+    assert!(res.is_err());
+    match res.unwrap_err() {
+        duke_runtime::error::VmError::JavaException { class_name } => {
+            assert_eq!(class_name, "java/io/IOException");
+        }
+        _ => panic!("Expected JavaException"),
+    }
+}

--- a/test_coverage_plan.md
+++ b/test_coverage_plan.md
@@ -1,0 +1,8 @@
+1. **Target**: `crates/duke-gc/src/lib.rs` - file handle operations.
+   - Added multiple tests to cover file I/O error edge cases in `crates/duke-gc/tests/io_errors.rs` to simulate `read_host_file_byte`, `write_host_file_byte`, `open_host_input_file`, and `open_host_output_file` branch failures.
+2. **Refactor**:
+   - Refactored tests to properly mock file access failures, maintaining cross-platform compatibility by avoiding `std::os::unix::fs::PermissionsExt`.
+3. **Review & Pre-commit Steps**:
+   - Run `cargo fmt`, `cargo test`, `cargo clippy`, and `cargo doc` via the pre commit steps.
+4. **Submit PR**:
+   - Submit a PR with title "🛡️ Sentry: Add coverage for duke-gc host file IO edge cases".


### PR DESCRIPTION
🎯 Target: `crates/duke-gc/src/lib.rs`
💣 Risk: Uncovered branches for `VmError::JavaException` during file operations (read, write, open) could mask unexpected IO panics.
🧪 Strategy: Added cross-platform unit tests in `crates/duke-gc/tests/io_errors.rs` testing invalid file handles, file not found errors, and read/write permission violations to hit error mappings correctly.
🔬 Verification: `cargo test -p duke-gc --test io_errors`

---
*PR created automatically by Jules for task [12915189385762393870](https://jules.google.com/task/12915189385762393870) started by @madmax983*