### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -948,8 +948,8 @@ impl Heap {
         }
 
         // Scan remembered-set old-gen objects for young refs.
-        let rs: Vec<usize> = self.remembered_set.iter().copied().collect();
-        for old_idx in rs {
+        // ⚡ Bolt: Avoid intermediate vector allocation by iterating directly
+        for &old_idx in &self.remembered_set {
             if let Some(Some(obj)) = self.old.get(old_idx) {
                 worklist.extend(
                     obj.fields


### PR DESCRIPTION
💡 **What:** Replaced an intermediate vector allocation (`.collect::<Vec<_>>()`) with direct iteration over `self.remembered_set` inside the `minor_collect_prepare` function in `duke-gc`.
🎯 **Why:** The garbage collector runs very frequently, and allocating a new `Vec` on the heap during every minor GC preparation cycle for the remembered set is an unnecessary bottleneck. Rust's borrow checker perfectly permits holding an immutable borrow to `&self.remembered_set` while simultaneously holding another immutable borrow to `&self.old` within the loop body.
📊 **Impact:** Reduces heap allocations by 1 per minor GC cycle.
🔬 **Measurement:** `cargo bench` run confirms no performance regressions across benchmarks and tests continue to pass.

---
*PR created automatically by Jules for task [10503875876353536018](https://jules.google.com/task/10503875876353536018) started by @madmax983*