### PR TITLE
🌟 Nova: Cyclomatic Complexity Static Analysis

### DIFF
--- a/crates/duke-bytecode/src/cfg.rs
+++ b/crates/duke-bytecode/src/cfg.rs
@@ -251,3 +251,124 @@ mod tests {
         assert!(cfg.contains("node0 -->|false| node5"));
     }
 }
+
+/// Computes the `McCabe` Cyclomatic Complexity of a sequence of JVM instructions.
+///
+/// Cyclomatic complexity (`v(G)`) measures the number of linearly independent paths
+/// through a program's source code. For JVM bytecode, this is equivalent to:
+/// `v(G) = E - N + 2`, where `E` is the number of edges and `N` is the number of nodes.
+///
+/// A simplified, common way to calculate this iteratively is:
+/// `v(G) = 1 + number_of_decision_points`.
+///
+/// Each conditional branch (`ifeq`, `if_icmpeq`, etc.) adds 1.
+/// Each `tableswitch` or `lookupswitch` branch (excluding the default) adds 1.
+/// `goto` statements do not add to complexity, as they don't branch.
+///
+/// # Examples
+///
+/// ```
+/// use duke_bytecode::{Instruction, cfg::cyclomatic_complexity};
+///
+/// let instructions = vec![
+///     (0, Instruction::Iconst0),
+///     (1, Instruction::Ifeq(5)), // +1 decision
+///     (4, Instruction::Iconst1),
+///     (5, Instruction::Ireturn),
+/// ];
+///
+/// assert_eq!(cyclomatic_complexity(&instructions), 2);
+/// ```
+#[must_use]
+pub fn cyclomatic_complexity(instructions: &[(usize, Instruction)]) -> usize {
+    let mut complexity = 1;
+
+    for (_, instr) in instructions {
+        match instr {
+            // Conditional branches
+            Instruction::Ifeq(_)
+            | Instruction::Ifne(_)
+            | Instruction::Iflt(_)
+            | Instruction::Ifge(_)
+            | Instruction::Ifgt(_)
+            | Instruction::Ifle(_)
+            | Instruction::IfIcmpeq(_)
+            | Instruction::IfIcmpne(_)
+            | Instruction::IfIcmplt(_)
+            | Instruction::IfIcmpge(_)
+            | Instruction::IfIcmpgt(_)
+            | Instruction::IfIcmple(_)
+            | Instruction::IfAcmpeq(_)
+            | Instruction::IfAcmpne(_)
+            | Instruction::Ifnull(_)
+            | Instruction::Ifnonnull(_)
+            | Instruction::Jsr(_)
+            | Instruction::JsrW(_) => {
+                complexity += 1;
+            }
+            // Switch statements
+            Instruction::Tableswitch { offsets, .. } => {
+                // Number of possible paths = offsets.len() + 1 (for default).
+                // Subtract 1 because we start at 1 complexity inherently.
+                complexity += offsets.len();
+            }
+            Instruction::Lookupswitch { pairs, .. } => {
+                // Number of possible paths = pairs.len() + 1 (for default).
+                complexity += pairs.len();
+            }
+            _ => {}
+        }
+    }
+
+    complexity
+}
+
+#[cfg(test)]
+mod complexity_tests {
+    use super::*;
+    use crate::Instruction;
+
+    #[test]
+    fn test_cyclomatic_complexity_linear() {
+        let instructions = vec![(0, Instruction::Iconst0), (1, Instruction::Ireturn)];
+        assert_eq!(cyclomatic_complexity(&instructions), 1);
+    }
+
+    #[test]
+    fn test_cyclomatic_complexity_branches() {
+        let instructions = vec![
+            (0, Instruction::Ifeq(5)),
+            (3, Instruction::Iconst1),
+            (4, Instruction::Ireturn),
+            (5, Instruction::Iconst2),
+            (6, Instruction::Ireturn),
+        ];
+        assert_eq!(cyclomatic_complexity(&instructions), 2);
+    }
+
+    #[test]
+    fn test_cyclomatic_complexity_tableswitch() {
+        let instructions = vec![(
+            0,
+            Instruction::Tableswitch {
+                default: 10,
+                low: 1,
+                high: 2,
+                offsets: vec![4, 6],
+            },
+        )];
+        assert_eq!(cyclomatic_complexity(&instructions), 3); // 1 + 2 offsets
+    }
+
+    #[test]
+    fn test_cyclomatic_complexity_lookupswitch() {
+        let instructions = vec![(
+            0,
+            Instruction::Lookupswitch {
+                default: 10,
+                pairs: vec![(5, 4), (10, 6)],
+            },
+        )];
+        assert_eq!(cyclomatic_complexity(&instructions), 3); // 1 + 2 pairs
+    }
+}

--- a/crates/duke-bytecode/src/lib.rs
+++ b/crates/duke-bytecode/src/lib.rs
@@ -15,7 +15,7 @@ pub mod instruction;
 pub mod opcodes;
 pub mod verifier;
 
-pub use cfg::generate_mermaid_cfg;
+pub use cfg::{cyclomatic_complexity, generate_mermaid_cfg};
 pub use decoder::decode;
 pub use error::{DecodeError, DecodeResult, Error, Result, VerifyError, VerifyResult};
 pub use instruction::Instruction;

--- a/duke/src/analyze.rs
+++ b/duke/src/analyze.rs
@@ -176,7 +176,8 @@ mod tests {
 
         // Add the extra constants
         let mut cf = cf;
-        cf.constant_pool.push(Some(CpEntry::Utf8("invalidMethod".to_string())));
+        cf.constant_pool
+            .push(Some(CpEntry::Utf8("invalidMethod".to_string())));
 
         let report = generate_analysis_report(&cf);
         assert!(report.contains("Static Analysis Report: MyClass"));

--- a/duke/src/analyze.rs
+++ b/duke/src/analyze.rs
@@ -1,0 +1,170 @@
+use duke_bytecode::{cyclomatic_complexity, decode};
+use duke_classfile::{
+    ClassFile,
+    types::{AttributeData, CpEntry, CpIndex},
+};
+use std::fmt::Write;
+
+fn cp_str(cf: &ClassFile, idx: CpIndex) -> Option<&str> {
+    cf.constant_pool
+        .get(idx.0 as usize)
+        .and_then(|slot| slot.as_ref())
+        .and_then(|entry| {
+            if let CpEntry::Utf8(s) = entry {
+                Some(s.as_str())
+            } else {
+                None
+            }
+        })
+}
+
+fn resolve_class_name(cf: &ClassFile, idx: CpIndex) -> &str {
+    if idx.0 == 0 {
+        return "<none>";
+    }
+    let class_entry = cf
+        .constant_pool
+        .get(idx.0 as usize)
+        .and_then(|s| s.as_ref());
+    if let Some(CpEntry::Class { name_index }) = class_entry {
+        cp_str(cf, *name_index).unwrap_or("<invalid utf8>")
+    } else {
+        "<not a class ref>"
+    }
+}
+
+/// Generates a static analysis report for the given class file.
+/// Iterates over all methods, calculating code size and cyclomatic complexity.
+#[must_use]
+pub fn generate_analysis_report(cf: &ClassFile) -> String {
+    let mut out = String::new();
+    let class_name = resolve_class_name(cf, cf.this_class);
+
+    let _ = writeln!(&mut out, "=== Static Analysis Report: {class_name} ===");
+    let _ = writeln!(
+        &mut out,
+        "{:<35} | {:<10} | {:<10}",
+        "Method", "Complexity", "Code Size"
+    );
+    let _ = writeln!(&mut out, "{}", "-".repeat(61));
+
+    for method in &cf.methods {
+        let name_str = cp_str(cf, method.name_index).unwrap_or("<invalid>");
+        let desc_str = cp_str(cf, method.descriptor_index).unwrap_or("<invalid>");
+        let full_name = format!("{name_str}{desc_str}");
+
+        let mut found_code = false;
+        for attr in &method.attributes {
+            if let AttributeData::Code(code) = &attr.data {
+                found_code = true;
+                let code_size = code.code.len();
+                match decode(&code.code) {
+                    Ok(instructions) => {
+                        let complexity = cyclomatic_complexity(&instructions);
+                        let _ = writeln!(
+                            &mut out,
+                            "{full_name:<35} | {complexity:<10} | {code_size:<10}"
+                        );
+                    }
+                    Err(_) => {
+                        let _ = writeln!(
+                            &mut out,
+                            "{full_name:<35} | {:<10} | {code_size:<10}",
+                            "Error"
+                        );
+                    }
+                }
+            }
+        }
+
+        if !found_code {
+            let _ = writeln!(&mut out, "{full_name:<35} | {:<10} | {:<10}", "N/A", "0");
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use duke_classfile::access_flags::{ClassAccessFlags, MethodAccessFlags};
+    use duke_classfile::types::{AttributeInfo, CodeAttribute, MethodInfo};
+
+    #[test]
+    fn test_generate_analysis_report_empty() {
+        let cf = ClassFile {
+            major_version: 61,
+            minor_version: 0,
+            constant_pool: vec![],
+            access_flags: ClassAccessFlags::PUBLIC,
+            this_class: CpIndex(0),
+            super_class: CpIndex(0),
+            interfaces: vec![],
+            fields: vec![],
+            methods: vec![],
+            attributes: vec![],
+        };
+
+        let report = generate_analysis_report(&cf);
+        assert!(report.contains("Static Analysis Report: <none>"));
+        assert!(report.contains("Method"));
+        assert!(report.contains("Complexity"));
+        assert!(report.contains("Code Size"));
+    }
+
+    #[test]
+    fn test_generate_analysis_report_with_methods() {
+        let cf = ClassFile {
+            major_version: 61,
+            minor_version: 0,
+            constant_pool: vec![
+                None,
+                Some(CpEntry::Class {
+                    name_index: CpIndex(2),
+                }),
+                Some(CpEntry::Utf8("MyClass".to_string())),
+                Some(CpEntry::Utf8("myMethod".to_string())),
+                Some(CpEntry::Utf8("()V".to_string())),
+                Some(CpEntry::Utf8("abstractMethod".to_string())),
+            ],
+            access_flags: ClassAccessFlags::PUBLIC,
+            this_class: CpIndex(1),
+            super_class: CpIndex(0),
+            interfaces: vec![],
+            fields: vec![],
+            methods: vec![
+                MethodInfo {
+                    access_flags: MethodAccessFlags::PUBLIC,
+                    name_index: CpIndex(3),
+                    descriptor_index: CpIndex(4),
+                    attributes: vec![AttributeInfo {
+                        name_index: CpIndex(0),
+                        data: AttributeData::Code(CodeAttribute {
+                            max_stack: 1,
+                            max_locals: 1,
+                            code: vec![0xb1], // return
+                            exception_table: vec![],
+                            attributes: vec![],
+                        }),
+                    }],
+                },
+                MethodInfo {
+                    access_flags: MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+                    name_index: CpIndex(5),
+                    descriptor_index: CpIndex(4),
+                    attributes: vec![],
+                },
+            ],
+            attributes: vec![],
+        };
+
+        let report = generate_analysis_report(&cf);
+        assert!(report.contains("Static Analysis Report: MyClass"));
+        assert!(report.contains("myMethod()V"));
+        assert!(report.contains("abstractMethod()V"));
+        assert!(report.contains("N/A")); // for abstract method
+        assert!(report.contains('1')); // code size for return
+        assert!(report.contains('1')); // complexity for return
+    }
+}

--- a/duke/src/analyze.rs
+++ b/duke/src/analyze.rs
@@ -155,16 +155,81 @@ mod tests {
                     descriptor_index: CpIndex(4),
                     attributes: vec![],
                 },
+                MethodInfo {
+                    access_flags: MethodAccessFlags::PUBLIC,
+                    name_index: CpIndex(6),
+                    descriptor_index: CpIndex(4),
+                    attributes: vec![AttributeInfo {
+                        name_index: CpIndex(0),
+                        data: AttributeData::Code(CodeAttribute {
+                            max_stack: 1,
+                            max_locals: 1,
+                            code: vec![0xFE], // Invalid opcode IMPDEP1 to trigger Err path
+                            exception_table: vec![],
+                            attributes: vec![],
+                        }),
+                    }],
+                },
             ],
             attributes: vec![],
         };
+
+        // Add the extra constants
+        let mut cf = cf;
+        cf.constant_pool.push(Some(CpEntry::Utf8("invalidMethod".to_string())));
 
         let report = generate_analysis_report(&cf);
         assert!(report.contains("Static Analysis Report: MyClass"));
         assert!(report.contains("myMethod()V"));
         assert!(report.contains("abstractMethod()V"));
+        assert!(report.contains("invalidMethod()V"));
         assert!(report.contains("N/A")); // for abstract method
+        assert!(report.contains("Error")); // for decoding error
         assert!(report.contains('1')); // code size for return
         assert!(report.contains('1')); // complexity for return
+    }
+
+    #[test]
+    fn test_resolve_class_name_invalid_index() {
+        let cf = ClassFile {
+            major_version: 61,
+            minor_version: 0,
+            constant_pool: vec![None], // Missing class entry
+            access_flags: ClassAccessFlags::PUBLIC,
+            this_class: CpIndex(1), // Points to out-of-bounds or non-class
+            super_class: CpIndex(0),
+            interfaces: vec![],
+            fields: vec![],
+            methods: vec![],
+            attributes: vec![],
+        };
+
+        let report = generate_analysis_report(&cf);
+        assert!(report.contains("Static Analysis Report: <not a class ref>"));
+    }
+
+    #[test]
+    fn test_resolve_class_name_invalid_utf8_index() {
+        let cf = ClassFile {
+            major_version: 61,
+            minor_version: 0,
+            constant_pool: vec![
+                None,
+                Some(CpEntry::Class {
+                    name_index: CpIndex(2),
+                }),
+                Some(CpEntry::Integer(42)), // Not a Utf8 entry
+            ],
+            access_flags: ClassAccessFlags::PUBLIC,
+            this_class: CpIndex(1),
+            super_class: CpIndex(0),
+            interfaces: vec![],
+            fields: vec![],
+            methods: vec![],
+            attributes: vec![],
+        };
+
+        let report = generate_analysis_report(&cf);
+        assert!(report.contains("Static Analysis Report: <invalid utf8>"));
     }
 }

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -5,6 +5,7 @@
 
 use std::process;
 
+mod analyze;
 mod html;
 
 use duke_bytecode::{decode, generate_mermaid_cfg};
@@ -205,6 +206,7 @@ fn main() {
         eprintln!("       duke html <classfile.class> [output.html]");
         eprintln!("       duke load <ClassName>");
         eprintln!("       duke cfg <classfile.class> <method>");
+        eprintln!("       duke analyze <classfile.class>");
         eprintln!("       duke exec <classfile.class> <method> [int-arg...]");
         eprintln!("       duke run <classfile.class> [string-arg...]");
         eprintln!("       duke stub <classfile.class>");
@@ -248,6 +250,12 @@ fn main() {
     // Dispatch `cfg`: dump control flow graph for a method.
     if args.len() >= 4 && args[1] == "cfg" {
         dump_cfg(&args[2], &args[3]);
+        return;
+    }
+
+    // Dispatch `analyze`: run static analysis on the class.
+    if args.len() >= 3 && args[1] == "analyze" {
+        dump_analyze(&args[2]);
         return;
     }
 
@@ -628,6 +636,20 @@ fn run_jar(
 // ---------------------------------------------------------------------------
 // Dump
 // ---------------------------------------------------------------------------
+
+fn dump_analyze(path: &str) {
+    let bytes = std::fs::read(path).unwrap_or_else(|e| {
+        eprintln!("duke: cannot read '{path}': {e}");
+        process::exit(1);
+    });
+    let cf = parse(&bytes).unwrap_or_else(|e| {
+        eprintln!("duke: parse error: {e}");
+        process::exit(1);
+    });
+
+    let report = analyze::generate_analysis_report(&cf);
+    println!("{report}");
+}
 
 fn dump_html(path: &str, output_path: Option<&str>) {
     let bytes = std::fs::read(path).unwrap_or_else(|e| {


### PR DESCRIPTION
💡 **The Spark:** "I noticed we parse JVM bytecode into structured instructions (`duke-bytecode`), but we mostly use it just to generate Control Flow Graphs or execute it. We aren't surfacing static analysis metrics from the compiled code directly to the user."

🚀 **The Feature:** "Implemented McCabe's Cyclomatic Complexity algorithm natively against our typed JVM `Instruction` set. Added a new `duke analyze <classfile.class>` CLI command that generates a clean tabular report of Code Size and Complexity for every method in the class."

🔮 **The Potential:** "This transforms `duke` from just an execution engine/debugger into a static analysis tool. We could easily extend this to calculate Halstead metrics, detect overly large methods (Code Smells), or identify excessive branching."

⚠️ **Risk:** "Extremely Low. The feature is purely additive. It lives in its own `analyze.rs` module and only adds a single standalone analysis function to `cfg.rs`. It does not touch the critical execution path."

---
*PR created automatically by Jules for task [14594049479987052819](https://jules.google.com/task/14594049479987052819) started by @madmax983*