### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/crates/duke-classfile/src/attributes.rs
+++ b/crates/duke-classfile/src/attributes.rs
@@ -1,3 +1,20 @@
+//! JVM Attributes parsing and representations.
+//!
+//! This module defines the structures for attributes found in a `.class` file.
+//! Attributes are used in the `ClassFile`, `field_info`, `method_info`, and `Code_attribute` structures.
+//!
+//! While there are many attributes defined in the JVM specification, this module
+//! currently parses the following well-known attributes into typed variants:
+//! - `Code` (§4.7.3)
+//! - `ConstantValue` (§4.7.2)
+//! - `SourceFile` (§4.7.10)
+//! - `LineNumberTable` (§4.7.12)
+//! - `LocalVariableTable` (§4.7.13)
+//! - `Exceptions` (§4.7.5)
+//! - `BootstrapMethods` (§4.7.23)
+//!
+//! Unknown attributes are captured as raw bytes in `AttributeData::Raw` for forward compatibility.
+
 use crate::constant_pool::CpIndex;
 
 /// Generic attribute container (§4.7).

--- a/crates/duke-classfile/src/class.rs
+++ b/crates/duke-classfile/src/class.rs
@@ -1,3 +1,10 @@
+//! Top-level structures for Java class files.
+//!
+//! This module defines the main `ClassFile` structure, which represents a fully
+//! parsed JVM class file. It also provides structures for fields (`FieldInfo`)
+//! and methods (`MethodInfo`). These representations closely follow the JVM
+//! specification's `ClassFile` layout (§4.1).
+
 use crate::access_flags::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use crate::attributes::AttributeInfo;
 use crate::constant_pool::CpIndex;

--- a/crates/duke-classfile/src/constant_pool.rs
+++ b/crates/duke-classfile/src/constant_pool.rs
@@ -1,3 +1,12 @@
+//! Constant pool entries and indices.
+//!
+//! This module defines structures that represent entries in the Java class file's constant pool.
+//! The constant pool is a table of structures representing various string constants, class and interface names,
+//! field names, and other constants that are referred to within the `ClassFile` structure and its substructures.
+//!
+//! The `CpEntry` enum covers all constant pool entry tags described in JVM SE 21 (§4.4), including Java 9+
+//! modules and packages.
+
 /// Newtype wrapper for constant pool indices (1-based per JVM spec).
 ///
 /// # Examples


### PR DESCRIPTION
📖 Chapter: The `duke-classfile` structures.
🔦 Insight: Added module-level (`//!`) overviews to `attributes.rs`, `class.rs`, and `constant_pool.rs` to explain their purpose within the JVM class file format and stop `missing_docs` warnings.
🧪 Example: Described that `constant_pool.rs` contains JVM SE 21 representations.
🖼️ Preview: (Tested via `cargo doc --open`).

---
*PR created automatically by Jules for task [15972022648339698104](https://jules.google.com/task/15972022648339698104) started by @madmax983*