### PR TITLE
⚡ Bolt: Remove intermediate allocation in GC prepare

### DIFF
--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -948,8 +948,8 @@ impl Heap {
         }
 
         // Scan remembered-set old-gen objects for young refs.
-        let rs: Vec<usize> = self.remembered_set.iter().copied().collect();
-        for old_idx in rs {
+        // ⚡ Bolt: Removed intermediate `.collect::<Vec<_>>()` allocation to avoid unnecessary heap allocations during GC preparation.
+        for &old_idx in &self.remembered_set {
             if let Some(Some(obj)) = self.old.get(old_idx) {
                 worklist.extend(
                     obj.fields


### PR DESCRIPTION
💡 **What:** Removed an intermediate `.collect::<Vec<_>>()` allocation in the `minor_collect_prepare` function of the garbage collector. Instead of collecting `self.remembered_set` into a temporary vector `rs`, the loop now iterates directly over `&self.remembered_set`. Added a doc comment explaining the optimization.

🎯 **Why:** Creating a temporary `Vec` requires a heap allocation purely to iterate over items that are already in memory. The borrow checker perfectly understands that iterating immutably over `self.remembered_set` while calling `self.old.get()` (another immutable borrow of a disjoint field) is safe. This eliminates a zero-value intermediate allocation on a hot path during GC preparation.

📊 **Impact:** Reduces heap allocations per minor GC cycle by 1. Given that GC is invoked repeatedly throughout execution, this shaves off completely unnecessary overhead on the hot path without sacrificing any readability or safety.

🔬 **Measurement:** Verified correctness with `cargo test -p duke-gc` and `cargo clippy -p duke-gc`. All tests passed successfully, confirming the borrow checker accepts the disjoint borrows without issue.

---
*PR created automatically by Jules for task [2222907566735338249](https://jules.google.com/task/2222907566735338249) started by @madmax983*