### PR TITLE
⚒️ Forge: Extract HTML generation logic into smaller functions

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -31,3 +31,7 @@
 **[Idiomatic String Parsing]
 **Learning:** Found string formatting functions like `native_string_format` using `while i < chars.len()` and manual index incrementing, which is verbose and requires bounds checking.
 **Action:** Replace manual `while` loops over `Vec<char>` with idiomatic `chars().peekable()` iterator chains using `while let Some(ch) = chars.next()` and `if let Some(&x) = chars.peek()`.
+
+**[Extracting God Functions]
+**Learning:** Found a massive `generate_html_report` function in `duke/src/html.rs` that generated an entire HTML document, mixing structural code with data processing for fields, methods, and bytecode.
+**Action:** Extract specific sections (e.g., `write_class_summary`, `write_fields`, `write_methods`) into separate helper functions that append to a mutable `String` buffer. This flattens the "God Function" and dramatically improves readability.

--- a/duke/src/html.rs
+++ b/duke/src/html.rs
@@ -39,136 +39,133 @@ fn resolve_class_name(cf: &ClassFile, idx: CpIndex) -> &str {
     }
 }
 
-/// Generates a complete, interactive HTML report of the given class file.
-/// Includes constants, fields, methods, and embedded Mermaid control flow graphs.
-#[must_use]
-#[allow(clippy::too_many_lines)]
-pub fn generate_html_report(cf: &ClassFile) -> String {
-    let mut out = String::new();
-    let this_name = escape_html(resolve_class_name(cf, cf.this_class));
-    let super_name = escape_html(resolve_class_name(cf, cf.super_class));
-
-    let _ = writeln!(&mut out, "<!DOCTYPE html>");
-    let _ = writeln!(&mut out, "<html lang=\"en\">");
-    let _ = writeln!(&mut out, "<head>");
-    let _ = writeln!(&mut out, "  <meta charset=\"UTF-8\">");
+fn write_html_header(out: &mut String, title: &str) {
+    let _ = writeln!(out, "<!DOCTYPE html>");
+    let _ = writeln!(out, "<html lang=\"en\">");
+    let _ = writeln!(out, "<head>");
+    let _ = writeln!(out, "  <meta charset=\"UTF-8\">");
     let _ = writeln!(
-        &mut out,
+        out,
         "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">"
     );
-    let _ = writeln!(&mut out, "  <title>Duke Class Report: {this_name}</title>");
-    let _ = writeln!(&mut out, "  <style>");
+    let _ = writeln!(out, "  <title>Duke Class Report: {title}</title>");
+    let _ = writeln!(out, "  <style>");
     let _ = writeln!(
-        &mut out,
+        out,
         "    body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 1200px; margin: 0 auto; padding: 20px; background: #f9f9f9; }}"
     );
     let _ = writeln!(
-        &mut out,
+        out,
         "    h1, h2, h3 {{ color: #2c3e50; border-bottom: 2px solid #eaecef; padding-bottom: 0.3em; }}"
     );
     let _ = writeln!(
-        &mut out,
+        out,
         "    .card {{ background: #fff; border: 1px solid #e1e4e8; border-radius: 6px; padding: 20px; margin-bottom: 20px; box-shadow: 0 1px 3px rgba(0,0,0,0.04); }}"
     );
     let _ = writeln!(
-        &mut out,
+        out,
         "    pre {{ background: #f6f8fa; border-radius: 6px; padding: 16px; overflow: auto; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 85%; margin: 0; }}"
     );
     let _ = writeln!(
-        &mut out,
+        out,
         "    .method {{ margin-top: 30px; border-left: 4px solid #0366d6; padding-left: 15px; }}"
     );
     let _ = writeln!(
-        &mut out,
+        out,
         "    .mermaid {{ margin: 20px 0; background: #fff; border: 1px solid #e1e4e8; border-radius: 6px; padding: 20px; display: flex; justify-content: center; }}"
     );
     let _ = writeln!(
-        &mut out,
+        out,
         "    table {{ width: 100%; border-collapse: collapse; margin-top: 10px; }}"
     );
     let _ = writeln!(
-        &mut out,
+        out,
         "    th, td {{ padding: 8px 12px; border: 1px solid #dfe2e5; text-align: left; }}"
     );
+    let _ = writeln!(out, "    th {{ background: #f6f8fa; font-weight: 600; }}");
     let _ = writeln!(
-        &mut out,
-        "    th {{ background: #f6f8fa; font-weight: 600; }}"
-    );
-    let _ = writeln!(
-        &mut out,
+        out,
         "    .badge {{ display: inline-block; padding: 0.25em 0.5em; font-size: 75%; font-weight: 600; line-height: 1; text-align: center; white-space: nowrap; vertical-align: baseline; border-radius: 0.25rem; background-color: #e1e4e8; color: #586069; margin-right: 5px; }}"
     );
-    let _ = writeln!(&mut out, "  </style>");
-    let _ = writeln!(&mut out, "  <script type=\"module\">");
+    let _ = writeln!(out, "  </style>");
+    let _ = writeln!(out, "  <script type=\"module\">");
     let _ = writeln!(
-        &mut out,
+        out,
         "    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';"
     );
     let _ = writeln!(
-        &mut out,
+        out,
         "    mermaid.initialize({{ startOnLoad: true, theme: 'default' }});"
     );
-    let _ = writeln!(&mut out, "  </script>");
-    let _ = writeln!(&mut out, "</head>");
-    let _ = writeln!(&mut out, "<body>");
+    let _ = writeln!(out, "  </script>");
+    let _ = writeln!(out, "</head>");
+    let _ = writeln!(out, "<body>");
+}
 
-    // Header
+fn write_class_summary(out: &mut String, cf: &ClassFile) {
+    let this_name = escape_html(resolve_class_name(cf, cf.this_class));
+    let super_name = escape_html(resolve_class_name(cf, cf.super_class));
+
     let _ = writeln!(
-        &mut out,
+        out,
         "  <h1>&#x1F4C4; Class Report: <code>{this_name}</code></h1>"
     );
-    let _ = writeln!(&mut out, "  <div class=\"card\">");
+    let _ = writeln!(out, "  <div class=\"card\">");
     let _ = writeln!(
-        &mut out,
+        out,
         "    <p><strong>Superclass:</strong> <code>{super_name}</code></p>"
     );
     let _ = writeln!(
-        &mut out,
+        out,
         "    <p><strong>Version:</strong> {}.{}</p>",
         cf.major_version, cf.minor_version
     );
     let _ = writeln!(
-        &mut out,
+        out,
         "    <p><strong>Access Flags:</strong> {:?}</p>",
         cf.access_flags
     );
     if !cf.interfaces.is_empty() {
-        let _ = writeln!(&mut out, "    <p><strong>Interfaces:</strong></p>");
-        let _ = writeln!(&mut out, "    <ul>");
+        let _ = writeln!(out, "    <p><strong>Interfaces:</strong></p>");
+        let _ = writeln!(out, "    <ul>");
         for idx in &cf.interfaces {
             let intf_name = escape_html(resolve_class_name(cf, *idx));
-            let _ = writeln!(&mut out, "      <li><code>{intf_name}</code></li>");
+            let _ = writeln!(out, "      <li><code>{intf_name}</code></li>");
         }
-        let _ = writeln!(&mut out, "    </ul>");
+        let _ = writeln!(out, "    </ul>");
     }
-    let _ = writeln!(&mut out, "  </div>");
+    let _ = writeln!(out, "  </div>");
+}
 
-    // Fields
-    if !cf.fields.is_empty() {
-        let _ = writeln!(&mut out, "  <h2>Fields</h2>");
-        let _ = writeln!(&mut out, "  <div class=\"card\">");
-        let _ = writeln!(&mut out, "    <table>");
-        let _ = writeln!(
-            &mut out,
-            "      <thead><tr><th>Access</th><th>Name</th><th>Descriptor</th></tr></thead>"
-        );
-        let _ = writeln!(&mut out, "      <tbody>");
-        for field in &cf.fields {
-            let name = escape_html(cp_str(cf, field.name_index).unwrap_or("<invalid>"));
-            let desc = escape_html(cp_str(cf, field.descriptor_index).unwrap_or("<invalid>"));
-            let _ = writeln!(&mut out, "        <tr>");
-            let _ = writeln!(&mut out, "          <td>{:?}</td>", field.access_flags);
-            let _ = writeln!(&mut out, "          <td><code>{name}</code></td>");
-            let _ = writeln!(&mut out, "          <td><code>{desc}</code></td>");
-            let _ = writeln!(&mut out, "        </tr>");
-        }
-        let _ = writeln!(&mut out, "      </tbody>");
-        let _ = writeln!(&mut out, "    </table>");
-        let _ = writeln!(&mut out, "  </div>");
+fn write_fields(out: &mut String, cf: &ClassFile) {
+    if cf.fields.is_empty() {
+        return;
     }
 
-    // Methods
-    let _ = writeln!(&mut out, "  <h2>Methods</h2>");
+    let _ = writeln!(out, "  <h2>Fields</h2>");
+    let _ = writeln!(out, "  <div class=\"card\">");
+    let _ = writeln!(out, "    <table>");
+    let _ = writeln!(
+        out,
+        "      <thead><tr><th>Access</th><th>Name</th><th>Descriptor</th></tr></thead>"
+    );
+    let _ = writeln!(out, "      <tbody>");
+    for field in &cf.fields {
+        let name = escape_html(cp_str(cf, field.name_index).unwrap_or("<invalid>"));
+        let desc = escape_html(cp_str(cf, field.descriptor_index).unwrap_or("<invalid>"));
+        let _ = writeln!(out, "        <tr>");
+        let _ = writeln!(out, "          <td>{:?}</td>", field.access_flags);
+        let _ = writeln!(out, "          <td><code>{name}</code></td>");
+        let _ = writeln!(out, "          <td><code>{desc}</code></td>");
+        let _ = writeln!(out, "        </tr>");
+    }
+    let _ = writeln!(out, "      </tbody>");
+    let _ = writeln!(out, "    </table>");
+    let _ = writeln!(out, "  </div>");
+}
+
+fn write_methods(out: &mut String, cf: &ClassFile) {
+    let _ = writeln!(out, "  <h2>Methods</h2>");
     for method in &cf.methods {
         let name_str = cp_str(cf, method.name_index).unwrap_or("<invalid>");
         let desc_str = cp_str(cf, method.descriptor_index).unwrap_or("<invalid>");
@@ -184,13 +181,10 @@ pub fn generate_html_report(cf: &ClassFile) -> String {
         let name = escape_html(name_str);
         let desc = escape_html(desc_str);
 
-        let _ = writeln!(&mut out, "  <div class=\"method\">");
+        let _ = writeln!(out, "  <div class=\"method\">");
+        let _ = writeln!(out, "    <h3><code>{name}{desc}{ctor_label}</code></h3>");
         let _ = writeln!(
-            &mut out,
-            "    <h3><code>{name}{desc}{ctor_label}</code></h3>"
-        );
-        let _ = writeln!(
-            &mut out,
+            out,
             "    <p><span class=\"badge\">{:?}</span></p>",
             method.access_flags
         );
@@ -199,9 +193,9 @@ pub fn generate_html_report(cf: &ClassFile) -> String {
         for attr in &method.attributes {
             if let AttributeData::Code(code) = &attr.data {
                 found_code = true;
-                let _ = writeln!(&mut out, "    <div class=\"card\">");
+                let _ = writeln!(out, "    <div class=\"card\">");
                 let _ = writeln!(
-                    &mut out,
+                    out,
                     "      <p><strong>Code Size:</strong> {} bytes | <strong>Max Stack:</strong> {} | <strong>Max Locals:</strong> {}</p>",
                     code.code.len(),
                     code.max_stack,
@@ -212,45 +206,58 @@ pub fn generate_html_report(cf: &ClassFile) -> String {
                     Ok(instructions) => {
                         // Generate Mermaid CFG
                         let cfg = generate_mermaid_cfg(&instructions);
-                        let _ = writeln!(&mut out, "      <h4>Control Flow Graph</h4>");
-                        let _ = writeln!(&mut out, "      <div class=\"mermaid\">");
-                        let _ = writeln!(&mut out, "{cfg}");
-                        let _ = writeln!(&mut out, "      </div>");
+                        let _ = writeln!(out, "      <h4>Control Flow Graph</h4>");
+                        let _ = writeln!(out, "      <div class=\"mermaid\">");
+                        let _ = writeln!(out, "{cfg}");
+                        let _ = writeln!(out, "      </div>");
 
                         // Also show raw bytecode for reference
-                        let _ = writeln!(&mut out, "      <details>");
+                        let _ = writeln!(out, "      <details>");
                         let _ = writeln!(
-                            &mut out,
+                            out,
                             "        <summary>View Raw Bytecode Instructions</summary>"
                         );
-                        let _ = writeln!(&mut out, "        <pre>");
+                        let _ = writeln!(out, "        <pre>");
                         for (pc, instr) in &instructions {
                             let mnemonic = instr.mnemonic();
-                            let _ = writeln!(&mut out, "  {pc:4}: {mnemonic}");
+                            let _ = writeln!(out, "  {pc:4}: {mnemonic}");
                         }
-                        let _ = writeln!(&mut out, "        </pre>");
-                        let _ = writeln!(&mut out, "      </details>");
+                        let _ = writeln!(out, "        </pre>");
+                        let _ = writeln!(out, "      </details>");
                     }
                     Err(e) => {
                         let _ = writeln!(
-                            &mut out,
+                            out,
                             "      <p style=\"color: red;\"><strong>Decode Error:</strong> {e}</p>"
                         );
                     }
                 }
-                let _ = writeln!(&mut out, "    </div>");
+                let _ = writeln!(out, "    </div>");
             }
         }
 
         if !found_code {
             let _ = writeln!(
-                &mut out,
+                out,
                 "    <p><em>No Code attribute (abstract or native).</em></p>"
             );
         }
 
-        let _ = writeln!(&mut out, "  </div>");
+        let _ = writeln!(out, "  </div>");
     }
+}
+
+/// Generates a complete, interactive HTML report of the given class file.
+/// Includes constants, fields, methods, and embedded Mermaid control flow graphs.
+#[must_use]
+pub fn generate_html_report(cf: &ClassFile) -> String {
+    let mut out = String::new();
+    let this_name = escape_html(resolve_class_name(cf, cf.this_class));
+
+    write_html_header(&mut out, &this_name);
+    write_class_summary(&mut out, cf);
+    write_fields(&mut out, cf);
+    write_methods(&mut out, cf);
 
     let _ = writeln!(&mut out, "</body>");
     let _ = writeln!(&mut out, "</html>");


### PR DESCRIPTION
🚮 **Smell:** The `generate_html_report` function in `duke/src/html.rs` was a massive "God Function" (~200 lines long). It was responsible for writing the HTML headers, CSS, JS scripts, class summaries, parsing and writing field lists, method lists, and even decoding bytecode to generate Mermaid CFGs. This made it extremely difficult to read and maintain, and necessitated an ugly `#[allow(clippy::too_many_lines)]` attribute to pass linting.

✨ **Solution:** Extracted the distinct logical sections into dedicated, private helper functions: `write_html_header`, `write_class_summary`, `write_fields`, and `write_methods`. The main `generate_html_report` function now serves simply as an orchestrator that calls these functions sequentially, appending output to a mutable string buffer. 

🧼 **Benefit:** Drastically improves readability and separation of concerns. Developers can now easily navigate to the specific structural component of the HTML report they wish to modify without parsing hundreds of lines of string interpolations. Additionally, it allowed the removal of the `#[allow(clippy::too_many_lines)]` clippy bypass.

🛡️ **Verification:** Tests passed. No logic changed. The generated HTML output is completely identical. All `cargo clippy`, `cargo test`, and `cargo fmt` commands ran successfully.

**Assumptions:** 
*   It is assumed that extracting these chunks into smaller helper functions mutating a shared `String` buffer (via `&mut String`) is the idiomatic Forge approach here, as it minimizes allocations while breaking up the pyramid of `writeln!` calls.

---
*PR created automatically by Jules for task [12744608901266661589](https://jules.google.com/task/12744608901266661589) started by @madmax983*