### PR TITLE
⚡ Bolt: Refactored `ExceptionEntry` cloning in interpreter

### DIFF
--- a/crates/duke-interpreter/src/context.rs
+++ b/crates/duke-interpreter/src/context.rs
@@ -167,3 +167,23 @@ pub struct ClassContext {
     /// `BootstrapMethods` entries from the class attribute (needed for invokedynamic).
     pub bootstrap_methods: Vec<duke_classfile::types::BootstrapMethodEntry>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exception_entry_clone() {
+        let entry1 = ExceptionEntry {
+            start_pc: 0,
+            end_pc: 10,
+            handler_pc: 15,
+            catch_type: Some("java/lang/Exception".to_string()),
+        };
+        let entry2 = entry1.clone();
+        assert_eq!(entry1.start_pc, entry2.start_pc);
+        assert_eq!(entry1.end_pc, entry2.end_pc);
+        assert_eq!(entry1.handler_pc, entry2.handler_pc);
+        assert_eq!(entry1.catch_type, entry2.catch_type);
+    }
+}

--- a/crates/duke-interpreter/src/context.rs
+++ b/crates/duke-interpreter/src/context.rs
@@ -109,6 +109,7 @@ pub struct FieldEntry {
 /// };
 /// assert!(handler.catch_type.is_some());
 /// ```
+#[derive(Clone)]
 pub struct ExceptionEntry {
     /// Inclusive start PC of the try block where this handler becomes active.
     pub start_pc: u16,

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -10878,12 +10878,7 @@ fn run_execution(
                 let exc_table = registry.get(&current_class)?.methods[*method_idx]
                     .exception_table
                     .iter()
-                    .map(|e| ExceptionEntry {
-                        start_pc: e.start_pc,
-                        end_pc: e.end_pc,
-                        handler_pc: e.handler_pc,
-                        catch_type: e.catch_type.clone(),
-                    })
+                    .cloned()
                     .collect::<Vec<_>>();
                 let handler = find_exception_handler(
                     &exc_table,
@@ -10953,12 +10948,7 @@ fn run_execution(
                                 let tbl = ctx.methods[*method_idx]
                                     .exception_table
                                     .iter()
-                                    .map(|e| ExceptionEntry {
-                                        start_pc: e.start_pc,
-                                        end_pc: e.end_pc,
-                                        handler_pc: e.handler_pc,
-                                        catch_type: e.catch_type.clone(),
-                                    })
+                                    .cloned()
                                     .collect::<Vec<_>>();
                                 (tbl, cpc)
                             };


### PR DESCRIPTION
💡 **What**: Added `#[derive(Clone)]` to the `ExceptionEntry` struct and replaced manual field-by-field mapping `.map(|e| ExceptionEntry { ... e.catch_type.clone() })` with a simple `.cloned()` inside `propagate_java_exception!` and handler resolution blocks.

🎯 **Why**: Manual mapping of struct fields during cloning is a code smell. It creates unneeded boilerplate and hides the true intent of duplicating a slice. 

📊 **Impact**: While the compiler typically optimizes away the manual struct reconstruction, this simplifies the codebase, improves code readability, and uses idiomatic Rust abstractions without any runtime overhead.

🔬 **Measurement**: Verified with `cargo clippy` and `cargo test`, ensuring all exception propagation workflows continue functioning appropriately with cleanly cloned entries.

---
*PR created automatically by Jules for task [15499114119441388437](https://jules.google.com/task/15499114119441388437) started by @madmax983*