### PR TITLE
👺 Havoc: Unbounded Allocations and Integer Overflows

### DIFF
--- a/crates/duke-loader/src/jimage.rs
+++ b/crates/duke-loader/src/jimage.rs
@@ -124,9 +124,9 @@ impl JImageReader {
         // offsets:  [u32; tl]  at HEADER_SIZE + tl*4
         // locations: [u8; ls]  at HEADER_SIZE + tl*8
         // strings:   [u8; ss]  at HEADER_SIZE + tl*8 + ls
-        let locations_offset = HEADER_SIZE + tl * 8;
-        let strings_offset = locations_offset + ls;
-        let data_offset = strings_offset + ss;
+        let locations_offset = HEADER_SIZE.checked_add(tl.checked_mul(8).ok_or_else(|| LoadError::JImageFormat { msg: "table_length overflow".into() })?).ok_or_else(|| LoadError::JImageFormat { msg: "locations_offset overflow".into() })?;
+        let strings_offset = locations_offset.checked_add(ls).ok_or_else(|| LoadError::JImageFormat { msg: "strings_offset overflow".into() })?;
+        let data_offset = strings_offset.checked_add(ss).ok_or_else(|| LoadError::JImageFormat { msg: "data_offset overflow".into() })?;
 
         if data.len() < data_offset {
             return Err(LoadError::JImageFormat {

--- a/crates/duke-runtime/src/frame.rs
+++ b/crates/duke-runtime/src/frame.rs
@@ -52,7 +52,10 @@ impl Frame {
     /// assert_eq!(frame.load_local(1).unwrap(), Slot::Int(0)); // zero-initialized
     /// ```
     pub fn new(max_stack: usize, max_locals: usize, args: Vec<Slot>) -> VmResult<Self> {
-        if args.len() > max_locals {
+        let safe_max_stack = max_stack.min(32 * 1024 * 1024);
+        let safe_max_locals = max_locals.min(32 * 1024 * 1024);
+
+        if args.len() > safe_max_locals {
             return Err(VmError::LocalOutOfBounds {
                 index: args.len(),
                 max_locals,
@@ -61,11 +64,15 @@ impl Frame {
         // ⚡ Bolt: Re-use the existing `args` vector for `locals` to avoid an allocation
         // and explicit copy loop. `resize` extends it with zeroes if needed.
         let mut locals = args;
-        locals.resize(max_locals, Slot::Int(0));
+        locals.try_reserve(safe_max_locals.saturating_sub(locals.len())).map_err(|_| VmError::LocalOutOfBounds { index: safe_max_locals, max_locals })?;
+        locals.resize(safe_max_locals, Slot::Int(0));
+
+        let mut stack = Vec::new();
+        stack.try_reserve(safe_max_stack).map_err(|_| VmError::StackOverflow)?;
+
         Ok(Self {
             locals,
-            // ⚡ Bolt: Pre-allocate `stack` capacity to avoid reallocations during execution.
-            stack: Vec::with_capacity(max_stack),
+            stack,
             max_stack,
         })
     }


### PR DESCRIPTION
🧨 **The Trigger:** 
1. The `duke-runtime::frame::Frame::new` method trusted the `max_stack` and `max_locals` bytecode attributes implicitly. A malformed classfile with large values triggers a capacity overflow panic when allocating the `locals` and `stack` `Vec`s.
2. The `duke-loader::jimage::JImageReader::open` method calculated the `locations_offset`, `strings_offset`, and `data_offset` from the `jimage` header without overflow checks. Large untrusted sizes cause arithmetic panics.

📉 **The Stack Trace:**
```text
thread '<unnamed>' (9484) panicked at library/alloc/src/raw_vec/mod.rs:28:5:
capacity overflow
==9484== ERROR: libFuzzer: deadly signal
```

🧪 **Reproduction:**
Run `cargo fuzz run runtime_frame_new` and `cargo fuzz run jimage_open` using the provided libfuzzer targets.

😈 **Comment:**
You assumed the classfile bounds and jimage header sizes would never be larger than RAM, and that an arithmetic product would fit in `usize`. You were wrong.

---
*PR created automatically by Jules for task [16678234100633444727](https://jules.google.com/task/16678234100633444727) started by @madmax983*