### PR TITLE
🗺️ Atlas: Extract bootstrap_stdlib to break up Blob anti-pattern

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -12,3 +12,7 @@
 **[Split ClassFile types]
 **Tangle:** `duke-classfile/src/types.rs` was a Blob anti-pattern holding constant pool, attributes, and class structures.
 **Blueprint:** Split into `constant_pool.rs`, `attributes.rs`, and `class.rs` to match domain responsibilities.
+
+**Refactoring Blob Anti-Pattern in Interpreter**
+**Tangle:** `crates/duke-interpreter/src/lib.rs` was a massive Blob containing both the `bootstrap_stdlib` registry logic (~3600 lines) and the internal native handlers, creating an overly monolithic file.
+**Blueprint:** Extracted `bootstrap_stdlib` to a new `stdlib.rs` file, making the internal native handlers and extraction helpers `pub(crate)` in `lib.rs` so `stdlib.rs` can access them without creating cyclic dependencies.

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -8,10 +8,12 @@
 pub mod context;
 /// Repositories for loaded classes and registered native methods.
 pub mod registry;
+pub mod stdlib;
 mod threading;
 
 pub use context::*;
 pub use registry::*;
+pub use stdlib::bootstrap_stdlib;
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::Write;
@@ -22,3650 +24,13 @@ use duke_classfile::types::CpEntry;
 use duke_loader::ClassLoader;
 use duke_runtime::{Frame, Slot, VmError, VmResult};
 
-/// Registry of loaded classes — maps class name to its `ClassContext`.
-///
-/// Used by `execute_class` for cross-class method dispatch.
-///
-/// # Examples
-///
-/// A native handler that can call back into the interpreter to invoke Java methods.
-///
-/// The `invoke` closure takes `heap` and `output` as *parameters* (not captured),
-/// using the "loan" pattern: the handler passes its borrows through each call and
-/// gets them back when the call returns. Sequential reborrows — no unsafe required.
-/// Bootstrap minimal JDK standard library classes for native method support.
-///
-/// Creates synthetic `java/lang/System` and `java/io/PrintStream` classes and
-/// registers native `println` handlers for `(Ljava/lang/String;)V`, `(I)V`,
-/// and `()V`.
-#[allow(clippy::too_many_lines)]
-pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) {
-    // Allocate a PrintStream object on the heap.
-    let ps_ref = heap.allocate("java/io/PrintStream".to_string(), 0);
-
-    // Create java/lang/System ClassContext with a single static field `out`.
-    let system_ctx = ClassContext {
-        class_name: "java/lang/System".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "out".to_string(),
-            descriptor: "Ljava/io/PrintStream;".to_string(),
-            is_static: true,
-        }],
-        static_fields: vec![Slot::Reference(Some(ps_ref))],
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(system_ctx);
-
-    // Create java/io/PrintStream ClassContext (empty — all methods are native).
-    let ps_ctx = ClassContext {
-        class_name: "java/io/PrintStream".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(ps_ctx);
-
-    // Register native println handlers.
-    registry.natives_mut().register(
-        "java/io/PrintStream",
-        "println",
-        "(Ljava/lang/String;)V",
-        native_println_string,
-    );
-    registry
-        .natives_mut()
-        .register("java/io/PrintStream", "println", "(I)V", native_println_int);
-    registry
-        .natives_mut()
-        .register("java/io/PrintStream", "println", "()V", native_println_void);
-
-    let file_ctx = ClassContext {
-        class_name: "java/io/File".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "path".to_string(),
-            descriptor: "Ljava/lang/String;".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(file_ctx);
-    registry.natives_mut().register(
-        "java/io/File",
-        "<init>",
-        "(Ljava/lang/String;)V",
-        native_file_init,
-    );
-    registry
-        .natives_mut()
-        .register("java/io/File", "exists", "()Z", native_file_exists);
-    registry
-        .natives_mut()
-        .register("java/io/File", "isFile", "()Z", native_file_is_file);
-    registry.natives_mut().register(
-        "java/io/File",
-        "isDirectory",
-        "()Z",
-        native_file_is_directory,
-    );
-
-    let io_exception_ctx = ClassContext {
-        class_name: "java/io/IOException".to_string(),
-        super_class: Some("java/lang/Exception".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(io_exception_ctx);
-
-    let file_not_found_ctx = ClassContext {
-        class_name: "java/io/FileNotFoundException".to_string(),
-        super_class: Some("java/io/IOException".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(file_not_found_ctx);
-
-    let socket_exception_ctx = ClassContext {
-        class_name: "java/net/SocketException".to_string(),
-        super_class: Some("java/io/IOException".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(socket_exception_ctx);
-
-    let bind_exception_ctx = ClassContext {
-        class_name: "java/net/BindException".to_string(),
-        super_class: Some("java/net/SocketException".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(bind_exception_ctx);
-
-    let connect_exception_ctx = ClassContext {
-        class_name: "java/net/ConnectException".to_string(),
-        super_class: Some("java/net/SocketException".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(connect_exception_ctx);
-
-    let input_stream_ctx = ClassContext {
-        class_name: "java/io/InputStream".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: vec!["java/lang/AutoCloseable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(input_stream_ctx);
-
-    let output_stream_ctx = ClassContext {
-        class_name: "java/io/OutputStream".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: vec!["java/lang/AutoCloseable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(output_stream_ctx);
-
-    let process_ctx = ClassContext {
-        class_name: "java/lang/Process".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(process_ctx);
-
-    let process_impl_ctx = ClassContext {
-        class_name: "java/lang/ProcessImpl".to_string(),
-        super_class: Some("java/lang/Process".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "pid".to_string(),
-                descriptor: "I".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "stdinFd".to_string(),
-                descriptor: "I".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "stdoutFd".to_string(),
-                descriptor: "I".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "stderrFd".to_string(),
-                descriptor: "I".to_string(),
-                is_static: false,
-            },
-        ],
-        static_fields: Vec::new(),
-        instance_field_count: 4,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(process_impl_ctx);
-    registry.natives_mut().register(
-        "java/lang/ProcessImpl",
-        "getInputStream",
-        "()Ljava/io/InputStream;",
-        native_process_get_input_stream,
-    );
-    registry.natives_mut().register(
-        "java/lang/ProcessImpl",
-        "getErrorStream",
-        "()Ljava/io/InputStream;",
-        native_process_get_error_stream,
-    );
-    registry.natives_mut().register(
-        "java/lang/ProcessImpl",
-        "getOutputStream",
-        "()Ljava/io/OutputStream;",
-        native_process_get_output_stream,
-    );
-    registry.natives_mut().register(
-        "java/lang/ProcessImpl",
-        "waitFor",
-        "()I",
-        native_process_wait_for,
-    );
-    registry.natives_mut().register(
-        "java/lang/ProcessImpl",
-        "exitValue",
-        "()I",
-        native_process_exit_value,
-    );
-    registry.natives_mut().register(
-        "java/lang/ProcessImpl",
-        "destroy",
-        "()V",
-        native_process_destroy,
-    );
-
-    let process_builder_ctx = ClassContext {
-        class_name: "java/lang/ProcessBuilder".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "command".to_string(),
-                descriptor: "[Ljava/lang/String;".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "directory".to_string(),
-                descriptor: "Ljava/io/File;".to_string(),
-                is_static: false,
-            },
-        ],
-        static_fields: Vec::new(),
-        instance_field_count: 2,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(process_builder_ctx);
-    registry.natives_mut().register(
-        "java/lang/ProcessBuilder",
-        "<init>",
-        "([Ljava/lang/String;)V",
-        native_process_builder_init,
-    );
-    registry.natives_mut().register(
-        "java/lang/ProcessBuilder",
-        "directory",
-        "(Ljava/io/File;)Ljava/lang/ProcessBuilder;",
-        native_process_builder_directory,
-    );
-    registry.natives_mut().register(
-        "java/lang/ProcessBuilder",
-        "start",
-        "()Ljava/lang/Process;",
-        native_process_builder_start,
-    );
-
-    let runtime_ctx = ClassContext {
-        class_name: "java/lang/Runtime".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(runtime_ctx);
-    registry.natives_mut().register(
-        "java/lang/Runtime",
-        "getRuntime",
-        "()Ljava/lang/Runtime;",
-        native_runtime_get_runtime,
-    );
-    registry.natives_mut().register(
-        "java/lang/Runtime",
-        "exec",
-        "([Ljava/lang/String;)Ljava/lang/Process;",
-        native_runtime_exec_array,
-    );
-    registry.natives_mut().register(
-        "java/lang/Runtime",
-        "exec",
-        "([Ljava/lang/String;[Ljava/lang/String;Ljava/io/File;)Ljava/lang/Process;",
-        native_runtime_exec_array_dir,
-    );
-
-    let process_input_stream_ctx = ClassContext {
-        class_name: "duke/process/ProcessInputStream".to_string(),
-        super_class: Some("java/io/InputStream".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "fd".to_string(),
-            descriptor: "I".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/AutoCloseable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(process_input_stream_ctx);
-    registry.natives_mut().register(
-        "duke/process/ProcessInputStream",
-        "read",
-        "()I",
-        native_file_input_stream_read,
-    );
-    registry.natives_mut().register(
-        "duke/process/ProcessInputStream",
-        "read",
-        "([B)I",
-        native_file_input_stream_read_bytes,
-    );
-    registry.natives_mut().register(
-        "duke/process/ProcessInputStream",
-        "close",
-        "()V",
-        native_file_input_stream_close,
-    );
-
-    let process_error_stream_ctx = ClassContext {
-        class_name: "duke/process/ProcessErrorStream".to_string(),
-        super_class: Some("java/io/InputStream".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "fd".to_string(),
-            descriptor: "I".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/AutoCloseable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(process_error_stream_ctx);
-    registry.natives_mut().register(
-        "duke/process/ProcessErrorStream",
-        "read",
-        "()I",
-        native_file_input_stream_read,
-    );
-    registry.natives_mut().register(
-        "duke/process/ProcessErrorStream",
-        "read",
-        "([B)I",
-        native_file_input_stream_read_bytes,
-    );
-    registry.natives_mut().register(
-        "duke/process/ProcessErrorStream",
-        "close",
-        "()V",
-        native_file_input_stream_close,
-    );
-
-    let process_output_stream_ctx = ClassContext {
-        class_name: "duke/process/ProcessOutputStream".to_string(),
-        super_class: Some("java/io/OutputStream".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "fd".to_string(),
-            descriptor: "I".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/AutoCloseable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(process_output_stream_ctx);
-    registry.natives_mut().register(
-        "duke/process/ProcessOutputStream",
-        "write",
-        "(I)V",
-        native_file_output_stream_write,
-    );
-    registry.natives_mut().register(
-        "duke/process/ProcessOutputStream",
-        "write",
-        "([B)V",
-        native_file_output_stream_write_bytes,
-    );
-    registry.natives_mut().register(
-        "duke/process/ProcessOutputStream",
-        "close",
-        "()V",
-        native_file_output_stream_close,
-    );
-
-    let file_input_stream_ctx = ClassContext {
-        class_name: "java/io/FileInputStream".to_string(),
-        super_class: Some("java/io/InputStream".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "fd".to_string(),
-            descriptor: "I".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/AutoCloseable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(file_input_stream_ctx);
-    registry.natives_mut().register(
-        "java/io/FileInputStream",
-        "<init>",
-        "(Ljava/lang/String;)V",
-        native_file_input_stream_init,
-    );
-    registry.natives_mut().register(
-        "java/io/FileInputStream",
-        "read",
-        "()I",
-        native_file_input_stream_read,
-    );
-    registry.natives_mut().register(
-        "java/io/FileInputStream",
-        "read",
-        "([B)I",
-        native_file_input_stream_read_bytes,
-    );
-    registry.natives_mut().register(
-        "java/io/FileInputStream",
-        "close",
-        "()V",
-        native_file_input_stream_close,
-    );
-
-    let file_output_stream_ctx = ClassContext {
-        class_name: "java/io/FileOutputStream".to_string(),
-        super_class: Some("java/io/OutputStream".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "fd".to_string(),
-            descriptor: "I".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/AutoCloseable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(file_output_stream_ctx);
-    registry.natives_mut().register(
-        "java/io/FileOutputStream",
-        "<init>",
-        "(Ljava/lang/String;)V",
-        native_file_output_stream_init,
-    );
-    registry.natives_mut().register(
-        "java/io/FileOutputStream",
-        "write",
-        "(I)V",
-        native_file_output_stream_write,
-    );
-    registry.natives_mut().register(
-        "java/io/FileOutputStream",
-        "write",
-        "([B)V",
-        native_file_output_stream_write_bytes,
-    );
-    registry.natives_mut().register(
-        "java/io/FileOutputStream",
-        "close",
-        "()V",
-        native_file_output_stream_close,
-    );
-
-    let server_socket_ctx = ClassContext {
-        class_name: "java/net/ServerSocket".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "fd".to_string(),
-                descriptor: "I".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "port".to_string(),
-                descriptor: "I".to_string(),
-                is_static: false,
-            },
-        ],
-        static_fields: Vec::new(),
-        instance_field_count: 2,
-        interfaces: vec!["java/lang/AutoCloseable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(server_socket_ctx);
-    registry.natives_mut().register(
-        "java/net/ServerSocket",
-        "<init>",
-        "(I)V",
-        native_server_socket_init,
-    );
-    registry.natives_mut().register(
-        "java/net/ServerSocket",
-        "accept",
-        "()Ljava/net/Socket;",
-        native_server_socket_accept,
-    );
-    registry.natives_mut().register(
-        "java/net/ServerSocket",
-        "getLocalPort",
-        "()I",
-        native_server_socket_get_local_port,
-    );
-    registry.natives_mut().register(
-        "java/net/ServerSocket",
-        "close",
-        "()V",
-        native_server_socket_close,
-    );
-
-    let socket_ctx = ClassContext {
-        class_name: "java/net/Socket".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "fdRead".to_string(),
-                descriptor: "I".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "fdWrite".to_string(),
-                descriptor: "I".to_string(),
-                is_static: false,
-            },
-        ],
-        static_fields: Vec::new(),
-        instance_field_count: 2,
-        interfaces: vec!["java/lang/AutoCloseable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(socket_ctx);
-    registry.natives_mut().register(
-        "java/net/Socket",
-        "<init>",
-        "(Ljava/lang/String;I)V",
-        native_socket_init,
-    );
-    registry.natives_mut().register(
-        "java/net/Socket",
-        "getInputStream",
-        "()Ljava/io/InputStream;",
-        native_socket_get_input_stream,
-    );
-    registry.natives_mut().register(
-        "java/net/Socket",
-        "getOutputStream",
-        "()Ljava/io/OutputStream;",
-        native_socket_get_output_stream,
-    );
-    registry
-        .natives_mut()
-        .register("java/net/Socket", "close", "()V", native_socket_close);
-
-    let socket_input_stream_ctx = ClassContext {
-        class_name: "duke/net/SocketInputStream".to_string(),
-        super_class: Some("java/io/InputStream".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "fd".to_string(),
-            descriptor: "I".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/AutoCloseable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(socket_input_stream_ctx);
-    registry.natives_mut().register(
-        "duke/net/SocketInputStream",
-        "read",
-        "()I",
-        native_file_input_stream_read,
-    );
-    registry.natives_mut().register(
-        "duke/net/SocketInputStream",
-        "read",
-        "([B)I",
-        native_file_input_stream_read_bytes,
-    );
-    registry.natives_mut().register(
-        "duke/net/SocketInputStream",
-        "close",
-        "()V",
-        native_file_input_stream_close,
-    );
-
-    let socket_output_stream_ctx = ClassContext {
-        class_name: "duke/net/SocketOutputStream".to_string(),
-        super_class: Some("java/io/OutputStream".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "fd".to_string(),
-            descriptor: "I".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/AutoCloseable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(socket_output_stream_ctx);
-    registry.natives_mut().register(
-        "duke/net/SocketOutputStream",
-        "write",
-        "(I)V",
-        native_file_output_stream_write,
-    );
-    registry.natives_mut().register(
-        "duke/net/SocketOutputStream",
-        "write",
-        "([B)V",
-        native_file_output_stream_write_bytes,
-    );
-    registry.natives_mut().register(
-        "duke/net/SocketOutputStream",
-        "close",
-        "()V",
-        native_file_output_stream_close,
-    );
-
-    // Register java/lang/String ClassContext (empty — instance methods are native).
-    let string_ctx = ClassContext {
-        class_name: "java/lang/String".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: vec![
-            "java/lang/Comparable".to_string(),
-            "java/io/Serializable".to_string(),
-            "java/lang/CharSequence".to_string(),
-        ],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(string_ctx);
-
-    // String instance methods
-    registry
-        .natives_mut()
-        .register("java/lang/String", "length", "()I", native_string_length);
-    registry.natives_mut().register(
-        "java/lang/String",
-        "equals",
-        "(Ljava/lang/Object;)Z",
-        native_string_equals,
-    );
-    registry
-        .natives_mut()
-        .register("java/lang/String", "charAt", "(I)C", native_string_char_at);
-    registry.natives_mut().register(
-        "java/lang/String",
-        "substring",
-        "(I)Ljava/lang/String;",
-        native_string_substring,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "substring",
-        "(II)Ljava/lang/String;",
-        native_string_substring_range,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "indexOf",
-        "(Ljava/lang/String;)I",
-        native_string_indexof,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "contains",
-        "(Ljava/lang/CharSequence;)Z",
-        native_string_contains,
-    );
-    registry
-        .natives_mut()
-        .register("java/lang/String", "isEmpty", "()Z", native_string_isempty);
-    registry.natives_mut().register(
-        "java/lang/String",
-        "compareTo",
-        "(Ljava/lang/String;)I",
-        native_string_compareto,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "compareTo",
-        "(Ljava/lang/Object;)I",
-        native_string_compareto_object,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "startsWith",
-        "(Ljava/lang/String;)Z",
-        native_string_startswith,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "endsWith",
-        "(Ljava/lang/String;)Z",
-        native_string_endswith,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "trim",
-        "()Ljava/lang/String;",
-        native_string_trim,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "toCharArray",
-        "()[C",
-        native_string_tochararray,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "toUpperCase",
-        "()Ljava/lang/String;",
-        native_string_touppercase,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "toLowerCase",
-        "()Ljava/lang/String;",
-        native_string_tolowercase,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "replace",
-        "(CC)Ljava/lang/String;",
-        native_string_replace_char,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "replace",
-        "(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/lang/String;",
-        native_string_replace_charsequence,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "split",
-        "(Ljava/lang/String;)[Ljava/lang/String;",
-        native_string_split,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "hashCode",
-        "()I",
-        native_string_hashcode,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "toString",
-        "()Ljava/lang/String;",
-        native_string_tostring,
-    );
-
-    // String static methods
-    registry.natives_mut().register(
-        "java/lang/String",
-        "valueOf",
-        "(I)Ljava/lang/String;",
-        native_string_value_of_int,
-    );
-
-    // PrintStream.print (no newline)
-    registry.natives_mut().register(
-        "java/io/PrintStream",
-        "print",
-        "(Ljava/lang/String;)V",
-        native_print_string,
-    );
-    registry
-        .natives_mut()
-        .register("java/io/PrintStream", "print", "(I)V", native_print_int);
-
-    // println overloads
-    registry.natives_mut().register(
-        "java/io/PrintStream",
-        "println",
-        "(J)V",
-        native_println_long,
-    );
-    registry.natives_mut().register(
-        "java/io/PrintStream",
-        "println",
-        "(F)V",
-        native_println_float,
-    );
-    registry.natives_mut().register(
-        "java/io/PrintStream",
-        "println",
-        "(D)V",
-        native_println_double,
-    );
-    registry.natives_mut().register(
-        "java/io/PrintStream",
-        "println",
-        "(Z)V",
-        native_println_boolean,
-    );
-    registry.natives_mut().register(
-        "java/io/PrintStream",
-        "println",
-        "(C)V",
-        native_println_char,
-    );
-    registry.natives_mut().register(
-        "java/io/PrintStream",
-        "println",
-        "(Ljava/lang/Object;)V",
-        native_println_object,
-    );
-
-    // print overloads
-    registry
-        .natives_mut()
-        .register("java/io/PrintStream", "print", "(J)V", native_print_long);
-    registry
-        .natives_mut()
-        .register("java/io/PrintStream", "print", "(F)V", native_print_float);
-    registry
-        .natives_mut()
-        .register("java/io/PrintStream", "print", "(D)V", native_print_double);
-    registry
-        .natives_mut()
-        .register("java/io/PrintStream", "print", "(Z)V", native_print_boolean);
-    registry
-        .natives_mut()
-        .register("java/io/PrintStream", "print", "(C)V", native_print_char);
-    registry.natives_mut().register(
-        "java/io/PrintStream",
-        "print",
-        "(Ljava/lang/Object;)V",
-        native_print_object,
-    );
-
-    // System.exit (static)
-    registry
-        .natives_mut()
-        .register("java/lang/System", "exit", "(I)V", native_system_exit);
-    registry.natives_mut().register(
-        "java/lang/System",
-        "currentTimeMillis",
-        "()J",
-        native_system_current_time_millis,
-    );
-    registry.natives_mut().register(
-        "java/lang/System",
-        "nanoTime",
-        "()J",
-        native_system_nano_time,
-    );
-    registry.natives_mut().register(
-        "java/lang/System",
-        "getProperty",
-        "(Ljava/lang/String;)Ljava/lang/String;",
-        native_system_get_property,
-    );
-    registry.natives_mut().register(
-        "java/lang/System",
-        "getProperty",
-        "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
-        native_system_get_property_with_default,
-    );
-    registry.natives_mut().register(
-        "java/lang/System",
-        "setProperty",
-        "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
-        native_system_set_property,
-    );
-
-    // Register synthetic exception hierarchy so is_assignable_from can walk it.
-    // java/lang/Object (root — no super)
-    let object_ctx = ClassContext {
-        class_name: "java/lang/Object".to_string(),
-        super_class: None,
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(object_ctx);
-
-    // Object instance methods
-    registry
-        .natives_mut()
-        .register("java/lang/Object", "<init>", "()V", native_object_init);
-    registry.natives_mut().register(
-        "java/lang/Object",
-        "equals",
-        "(Ljava/lang/Object;)Z",
-        native_object_equals,
-    );
-    registry.natives_mut().register(
-        "java/lang/Object",
-        "hashCode",
-        "()I",
-        native_object_hashcode,
-    );
-    registry.natives_mut().register(
-        "java/lang/Object",
-        "toString",
-        "()Ljava/lang/String;",
-        native_object_tostring,
-    );
-    registry.natives_mut().register(
-        "java/lang/Object",
-        "clone",
-        "()Ljava/lang/Object;",
-        native_object_clone,
-    );
-    registry.natives_mut().register(
-        "java/lang/Object",
-        "getClass",
-        "()Ljava/lang/Class;",
-        native_object_get_class,
-    );
-
-    // java/lang/Class — lightweight stub for class literals
-    let class_ctx = ClassContext {
-        class_name: "java/lang/Class".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(class_ctx);
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "forName",
-        "(Ljava/lang/String;)Ljava/lang/Class;",
-        native_class_for_name,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "forName",
-        "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;",
-        native_class_for_name_with_loader,
-    );
-    registry.natives_mut().register(
-        "java/lang/Class",
-        "getName",
-        "()Ljava/lang/String;",
-        native_class_get_name,
-    );
-    registry.natives_mut().register(
-        "java/lang/Class",
-        "getPackageName",
-        "()Ljava/lang/String;",
-        native_class_get_package_name,
-    );
-    registry.natives_mut().register(
-        "java/lang/Class",
-        "desiredAssertionStatus",
-        "()Z",
-        native_class_desired_assertion_status,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "getDeclaredMethods",
-        "()[Ljava/lang/reflect/Method;",
-        native_class_get_declared_methods,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "getDeclaredFields",
-        "()[Ljava/lang/reflect/Field;",
-        native_class_get_declared_fields,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "getDeclaredConstructors",
-        "()[Ljava/lang/reflect/Constructor;",
-        native_class_get_declared_constructors,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "getMethods",
-        "()[Ljava/lang/reflect/Method;",
-        native_class_get_methods,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "getFields",
-        "()[Ljava/lang/reflect/Field;",
-        native_class_get_fields,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "getConstructors",
-        "()[Ljava/lang/reflect/Constructor;",
-        native_class_get_constructors,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "getDeclaredMethod",
-        "(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;",
-        native_class_get_declared_method,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "getDeclaredField",
-        "(Ljava/lang/String;)Ljava/lang/reflect/Field;",
-        native_class_get_declared_field,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "getDeclaredConstructor",
-        "([Ljava/lang/Class;)Ljava/lang/reflect/Constructor;",
-        native_class_get_declared_constructor,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "getMethod",
-        "(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;",
-        native_class_get_method,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "getField",
-        "(Ljava/lang/String;)Ljava/lang/reflect/Field;",
-        native_class_get_field,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "getConstructor",
-        "([Ljava/lang/Class;)Ljava/lang/reflect/Constructor;",
-        native_class_get_constructor,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "newInstance",
-        "()Ljava/lang/Object;",
-        native_class_new_instance,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "getProtectionDomain",
-        "()Ljava/security/ProtectionDomain;",
-        native_class_get_protection_domain,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/Class",
-        "getClassLoader",
-        "()Ljava/lang/ClassLoader;",
-        native_class_get_class_loader,
-    );
-    registry.natives_mut().register(
-        "jdk/internal/misc/CDS",
-        "isDumpingClassList0",
-        "()Z",
-        native_false_boolean,
-    );
-    registry.natives_mut().register(
-        "jdk/internal/misc/CDS",
-        "isDumpingArchive0",
-        "()Z",
-        native_false_boolean,
-    );
-    registry.natives_mut().register(
-        "jdk/internal/misc/CDS",
-        "isSharingEnabled0",
-        "()Z",
-        native_false_boolean,
-    );
-    registry.natives_mut().register(
-        "jdk/internal/misc/CDS",
-        "getRandomSeedForDumping",
-        "()J",
-        native_zero_long,
-    );
-    registry.natives_mut().register(
-        "jdk/internal/misc/CDS",
-        "initializeFromArchive",
-        "(Ljava/lang/Class;)V",
-        native_void_noop,
-    );
-    registry.natives_mut().register(
-        "jdk/internal/misc/CDS",
-        "defineArchivedModules",
-        "(Ljava/lang/ClassLoader;Ljava/lang/ClassLoader;)V",
-        native_void_noop,
-    );
-    registry.natives_mut().register(
-        "jdk/internal/misc/CDS",
-        "logLambdaFormInvoker",
-        "(Ljava/lang/String;)V",
-        native_void_noop,
-    );
-
-    let protection_domain_ctx = ClassContext {
-        class_name: "java/security/ProtectionDomain".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "codeSource".to_string(),
-            descriptor: "Ljava/security/CodeSource;".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(protection_domain_ctx);
-    registry.natives_mut().register(
-        "java/security/ProtectionDomain",
-        "getCodeSource",
-        "()Ljava/security/CodeSource;",
-        native_protection_domain_get_code_source,
-    );
-
-    let code_source_ctx = ClassContext {
-        class_name: "java/security/CodeSource".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "location".to_string(),
-            descriptor: "Ljava/net/URL;".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(code_source_ctx);
-    registry.natives_mut().register(
-        "java/security/CodeSource",
-        "getLocation",
-        "()Ljava/net/URL;",
-        native_code_source_get_location,
-    );
-
-    let url_ctx = ClassContext {
-        class_name: "java/net/URL".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "spec".to_string(),
-            descriptor: "Ljava/lang/String;".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(url_ctx);
-    registry.natives_mut().register(
-        "java/net/URL",
-        "toURI",
-        "()Ljava/net/URI;",
-        native_url_to_uri,
-    );
-    registry.natives_mut().register(
-        "java/net/URL",
-        "setURLStreamHandlerFactory",
-        "(Ljava/net/URLStreamHandlerFactory;)V",
-        native_url_set_url_stream_handler_factory,
-    );
-
-    let uri_ctx = ClassContext {
-        class_name: "java/net/URI".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "spec".to_string(),
-            descriptor: "Ljava/lang/String;".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(uri_ctx);
-
-    let path_ctx = ClassContext {
-        class_name: "java/nio/file/Path".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "path".to_string(),
-            descriptor: "Ljava/lang/String;".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(path_ctx);
-    registry.natives_mut().register(
-        "java/nio/file/Path",
-        "of",
-        "(Ljava/net/URI;)Ljava/nio/file/Path;",
-        native_path_of,
-    );
-    registry.natives_mut().register(
-        "java/nio/file/Path",
-        "toFile",
-        "()Ljava/io/File;",
-        native_path_to_file,
-    );
-    let paths_ctx = ClassContext {
-        class_name: "java/nio/file/Paths".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(paths_ctx);
-    registry.natives_mut().register(
-        "java/nio/file/Paths",
-        "get",
-        "(Ljava/lang/String;[Ljava/lang/String;)Ljava/nio/file/Path;",
-        native_paths_get,
-    );
-
-    let file_attribute_ctx = ClassContext {
-        class_name: "java/nio/file/attribute/FileAttribute".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(file_attribute_ctx);
-
-    let posix_owner_read_ref =
-        heap.allocate("java/nio/file/attribute/PosixFilePermission".to_string(), 0);
-    let posix_owner_write_ref =
-        heap.allocate("java/nio/file/attribute/PosixFilePermission".to_string(), 0);
-    let posix_owner_execute_ref =
-        heap.allocate("java/nio/file/attribute/PosixFilePermission".to_string(), 0);
-    let posix_file_permission_ctx = ClassContext {
-        class_name: "java/nio/file/attribute/PosixFilePermission".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "OWNER_READ".to_string(),
-                descriptor: "Ljava/nio/file/attribute/PosixFilePermission;".to_string(),
-                is_static: true,
-            },
-            FieldEntry {
-                name: "OWNER_WRITE".to_string(),
-                descriptor: "Ljava/nio/file/attribute/PosixFilePermission;".to_string(),
-                is_static: true,
-            },
-            FieldEntry {
-                name: "OWNER_EXECUTE".to_string(),
-                descriptor: "Ljava/nio/file/attribute/PosixFilePermission;".to_string(),
-                is_static: true,
-            },
-        ],
-        static_fields: vec![
-            Slot::Reference(Some(posix_owner_read_ref)),
-            Slot::Reference(Some(posix_owner_write_ref)),
-            Slot::Reference(Some(posix_owner_execute_ref)),
-        ],
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(posix_file_permission_ctx);
-
-    let posix_file_permissions_ctx = ClassContext {
-        class_name: "java/nio/file/attribute/PosixFilePermissions".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(posix_file_permissions_ctx);
-    registry.natives_mut().register(
-        "java/nio/file/attribute/PosixFilePermissions",
-        "asFileAttribute",
-        "(Ljava/util/Set;)Ljava/nio/file/attribute/FileAttribute;",
-        native_posix_file_permissions_as_file_attribute,
-    );
-    let boot_archive_entry_ctx = ClassContext {
-        class_name: "duke/boot/ArchiveEntry".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "name".to_string(),
-                descriptor: "Ljava/lang/String;".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "directory".to_string(),
-                descriptor: "Z".to_string(),
-                is_static: false,
-            },
-        ],
-        static_fields: Vec::new(),
-        instance_field_count: 2,
-        interfaces: vec!["org/springframework/boot/loader/launch/Archive$Entry".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(boot_archive_entry_ctx);
-    registry.natives_mut().register(
-        "duke/boot/ArchiveEntry",
-        "name",
-        "()Ljava/lang/String;",
-        native_boot_archive_entry_name,
-    );
-    registry.natives_mut().register(
-        "duke/boot/ArchiveEntry",
-        "isDirectory",
-        "()Z",
-        native_boot_archive_entry_is_directory,
-    );
-    registry.natives_mut().register_callback(
-        "org/springframework/boot/loader/launch/JarFileArchive",
-        "getClassPathUrls",
-        "(Ljava/util/function/Predicate;Ljava/util/function/Predicate;)Ljava/util/Set;",
-        native_boot_jar_file_archive_get_class_path_urls,
-    );
-    registry.natives_mut().register(
-        "org/springframework/boot/loader/launch/Archive",
-        "getManifest",
-        "()Ljava/util/jar/Manifest;",
-        native_boot_archive_get_manifest,
-    );
-    registry.natives_mut().register(
-        "org/springframework/boot/loader/launch/JarFileArchive",
-        "getManifest",
-        "()Ljava/util/jar/Manifest;",
-        native_boot_jar_file_archive_get_manifest,
-    );
-    registry.natives_mut().register_callback(
-        "org/springframework/boot/loader/launch/ExplodedArchive",
-        "getClassPathUrls",
-        "(Ljava/util/function/Predicate;Ljava/util/function/Predicate;)Ljava/util/Set;",
-        native_boot_exploded_archive_get_class_path_urls,
-    );
-    registry.natives_mut().register(
-        "org/springframework/boot/loader/launch/ExplodedArchive",
-        "getManifest",
-        "()Ljava/util/jar/Manifest;",
-        native_boot_exploded_archive_get_manifest,
-    );
-    registry.natives_mut().register_callback(
-        "org/springframework/boot/loader/launch/LaunchedClassLoader",
-        "<init>",
-        "(ZLorg/springframework/boot/loader/launch/Archive;[Ljava/net/URL;Ljava/lang/ClassLoader;)V",
-        native_boot_launched_class_loader_init,
-    );
-
-    let reflect_method_ctx = ClassContext {
-        class_name: "java/lang/reflect/Method".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "declaringClass".to_string(),
-                descriptor: "Ljava/lang/Class;".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "name".to_string(),
-                descriptor: "Ljava/lang/String;".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "descriptor".to_string(),
-                descriptor: "Ljava/lang/String;".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "publicFlag".to_string(),
-                descriptor: "Z".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "staticFlag".to_string(),
-                descriptor: "Z".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "accessibleFlag".to_string(),
-                descriptor: "Z".to_string(),
-                is_static: false,
-            },
-        ],
-        static_fields: Vec::new(),
-        instance_field_count: 6,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(reflect_method_ctx);
-    registry.natives_mut().register(
-        "java/lang/reflect/Method",
-        "getName",
-        "()Ljava/lang/String;",
-        native_reflect_method_get_name,
-    );
-    registry.natives_mut().register(
-        "java/lang/reflect/Method",
-        "getDeclaringClass",
-        "()Ljava/lang/Class;",
-        native_reflection_member_get_declaring_class,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/reflect/Method",
-        "getReturnType",
-        "()Ljava/lang/Class;",
-        native_reflect_method_get_return_type,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/reflect/Method",
-        "invoke",
-        "(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;",
-        native_reflect_method_invoke,
-    );
-    registry.natives_mut().register(
-        "java/lang/reflect/Method",
-        "setAccessible",
-        "(Z)V",
-        native_reflection_member_set_accessible,
-    );
-    registry.natives_mut().register(
-        "java/lang/reflect/Method",
-        "getParameterCount",
-        "()I",
-        native_reflect_method_get_parameter_count,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/reflect/Method",
-        "getParameterTypes",
-        "()[Ljava/lang/Class;",
-        native_reflect_executable_get_parameter_types,
-    );
-
-    let reflect_constructor_ctx = ClassContext {
-        class_name: "java/lang/reflect/Constructor".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "declaringClass".to_string(),
-                descriptor: "Ljava/lang/Class;".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "name".to_string(),
-                descriptor: "Ljava/lang/String;".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "descriptor".to_string(),
-                descriptor: "Ljava/lang/String;".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "publicFlag".to_string(),
-                descriptor: "Z".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "staticFlag".to_string(),
-                descriptor: "Z".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "accessibleFlag".to_string(),
-                descriptor: "Z".to_string(),
-                is_static: false,
-            },
-        ],
-        static_fields: Vec::new(),
-        instance_field_count: 6,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(reflect_constructor_ctx);
-    registry.natives_mut().register(
-        "java/lang/reflect/Constructor",
-        "getName",
-        "()Ljava/lang/String;",
-        native_reflect_constructor_get_name,
-    );
-    registry.natives_mut().register(
-        "java/lang/reflect/Constructor",
-        "getDeclaringClass",
-        "()Ljava/lang/Class;",
-        native_reflection_member_get_declaring_class,
-    );
-    registry.natives_mut().register(
-        "java/lang/reflect/Constructor",
-        "setAccessible",
-        "(Z)V",
-        native_reflection_member_set_accessible,
-    );
-    registry.natives_mut().register(
-        "java/lang/reflect/Constructor",
-        "getParameterCount",
-        "()I",
-        native_reflect_method_get_parameter_count,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/reflect/Constructor",
-        "getParameterTypes",
-        "()[Ljava/lang/Class;",
-        native_reflect_executable_get_parameter_types,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/reflect/Constructor",
-        "newInstance",
-        "([Ljava/lang/Object;)Ljava/lang/Object;",
-        native_reflect_constructor_new_instance,
-    );
-
-    let reflect_field_ctx = ClassContext {
-        class_name: "java/lang/reflect/Field".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "declaringClass".to_string(),
-                descriptor: "Ljava/lang/Class;".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "name".to_string(),
-                descriptor: "Ljava/lang/String;".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "descriptor".to_string(),
-                descriptor: "Ljava/lang/String;".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "publicFlag".to_string(),
-                descriptor: "Z".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "staticFlag".to_string(),
-                descriptor: "Z".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "accessibleFlag".to_string(),
-                descriptor: "Z".to_string(),
-                is_static: false,
-            },
-        ],
-        static_fields: Vec::new(),
-        instance_field_count: 6,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(reflect_field_ctx);
-    registry.natives_mut().register(
-        "java/lang/reflect/Field",
-        "getName",
-        "()Ljava/lang/String;",
-        native_reflect_field_get_name,
-    );
-    registry.natives_mut().register(
-        "java/lang/reflect/Field",
-        "getDeclaringClass",
-        "()Ljava/lang/Class;",
-        native_reflection_member_get_declaring_class,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/reflect/Field",
-        "getType",
-        "()Ljava/lang/Class;",
-        native_reflect_field_get_type,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/reflect/Field",
-        "get",
-        "(Ljava/lang/Object;)Ljava/lang/Object;",
-        native_reflect_field_get,
-    );
-    registry.natives_mut().register_callback(
-        "java/lang/reflect/Field",
-        "set",
-        "(Ljava/lang/Object;Ljava/lang/Object;)V",
-        native_reflect_field_set,
-    );
-    registry.natives_mut().register(
-        "java/lang/reflect/Field",
-        "setAccessible",
-        "(Z)V",
-        native_reflection_member_set_accessible,
-    );
-
-    let runnable_ctx = ClassContext {
-        class_name: "java/lang/Runnable".to_string(),
-        super_class: None,
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(runnable_ctx);
-
-    let class_loader_ctx = ClassContext {
-        class_name: "java/lang/ClassLoader".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(class_loader_ctx);
-    registry.natives_mut().register(
-        "java/lang/ClassLoader",
-        "registerAsParallelCapable",
-        "()Z",
-        native_class_loader_register_as_parallel_capable,
-    );
-
-    let thread_ctx = ClassContext {
-        class_name: "java/lang/Thread".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "target".to_string(),
-                descriptor: "Ljava/lang/Runnable;".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "threadId".to_string(),
-                descriptor: "I".to_string(),
-                is_static: false,
-            },
-        ],
-        static_fields: Vec::new(),
-        instance_field_count: 2,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(thread_ctx);
-    registry
-        .natives_mut()
-        .register("java/lang/Thread", "<init>", "()V", native_thread_init);
-    registry.natives_mut().register(
-        "java/lang/Thread",
-        "<init>",
-        "(Ljava/lang/Runnable;)V",
-        native_thread_init_runnable,
-    );
-    registry.natives_mut().register(
-        "java/lang/Thread",
-        "currentThread",
-        "()Ljava/lang/Thread;",
-        native_thread_current_thread,
-    );
-    registry
-        .natives_mut()
-        .register("java/lang/Thread", "start", "()V", native_thread_start);
-    registry
-        .natives_mut()
-        .register("java/lang/Thread", "join", "()V", native_thread_join);
-    registry
-        .natives_mut()
-        .register("java/lang/Thread", "sleep", "(J)V", native_thread_sleep);
-    registry.natives_mut().register(
-        "java/lang/Thread",
-        "setContextClassLoader",
-        "(Ljava/lang/ClassLoader;)V",
-        native_void_noop,
-    );
-
-    // java/lang/Throwable extends Object
-    let throwable_ctx = ClassContext {
-        class_name: "java/lang/Throwable".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(throwable_ctx);
-    registry.natives_mut().register(
-        "java/lang/Throwable",
-        "addSuppressed",
-        "(Ljava/lang/Throwable;)V",
-        native_throwable_add_suppressed,
-    );
-    registry
-        .natives_mut()
-        .register("java/lang/Throwable", "<init>", "()V", native_object_init);
-    registry.natives_mut().register(
-        "java/lang/Throwable",
-        "<init>",
-        "(Ljava/lang/String;)V",
-        native_object_init,
-    );
-
-    // java/lang/Exception extends Throwable
-    let exception_ctx = ClassContext {
-        class_name: "java/lang/Exception".to_string(),
-        super_class: Some("java/lang/Throwable".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(exception_ctx);
-    registry
-        .natives_mut()
-        .register("java/lang/Exception", "<init>", "()V", native_object_init);
-    registry.natives_mut().register(
-        "java/lang/Exception",
-        "<init>",
-        "(Ljava/lang/String;)V",
-        native_object_init,
-    );
-
-    // java/lang/RuntimeException extends Exception
-    let rte_ctx = ClassContext {
-        class_name: "java/lang/RuntimeException".to_string(),
-        super_class: Some("java/lang/Exception".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(rte_ctx);
-    registry.natives_mut().register(
-        "java/lang/RuntimeException",
-        "<init>",
-        "()V",
-        native_object_init,
-    );
-    registry.natives_mut().register(
-        "java/lang/RuntimeException",
-        "<init>",
-        "(Ljava/lang/String;)V",
-        native_object_init,
-    );
-
-    let illegal_argument_ctx = ClassContext {
-        class_name: "java/lang/IllegalArgumentException".to_string(),
-        super_class: Some("java/lang/RuntimeException".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(illegal_argument_ctx);
-
-    let illegal_thread_state_ctx = ClassContext {
-        class_name: "java/lang/IllegalThreadStateException".to_string(),
-        super_class: Some("java/lang/IllegalArgumentException".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(illegal_thread_state_ctx);
-
-    let reflective_operation_ctx = ClassContext {
-        class_name: "java/lang/ReflectiveOperationException".to_string(),
-        super_class: Some("java/lang/Exception".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(reflective_operation_ctx);
-
-    let class_not_found_ctx = ClassContext {
-        class_name: "java/lang/ClassNotFoundException".to_string(),
-        super_class: Some("java/lang/ReflectiveOperationException".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(class_not_found_ctx);
-
-    let no_such_method_ctx = ClassContext {
-        class_name: "java/lang/NoSuchMethodException".to_string(),
-        super_class: Some("java/lang/ReflectiveOperationException".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(no_such_method_ctx);
-
-    let no_such_field_ctx = ClassContext {
-        class_name: "java/lang/NoSuchFieldException".to_string(),
-        super_class: Some("java/lang/ReflectiveOperationException".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(no_such_field_ctx);
-
-    let illegal_access_ctx = ClassContext {
-        class_name: "java/lang/IllegalAccessException".to_string(),
-        super_class: Some("java/lang/ReflectiveOperationException".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(illegal_access_ctx);
-
-    let instantiation_ctx = ClassContext {
-        class_name: "java/lang/InstantiationException".to_string(),
-        super_class: Some("java/lang/ReflectiveOperationException".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(instantiation_ctx);
-
-    let invocation_target_ctx = ClassContext {
-        class_name: "java/lang/reflect/InvocationTargetException".to_string(),
-        super_class: Some("java/lang/ReflectiveOperationException".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(invocation_target_ctx);
-
-    // java/lang/AutoCloseable — marker interface for try-with-resources.
-    // Registered so is_assignable_from correctly handles queries like
-    // "does TryWithResources$Res implement AutoCloseable?" without
-    // erroring on an unknown class.
-    let autocloseable_ctx = ClassContext {
-        class_name: "java/lang/AutoCloseable".to_string(),
-        super_class: None, // interface — no super class
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(autocloseable_ctx);
-
-    // java/lang/Enum — abstract superclass for all enums.
-    // Fields: name (String) at index 0, ordinal (int) at index 1.
-    let enum_ctx = ClassContext {
-        class_name: "java/lang/Enum".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "name".to_string(),
-                descriptor: "Ljava/lang/String;".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "ordinal".to_string(),
-                descriptor: "I".to_string(),
-                is_static: false,
-            },
-        ],
-        static_fields: Vec::new(),
-        instance_field_count: 2,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(enum_ctx);
-    registry.natives_mut().register(
-        "java/lang/Enum",
-        "<init>",
-        "(Ljava/lang/String;I)V",
-        native_enum_init,
-    );
-    registry
-        .natives_mut()
-        .register("java/lang/Enum", "ordinal", "()I", native_enum_ordinal);
-    registry.natives_mut().register(
-        "java/lang/Enum",
-        "name",
-        "()Ljava/lang/String;",
-        native_enum_name,
-    );
-    registry.natives_mut().register(
-        "java/lang/Enum",
-        "valueOf",
-        "(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;",
-        native_enum_valueof,
-    );
-
-    // java/lang/Integer — boxed int with value field + numeric constants
-    let integer_ctx = ClassContext {
-        class_name: "java/lang/Integer".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "value".to_string(),
-                descriptor: "I".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "MAX_VALUE".to_string(),
-                descriptor: "I".to_string(),
-                is_static: true,
-            },
-            FieldEntry {
-                name: "MIN_VALUE".to_string(),
-                descriptor: "I".to_string(),
-                is_static: true,
-            },
-            FieldEntry {
-                name: "TYPE".to_string(),
-                descriptor: "Ljava/lang/Class;".to_string(),
-                is_static: true,
-            },
-        ],
-        static_fields: vec![
-            Slot::Int(i32::MAX),
-            Slot::Int(i32::MIN),
-            Slot::Reference(None),
-        ],
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/Comparable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(integer_ctx);
-    registry.natives_mut().register(
-        "java/lang/Integer",
-        "parseInt",
-        "(Ljava/lang/String;)I",
-        native_integer_parseint,
-    );
-    registry.natives_mut().register(
-        "java/lang/Integer",
-        "parseInt",
-        "(Ljava/lang/String;I)I",
-        native_integer_parseint_radix,
-    );
-    registry.natives_mut().register(
-        "java/lang/Integer",
-        "valueOf",
-        "(Ljava/lang/String;)Ljava/lang/Integer;",
-        native_integer_valueof_string,
-    );
-    registry.natives_mut().register(
-        "java/lang/Integer",
-        "valueOf",
-        "(Ljava/lang/String;I)Ljava/lang/Integer;",
-        native_integer_valueof_string_radix,
-    );
-    registry.natives_mut().register(
-        "java/lang/Integer",
-        "decode",
-        "(Ljava/lang/String;)Ljava/lang/Integer;",
-        native_integer_decode,
-    );
-    registry.natives_mut().register(
-        "java/lang/Integer",
-        "valueOf",
-        "(I)Ljava/lang/Integer;",
-        native_integer_valueof,
-    );
-    registry.natives_mut().register(
-        "java/lang/Integer",
-        "intValue",
-        "()I",
-        native_integer_intvalue,
-    );
-    registry.natives_mut().register(
-        "java/lang/Integer",
-        "toString",
-        "(I)Ljava/lang/String;",
-        native_integer_tostring_static,
-    );
-    registry.natives_mut().register(
-        "java/lang/Integer",
-        "toHexString",
-        "(I)Ljava/lang/String;",
-        native_integer_tohexstring_static,
-    );
-    registry.natives_mut().register(
-        "java/lang/Integer",
-        "toOctalString",
-        "(I)Ljava/lang/String;",
-        native_integer_tooctalstring_static,
-    );
-    registry.natives_mut().register(
-        "java/lang/Integer",
-        "toBinaryString",
-        "(I)Ljava/lang/String;",
-        native_integer_tobinarystring_static,
-    );
-    registry.natives_mut().register(
-        "java/lang/Integer",
-        "toUnsignedLong",
-        "(I)J",
-        native_integer_tounsignedlong_static,
-    );
-    registry.natives_mut().register(
-        "java/lang/Integer",
-        "compareUnsigned",
-        "(II)I",
-        native_integer_compareunsigned_static,
-    );
-    registry.natives_mut().register(
-        "java/lang/Integer",
-        "compareTo",
-        "(Ljava/lang/Object;)I",
-        native_integer_compareto,
-    );
-    registry.natives_mut().register(
-        "java/lang/Integer",
-        "compareTo",
-        "(Ljava/lang/Integer;)I",
-        native_integer_compareto,
-    );
-
-    // java/lang/Long — boxed long with value field + numeric constants
-    let long_ctx = ClassContext {
-        class_name: "java/lang/Long".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "value".to_string(),
-                descriptor: "J".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "MAX_VALUE".to_string(),
-                descriptor: "J".to_string(),
-                is_static: true,
-            },
-            FieldEntry {
-                name: "MIN_VALUE".to_string(),
-                descriptor: "J".to_string(),
-                is_static: true,
-            },
-            FieldEntry {
-                name: "TYPE".to_string(),
-                descriptor: "Ljava/lang/Class;".to_string(),
-                is_static: true,
-            },
-        ],
-        static_fields: vec![
-            Slot::Long(i64::MAX),
-            Slot::Long(i64::MIN),
-            Slot::Reference(None),
-        ],
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/Comparable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(long_ctx);
-    registry.natives_mut().register(
-        "java/lang/Long",
-        "parseLong",
-        "(Ljava/lang/String;)J",
-        native_long_parselong,
-    );
-    registry.natives_mut().register(
-        "java/lang/Long",
-        "parseLong",
-        "(Ljava/lang/String;I)J",
-        native_long_parselong_radix,
-    );
-    registry.natives_mut().register(
-        "java/lang/Long",
-        "valueOf",
-        "(Ljava/lang/String;)Ljava/lang/Long;",
-        native_long_valueof_string,
-    );
-    registry.natives_mut().register(
-        "java/lang/Long",
-        "valueOf",
-        "(Ljava/lang/String;I)Ljava/lang/Long;",
-        native_long_valueof_string_radix,
-    );
-    registry.natives_mut().register(
-        "java/lang/Long",
-        "decode",
-        "(Ljava/lang/String;)Ljava/lang/Long;",
-        native_long_decode,
-    );
-    registry.natives_mut().register(
-        "java/lang/Long",
-        "valueOf",
-        "(J)Ljava/lang/Long;",
-        native_long_valueof,
-    );
-    registry
-        .natives_mut()
-        .register("java/lang/Long", "longValue", "()J", native_long_longvalue);
-    registry.natives_mut().register(
-        "java/lang/Long",
-        "toString",
-        "(J)Ljava/lang/String;",
-        native_long_tostring_static,
-    );
-    registry.natives_mut().register(
-        "java/lang/Long",
-        "toHexString",
-        "(J)Ljava/lang/String;",
-        native_long_tohexstring_static,
-    );
-    registry.natives_mut().register(
-        "java/lang/Long",
-        "toOctalString",
-        "(J)Ljava/lang/String;",
-        native_long_tooctalstring_static,
-    );
-    registry.natives_mut().register(
-        "java/lang/Long",
-        "toBinaryString",
-        "(J)Ljava/lang/String;",
-        native_long_tobinarystring_static,
-    );
-    registry.natives_mut().register(
-        "java/lang/Long",
-        "compareUnsigned",
-        "(JJ)I",
-        native_long_compareunsigned_static,
-    );
-    registry.natives_mut().register(
-        "java/lang/Long",
-        "compareTo",
-        "(Ljava/lang/Object;)I",
-        native_long_compareto,
-    );
-    registry.natives_mut().register(
-        "java/lang/Long",
-        "compareTo",
-        "(Ljava/lang/Long;)I",
-        native_long_compareto,
-    );
-
-    // java/lang/Double — boxed double with value field + numeric constants
-    let double_ctx = ClassContext {
-        class_name: "java/lang/Double".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "value".to_string(),
-                descriptor: "D".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "MAX_VALUE".to_string(),
-                descriptor: "D".to_string(),
-                is_static: true,
-            },
-            FieldEntry {
-                name: "MIN_VALUE".to_string(),
-                descriptor: "D".to_string(),
-                is_static: true,
-            },
-            FieldEntry {
-                name: "NaN".to_string(),
-                descriptor: "D".to_string(),
-                is_static: true,
-            },
-            FieldEntry {
-                name: "POSITIVE_INFINITY".to_string(),
-                descriptor: "D".to_string(),
-                is_static: true,
-            },
-            FieldEntry {
-                name: "NEGATIVE_INFINITY".to_string(),
-                descriptor: "D".to_string(),
-                is_static: true,
-            },
-            FieldEntry {
-                name: "TYPE".to_string(),
-                descriptor: "Ljava/lang/Class;".to_string(),
-                is_static: true,
-            },
-        ],
-        static_fields: vec![
-            Slot::Double(f64::MAX),
-            Slot::Double(5e-324_f64),
-            Slot::Double(f64::NAN),
-            Slot::Double(f64::INFINITY),
-            Slot::Double(f64::NEG_INFINITY),
-            Slot::Reference(None),
-        ],
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/Comparable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(double_ctx);
-    registry.natives_mut().register(
-        "java/lang/Double",
-        "parseDouble",
-        "(Ljava/lang/String;)D",
-        native_double_parsedouble,
-    );
-    registry.natives_mut().register(
-        "java/lang/Double",
-        "valueOf",
-        "(D)Ljava/lang/Double;",
-        native_double_valueof,
-    );
-    registry.natives_mut().register(
-        "java/lang/Double",
-        "doubleValue",
-        "()D",
-        native_double_doublevalue,
-    );
-    registry
-        .natives_mut()
-        .register("java/lang/Double", "isNaN", "(D)Z", native_double_isnan);
-    registry.natives_mut().register(
-        "java/lang/Double",
-        "compareTo",
-        "(Ljava/lang/Object;)I",
-        native_double_compareto,
-    );
-    registry.natives_mut().register(
-        "java/lang/Double",
-        "compareTo",
-        "(Ljava/lang/Double;)I",
-        native_double_compareto,
-    );
-
-    // java/lang/Float — boxed float with value field
-    let float_ctx = ClassContext {
-        class_name: "java/lang/Float".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "value".to_string(),
-                descriptor: "F".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "TYPE".to_string(),
-                descriptor: "Ljava/lang/Class;".to_string(),
-                is_static: true,
-            },
-        ],
-        static_fields: vec![Slot::Reference(None)],
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/Comparable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(float_ctx);
-    registry.natives_mut().register(
-        "java/lang/Float",
-        "parseFloat",
-        "(Ljava/lang/String;)F",
-        native_float_parsefloat,
-    );
-    registry.natives_mut().register(
-        "java/lang/Float",
-        "valueOf",
-        "(F)Ljava/lang/Float;",
-        native_float_valueof,
-    );
-    registry.natives_mut().register(
-        "java/lang/Float",
-        "floatValue",
-        "()F",
-        native_float_floatvalue,
-    );
-    registry.natives_mut().register(
-        "java/lang/Float",
-        "compareTo",
-        "(Ljava/lang/Object;)I",
-        native_float_compareto,
-    );
-    registry.natives_mut().register(
-        "java/lang/Float",
-        "compareTo",
-        "(Ljava/lang/Float;)I",
-        native_float_compareto,
-    );
-
-    // java/lang/Boolean — boxed boolean + static utility
-    let boolean_ctx = ClassContext {
-        class_name: "java/lang/Boolean".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "value".to_string(),
-                descriptor: "Z".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "TYPE".to_string(),
-                descriptor: "Ljava/lang/Class;".to_string(),
-                is_static: true,
-            },
-        ],
-        static_fields: vec![Slot::Reference(None)],
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/Comparable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(boolean_ctx);
-    registry.natives_mut().register(
-        "java/lang/Boolean",
-        "parseBoolean",
-        "(Ljava/lang/String;)Z",
-        native_boolean_parseboolean,
-    );
-    registry.natives_mut().register(
-        "java/lang/Boolean",
-        "valueOf",
-        "(Z)Ljava/lang/Boolean;",
-        native_boolean_valueof,
-    );
-    registry.natives_mut().register(
-        "java/lang/Boolean",
-        "booleanValue",
-        "()Z",
-        native_boolean_booleanvalue,
-    );
-    registry.natives_mut().register(
-        "java/lang/Boolean",
-        "compareTo",
-        "(Ljava/lang/Object;)I",
-        native_boolean_compareto,
-    );
-    registry.natives_mut().register(
-        "java/lang/Boolean",
-        "compareTo",
-        "(Ljava/lang/Boolean;)I",
-        native_boolean_compareto,
-    );
-
-    let byte_ctx = ClassContext {
-        class_name: "java/lang/Byte".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "value".to_string(),
-                descriptor: "B".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "TYPE".to_string(),
-                descriptor: "Ljava/lang/Class;".to_string(),
-                is_static: true,
-            },
-        ],
-        static_fields: vec![Slot::Reference(None)],
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/Comparable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(byte_ctx);
-    registry.natives_mut().register(
-        "java/lang/Byte",
-        "parseByte",
-        "(Ljava/lang/String;)B",
-        native_byte_parsebyte,
-    );
-    registry.natives_mut().register(
-        "java/lang/Byte",
-        "parseByte",
-        "(Ljava/lang/String;I)B",
-        native_byte_parsebyte_radix,
-    );
-    registry.natives_mut().register(
-        "java/lang/Byte",
-        "valueOf",
-        "(Ljava/lang/String;)Ljava/lang/Byte;",
-        native_byte_valueof_string,
-    );
-    registry.natives_mut().register(
-        "java/lang/Byte",
-        "valueOf",
-        "(Ljava/lang/String;I)Ljava/lang/Byte;",
-        native_byte_valueof_string_radix,
-    );
-    registry.natives_mut().register(
-        "java/lang/Byte",
-        "valueOf",
-        "(B)Ljava/lang/Byte;",
-        native_byte_valueof,
-    );
-    registry
-        .natives_mut()
-        .register("java/lang/Byte", "byteValue", "()B", native_byte_bytevalue);
-    registry.natives_mut().register(
-        "java/lang/Byte",
-        "compareTo",
-        "(Ljava/lang/Object;)I",
-        native_byte_compareto,
-    );
-    registry.natives_mut().register(
-        "java/lang/Byte",
-        "compareTo",
-        "(Ljava/lang/Byte;)I",
-        native_byte_compareto,
-    );
-
-    let short_ctx = ClassContext {
-        class_name: "java/lang/Short".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "value".to_string(),
-                descriptor: "S".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "TYPE".to_string(),
-                descriptor: "Ljava/lang/Class;".to_string(),
-                is_static: true,
-            },
-        ],
-        static_fields: vec![Slot::Reference(None)],
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/Comparable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(short_ctx);
-    registry.natives_mut().register(
-        "java/lang/Short",
-        "parseShort",
-        "(Ljava/lang/String;)S",
-        native_short_parseshort,
-    );
-    registry.natives_mut().register(
-        "java/lang/Short",
-        "parseShort",
-        "(Ljava/lang/String;I)S",
-        native_short_parseshort_radix,
-    );
-    registry.natives_mut().register(
-        "java/lang/Short",
-        "valueOf",
-        "(Ljava/lang/String;)Ljava/lang/Short;",
-        native_short_valueof_string,
-    );
-    registry.natives_mut().register(
-        "java/lang/Short",
-        "valueOf",
-        "(Ljava/lang/String;I)Ljava/lang/Short;",
-        native_short_valueof_string_radix,
-    );
-    registry.natives_mut().register(
-        "java/lang/Short",
-        "valueOf",
-        "(S)Ljava/lang/Short;",
-        native_short_valueof,
-    );
-    registry.natives_mut().register(
-        "java/lang/Short",
-        "shortValue",
-        "()S",
-        native_short_shortvalue,
-    );
-    registry.natives_mut().register(
-        "java/lang/Short",
-        "compareTo",
-        "(Ljava/lang/Object;)I",
-        native_short_compareto,
-    );
-    registry.natives_mut().register(
-        "java/lang/Short",
-        "compareTo",
-        "(Ljava/lang/Short;)I",
-        native_short_compareto,
-    );
-
-    let void_ctx = ClassContext {
-        class_name: "java/lang/Void".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "TYPE".to_string(),
-            descriptor: "Ljava/lang/Class;".to_string(),
-            is_static: true,
-        }],
-        static_fields: vec![Slot::Reference(None)],
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(void_ctx);
-
-    // java/lang/Math — static math utilities with PI and E constants
-    let math_ctx = ClassContext {
-        class_name: "java/lang/Math".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "PI".to_string(),
-                descriptor: "D".to_string(),
-                is_static: true,
-            },
-            FieldEntry {
-                name: "E".to_string(),
-                descriptor: "D".to_string(),
-                is_static: true,
-            },
-        ],
-        static_fields: vec![
-            Slot::Double(std::f64::consts::PI),
-            Slot::Double(std::f64::consts::E),
-        ],
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(math_ctx);
-    registry
-        .natives_mut()
-        .register("java/lang/Math", "max", "(II)I", native_math_max_int);
-    registry
-        .natives_mut()
-        .register("java/lang/Math", "min", "(II)I", native_math_min_int);
-    registry
-        .natives_mut()
-        .register("java/lang/Math", "abs", "(I)I", native_math_abs_int);
-    registry.natives_mut().register(
-        "java/lang/Math",
-        "floorMod",
-        "(II)I",
-        native_math_floor_mod_int,
-    );
-    registry
-        .natives_mut()
-        .register("java/lang/Math", "sqrt", "(D)D", native_math_sqrt);
-    registry
-        .natives_mut()
-        .register("java/lang/Math", "pow", "(DD)D", native_math_pow);
-    registry
-        .natives_mut()
-        .register("java/lang/Math", "floor", "(D)D", native_math_floor);
-    registry
-        .natives_mut()
-        .register("java/lang/Math", "ceil", "(D)D", native_math_ceil);
-    registry
-        .natives_mut()
-        .register("java/lang/Math", "round", "(D)J", native_math_round_double);
-    registry
-        .natives_mut()
-        .register("java/lang/Math", "abs", "(J)J", native_math_abs_long);
-    registry
-        .natives_mut()
-        .register("java/lang/Math", "abs", "(D)D", native_math_abs_double);
-    registry
-        .natives_mut()
-        .register("java/lang/Math", "max", "(JJ)J", native_math_max_long);
-    registry
-        .natives_mut()
-        .register("java/lang/Math", "min", "(JJ)J", native_math_min_long);
-    registry
-        .natives_mut()
-        .register("java/lang/Math", "max", "(DD)D", native_math_max_double);
-    registry
-        .natives_mut()
-        .register("java/lang/Math", "min", "(DD)D", native_math_min_double);
-
-    // String.valueOf overloads (int already registered above)
-    registry.natives_mut().register(
-        "java/lang/String",
-        "valueOf",
-        "(J)Ljava/lang/String;",
-        native_string_value_of_long,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "valueOf",
-        "(D)Ljava/lang/String;",
-        native_string_value_of_double,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "valueOf",
-        "(F)Ljava/lang/String;",
-        native_string_value_of_float,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "valueOf",
-        "(Z)Ljava/lang/String;",
-        native_string_value_of_boolean,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "valueOf",
-        "(C)Ljava/lang/String;",
-        native_string_value_of_char,
-    );
-    registry.natives_mut().register(
-        "java/lang/String",
-        "valueOf",
-        "(Ljava/lang/Object;)Ljava/lang/String;",
-        native_string_value_of_object,
-    );
-
-    // String.concat
-    registry.natives_mut().register(
-        "java/lang/String",
-        "concat",
-        "(Ljava/lang/String;)Ljava/lang/String;",
-        native_string_concat,
-    );
-
-    // String.format(String, Object[]) -> String
-    registry.natives_mut().register(
-        "java/lang/String",
-        "format",
-        "(Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;",
-        native_string_format,
-    );
-
-    // java/lang/StringBuilder — mutable string buffer
-    let sb_ctx = ClassContext {
-        class_name: "java/lang/StringBuilder".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: vec!["java/lang/CharSequence".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(sb_ctx);
-
-    // StringBuilder.<init>()V
-    registry
-        .natives_mut()
-        .register("java/lang/StringBuilder", "<init>", "()V", native_sb_init);
-    // StringBuilder.<init>(String)V
-    registry.natives_mut().register(
-        "java/lang/StringBuilder",
-        "<init>",
-        "(Ljava/lang/String;)V",
-        native_sb_init_string,
-    );
-    // StringBuilder.append(String)
-    registry.natives_mut().register(
-        "java/lang/StringBuilder",
-        "append",
-        "(Ljava/lang/String;)Ljava/lang/StringBuilder;",
-        native_sb_append_string,
-    );
-    // StringBuilder.append(int)
-    registry.natives_mut().register(
-        "java/lang/StringBuilder",
-        "append",
-        "(I)Ljava/lang/StringBuilder;",
-        native_sb_append_int,
-    );
-    // StringBuilder.append(long)
-    registry.natives_mut().register(
-        "java/lang/StringBuilder",
-        "append",
-        "(J)Ljava/lang/StringBuilder;",
-        native_sb_append_long,
-    );
-    // StringBuilder.append(double)
-    registry.natives_mut().register(
-        "java/lang/StringBuilder",
-        "append",
-        "(D)Ljava/lang/StringBuilder;",
-        native_sb_append_double,
-    );
-    // StringBuilder.append(float)
-    registry.natives_mut().register(
-        "java/lang/StringBuilder",
-        "append",
-        "(F)Ljava/lang/StringBuilder;",
-        native_sb_append_float,
-    );
-    // StringBuilder.append(boolean)
-    registry.natives_mut().register(
-        "java/lang/StringBuilder",
-        "append",
-        "(Z)Ljava/lang/StringBuilder;",
-        native_sb_append_boolean,
-    );
-    // StringBuilder.append(char)
-    registry.natives_mut().register(
-        "java/lang/StringBuilder",
-        "append",
-        "(C)Ljava/lang/StringBuilder;",
-        native_sb_append_char,
-    );
-    // StringBuilder.toString()
-    registry.natives_mut().register(
-        "java/lang/StringBuilder",
-        "toString",
-        "()Ljava/lang/String;",
-        native_sb_tostring,
-    );
-    // StringBuilder.length()
-    registry
-        .natives_mut()
-        .register("java/lang/StringBuilder", "length", "()I", native_sb_length);
-
-    // java/lang/Character — static character utilities + boxed char
-    let character_ctx = ClassContext {
-        class_name: "java/lang/Character".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "value".to_string(),
-                descriptor: "C".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "TYPE".to_string(),
-                descriptor: "Ljava/lang/Class;".to_string(),
-                is_static: true,
-            },
-        ],
-        static_fields: vec![Slot::Reference(None)],
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/Comparable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(character_ctx);
-
-    // Character.isDigit(C)Z
-    registry.natives_mut().register(
-        "java/lang/Character",
-        "isDigit",
-        "(C)Z",
-        native_char_is_digit,
-    );
-    // Character.isLetter(C)Z
-    registry.natives_mut().register(
-        "java/lang/Character",
-        "isLetter",
-        "(C)Z",
-        native_char_is_letter,
-    );
-    // Character.isWhitespace(C)Z
-    registry.natives_mut().register(
-        "java/lang/Character",
-        "isWhitespace",
-        "(C)Z",
-        native_char_is_whitespace,
-    );
-    // Character.isUpperCase(C)Z
-    registry.natives_mut().register(
-        "java/lang/Character",
-        "isUpperCase",
-        "(C)Z",
-        native_char_is_uppercase,
-    );
-    // Character.isLowerCase(C)Z
-    registry.natives_mut().register(
-        "java/lang/Character",
-        "isLowerCase",
-        "(C)Z",
-        native_char_is_lowercase,
-    );
-    // Character.toUpperCase(C)C
-    registry.natives_mut().register(
-        "java/lang/Character",
-        "toUpperCase",
-        "(C)C",
-        native_char_to_uppercase,
-    );
-    // Character.toLowerCase(C)C
-    registry.natives_mut().register(
-        "java/lang/Character",
-        "toLowerCase",
-        "(C)C",
-        native_char_to_lowercase,
-    );
-    // Character.isLetterOrDigit(C)Z
-    registry.natives_mut().register(
-        "java/lang/Character",
-        "isLetterOrDigit",
-        "(C)Z",
-        native_char_is_letter_or_digit,
-    );
-    // Character.valueOf(C)Ljava/lang/Character;
-    registry.natives_mut().register(
-        "java/lang/Character",
-        "valueOf",
-        "(C)Ljava/lang/Character;",
-        native_char_valueof,
-    );
-    // Character.charValue()C
-    registry.natives_mut().register(
-        "java/lang/Character",
-        "charValue",
-        "()C",
-        native_char_charvalue,
-    );
-    registry.natives_mut().register(
-        "java/lang/Character",
-        "compareTo",
-        "(Ljava/lang/Object;)I",
-        native_char_compareto,
-    );
-    registry.natives_mut().register(
-        "java/lang/Character",
-        "compareTo",
-        "(Ljava/lang/Character;)I",
-        native_char_compareto,
-    );
-
-    let collection_ctx = ClassContext {
-        class_name: "java/util/Collection".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(collection_ctx);
-    registry.natives_mut().register(
-        "java/util/Collection",
-        "toArray",
-        "()[Ljava/lang/Object;",
-        native_collection_to_array,
-    );
-    registry.natives_mut().register(
-        "java/util/Collection",
-        "toArray",
-        "([Ljava/lang/Object;)[Ljava/lang/Object;",
-        native_collection_to_array_with_seed_array,
-    );
-
-    // java/util/ArrayList — dynamic list backed by growable fields
-    // fields[0] = size (Int), fields[1..] = elements (pushed dynamically)
-    let arraylist_ctx = ClassContext {
-        class_name: "java/util/ArrayList".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "size".to_string(),
-            descriptor: "I".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: vec![
-            "java/util/List".to_string(),
-            "java/util/Collection".to_string(),
-            "java/lang/Iterable".to_string(),
-        ],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(arraylist_ctx);
-    registry.natives_mut().register(
-        "java/util/ArrayList",
-        "<init>",
-        "()V",
-        native_arraylist_init,
-    );
-    registry.natives_mut().register(
-        "java/util/ArrayList",
-        "add",
-        "(Ljava/lang/Object;)Z",
-        native_arraylist_add,
-    );
-    registry.natives_mut().register(
-        "java/util/ArrayList",
-        "get",
-        "(I)Ljava/lang/Object;",
-        native_arraylist_get,
-    );
-    registry
-        .natives_mut()
-        .register("java/util/ArrayList", "size", "()I", native_arraylist_size);
-    registry.natives_mut().register(
-        "java/util/ArrayList",
-        "toArray",
-        "()[Ljava/lang/Object;",
-        native_collection_to_array,
-    );
-    registry.natives_mut().register(
-        "java/util/ArrayList",
-        "toArray",
-        "([Ljava/lang/Object;)[Ljava/lang/Object;",
-        native_collection_to_array_with_seed_array,
-    );
-    registry.natives_mut().register(
-        "java/util/ArrayList",
-        "iterator",
-        "()Ljava/util/Iterator;",
-        native_arraylist_iterator,
-    );
-    registry.natives_mut().register_callback(
-        "java/util/ArrayList",
-        "sort",
-        "(Ljava/util/Comparator;)V",
-        array_list_sort,
-    );
-
-    // duke/util/ArrayListIterator — internal iterator for ArrayList
-    // fields[0] = ArrayList reference, fields[1] = current index (Int)
-    let iter_ctx = ClassContext {
-        class_name: "duke/util/ArrayListIterator".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "list".to_string(),
-                descriptor: "Ljava/util/ArrayList;".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "index".to_string(),
-                descriptor: "I".to_string(),
-                is_static: false,
-            },
-        ],
-        static_fields: Vec::new(),
-        instance_field_count: 2,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(iter_ctx);
-    registry.natives_mut().register(
-        "duke/util/ArrayListIterator",
-        "<init>",
-        "()V",
-        native_arraylist_iter_init,
-    );
-    registry.natives_mut().register(
-        "duke/util/ArrayListIterator",
-        "hasNext",
-        "()Z",
-        native_arraylist_iter_hasnext,
-    );
-    registry.natives_mut().register(
-        "duke/util/ArrayListIterator",
-        "next",
-        "()Ljava/lang/Object;",
-        native_arraylist_iter_next,
-    );
-
-    // java/util/Arrays — static array utilities
-    let arrays_ctx = ClassContext {
-        class_name: "java/util/Arrays".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(arrays_ctx);
-    registry
-        .natives_mut()
-        .register("java/util/Arrays", "fill", "([II)V", native_arrays_fill_int);
-    registry.natives_mut().register(
-        "java/util/Arrays",
-        "fill",
-        "([Ljava/lang/Object;Ljava/lang/Object;)V",
-        native_arrays_fill_object,
-    );
-    registry.natives_mut().register(
-        "java/util/Arrays",
-        "copyOf",
-        "([II)[I",
-        native_arrays_copyof_int,
-    );
-    registry.natives_mut().register(
-        "java/util/Arrays",
-        "copyOf",
-        "([Ljava/lang/Object;I)[Ljava/lang/Object;",
-        native_arrays_copyof_object,
-    );
-    registry
-        .natives_mut()
-        .register("java/util/Arrays", "sort", "([I)V", native_arrays_sort_int);
-
-    // java/util/HashMap — hash map backed by flat key/value pair list in fields
-    // fields[0] = Int(size), fields[1]=key0, fields[2]=val0, fields[3]=key1, ...
-    let hashmap_ctx = ClassContext {
-        class_name: "java/util/HashMap".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "size".to_string(),
-            descriptor: "I".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(hashmap_ctx);
-    registry
-        .natives_mut()
-        .register("java/util/HashMap", "<init>", "()V", native_hashmap_init);
-    registry.natives_mut().register(
-        "java/util/HashMap",
-        "put",
-        "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
-        native_hashmap_put,
-    );
-    registry.natives_mut().register(
-        "java/util/HashMap",
-        "get",
-        "(Ljava/lang/Object;)Ljava/lang/Object;",
-        native_hashmap_get,
-    );
-    registry.natives_mut().register(
-        "java/util/HashMap",
-        "containsKey",
-        "(Ljava/lang/Object;)Z",
-        native_hashmap_contains_key,
-    );
-    registry
-        .natives_mut()
-        .register("java/util/HashMap", "size", "()I", native_hashmap_size);
-    registry.natives_mut().register(
-        "java/util/HashMap",
-        "remove",
-        "(Ljava/lang/Object;)Ljava/lang/Object;",
-        native_hashmap_remove,
-    );
-    registry.natives_mut().register(
-        "java/util/HashMap",
-        "isEmpty",
-        "()Z",
-        native_hashmap_is_empty,
-    );
-    registry.natives_mut().register(
-        "java/util/HashMap",
-        "getOrDefault",
-        "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
-        native_hashmap_get_or_default,
-    );
-
-    // java/util/HashSet — set backed by unique elements in fields
-    // fields[0] = Int(size), fields[1..] = elements (unique, no duplicates)
-    let hashset_ctx = ClassContext {
-        class_name: "java/util/HashSet".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "size".to_string(),
-            descriptor: "I".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: vec![
-            "java/util/Set".to_string(),
-            "java/util/Collection".to_string(),
-            "java/lang/Iterable".to_string(),
-        ],
-        bootstrap_methods: Vec::new(),
-    };
-    let set_ctx = ClassContext {
-        class_name: "java/util/Set".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(set_ctx);
-    registry.natives_mut().register(
-        "java/util/Set",
-        "of",
-        "([Ljava/lang/Object;)Ljava/util/Set;",
-        native_set_of,
-    );
-    registry.register(hashset_ctx);
-    registry
-        .natives_mut()
-        .register("java/util/HashSet", "<init>", "()V", native_hashset_init);
-    registry.natives_mut().register_callback(
-        "java/util/HashSet",
-        "<init>",
-        "(Ljava/util/Collection;)V",
-        native_hashset_init_from_collection,
-    );
-    registry.natives_mut().register(
-        "java/util/HashSet",
-        "add",
-        "(Ljava/lang/Object;)Z",
-        native_hashset_add,
-    );
-    registry.natives_mut().register(
-        "java/util/HashSet",
-        "contains",
-        "(Ljava/lang/Object;)Z",
-        native_hashset_contains,
-    );
-    registry.natives_mut().register(
-        "java/util/HashSet",
-        "remove",
-        "(Ljava/lang/Object;)Z",
-        native_hashset_remove,
-    );
-    registry
-        .natives_mut()
-        .register("java/util/HashSet", "size", "()I", native_hashset_size);
-    registry.natives_mut().register(
-        "java/util/HashSet",
-        "isEmpty",
-        "()Z",
-        native_hashset_is_empty,
-    );
-    registry.natives_mut().register(
-        "java/util/HashSet",
-        "iterator",
-        "()Ljava/util/Iterator;",
-        native_hashset_iterator,
-    );
-    registry.natives_mut().register(
-        "java/util/HashSet",
-        "toArray",
-        "()[Ljava/lang/Object;",
-        native_collection_to_array,
-    );
-    registry.natives_mut().register(
-        "java/util/HashSet",
-        "toArray",
-        "([Ljava/lang/Object;)[Ljava/lang/Object;",
-        native_collection_to_array_with_seed_array,
-    );
-
-    let hashset_iter_ctx = ClassContext {
-        class_name: "duke/util/HashSetIterator".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "set".to_string(),
-                descriptor: "Ljava/util/HashSet;".to_string(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "index".to_string(),
-                descriptor: "I".to_string(),
-                is_static: false,
-            },
-        ],
-        static_fields: Vec::new(),
-        instance_field_count: 2,
-        interfaces: vec!["java/util/Iterator".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(hashset_iter_ctx);
-    registry.natives_mut().register(
-        "duke/util/HashSetIterator",
-        "<init>",
-        "()V",
-        native_hashset_iter_init,
-    );
-    registry.natives_mut().register(
-        "duke/util/HashSetIterator",
-        "hasNext",
-        "()Z",
-        native_hashset_iter_hasnext,
-    );
-    registry.natives_mut().register(
-        "duke/util/HashSetIterator",
-        "next",
-        "()Ljava/lang/Object;",
-        native_hashset_iter_next,
-    );
-
-    // java/util/Collections — static utility class
-    // Only sort(List) is supported; delegates to ArrayList.sort(null).
-    let collections_ctx = ClassContext {
-        class_name: "java/util/Collections".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(collections_ctx);
-    registry.natives_mut().register_callback(
-        "java/util/Collections",
-        "sort",
-        "(Ljava/util/List;)V",
-        native_collections_sort,
-    );
-
-    // ── java.util.zip ──────────────────────────────────────────────────
-
-    let zip_exception_ctx = ClassContext {
-        class_name: "java/util/zip/ZipException".to_string(),
-        super_class: Some("java/io/IOException".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(zip_exception_ctx);
-
-    // ZipEntry: [name: Ref, compressedSize_lo: Int, compressedSize_hi: Int,
-    //            size_lo: Int, size_hi: Int, method: Int]  → 6 fields
-    let zip_entry_ctx = ClassContext {
-        class_name: "java/util/zip/ZipEntry".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![
-            FieldEntry {
-                name: "name".into(),
-                descriptor: "Ljava/lang/String;".into(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "compressedSize_lo".into(),
-                descriptor: "I".into(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "compressedSize_hi".into(),
-                descriptor: "I".into(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "size_lo".into(),
-                descriptor: "I".into(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "size_hi".into(),
-                descriptor: "I".into(),
-                is_static: false,
-            },
-            FieldEntry {
-                name: "method".into(),
-                descriptor: "I".into(),
-                is_static: false,
-            },
-        ],
-        static_fields: Vec::new(),
-        instance_field_count: 6,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(zip_entry_ctx);
-    registry.natives_mut().register(
-        "java/util/zip/ZipEntry",
-        "getName",
-        "()Ljava/lang/String;",
-        native_zip_entry_get_name,
-    );
-    registry.natives_mut().register(
-        "java/util/zip/ZipEntry",
-        "getCompressedSize",
-        "()J",
-        native_zip_entry_get_compressed_size,
-    );
-    registry.natives_mut().register(
-        "java/util/zip/ZipEntry",
-        "getSize",
-        "()J",
-        native_zip_entry_get_size,
-    );
-    registry.natives_mut().register(
-        "java/util/zip/ZipEntry",
-        "getMethod",
-        "()I",
-        native_zip_entry_get_method,
-    );
-
-    // ZipFile: [fd: Int] → 1 field
-    let zip_file_ctx = ClassContext {
-        class_name: "java/util/zip/ZipFile".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "fd".into(),
-            descriptor: "I".into(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/AutoCloseable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(zip_file_ctx);
-    registry.natives_mut().register(
-        "java/util/zip/ZipFile",
-        "<init>",
-        "(Ljava/lang/String;)V",
-        native_zip_file_init,
-    );
-    registry.natives_mut().register(
-        "java/util/zip/ZipFile",
-        "getEntry",
-        "(Ljava/lang/String;)Ljava/util/zip/ZipEntry;",
-        native_zip_file_get_entry,
-    );
-    registry.natives_mut().register(
-        "java/util/zip/ZipFile",
-        "getInputStream",
-        "(Ljava/util/zip/ZipEntry;)Ljava/io/InputStream;",
-        native_zip_file_get_input_stream,
-    );
-    registry.natives_mut().register(
-        "java/util/zip/ZipFile",
-        "close",
-        "()V",
-        native_zip_file_close,
-    );
-    registry
-        .natives_mut()
-        .register("java/util/zip/ZipFile", "size", "()I", native_zip_file_size);
-
-    // JarFile extends ZipFile — inherits everything for now.
-    let jar_file_ctx = ClassContext {
-        class_name: "java/util/jar/JarFile".to_string(),
-        super_class: Some("java/util/zip/ZipFile".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
-        instance_field_count: 0,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(jar_file_ctx);
-    registry.natives_mut().register(
-        "java/util/jar/JarFile",
-        "<init>",
-        "(Ljava/io/File;)V",
-        native_jar_file_init_from_file,
-    );
-    registry.natives_mut().register(
-        "java/util/jar/JarFile",
-        "<init>",
-        "(Ljava/io/File;ZILjava/lang/Runtime$Version;)V",
-        native_jar_file_init_with_mode_and_version,
-    );
-    registry.natives_mut().register(
-        "java/util/jar/JarFile",
-        "getManifest",
-        "()Ljava/util/jar/Manifest;",
-        native_jar_file_get_manifest,
-    );
-    registry.natives_mut().register(
-        "org/springframework/boot/loader/jar/NestedJarFile",
-        "getManifest",
-        "()Ljava/util/jar/Manifest;",
-        native_boot_nested_jar_file_get_manifest,
-    );
-    registry.natives_mut().register(
-        "org/springframework/boot/loader/net/protocol/jar/UrlJarFile",
-        "getManifest",
-        "()Ljava/util/jar/Manifest;",
-        native_boot_nested_jar_file_get_manifest,
-    );
-    registry.natives_mut().register(
-        "org/springframework/boot/loader/net/protocol/jar/UrlNestedJarFile",
-        "getManifest",
-        "()Ljava/util/jar/Manifest;",
-        native_boot_nested_jar_file_get_manifest,
-    );
-
-    let manifest_ctx = ClassContext {
-        class_name: "java/util/jar/Manifest".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "raw".to_string(),
-            descriptor: "Ljava/lang/String;".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(manifest_ctx);
-    registry.natives_mut().register(
-        "java/util/jar/Manifest",
-        "getMainAttributes",
-        "()Ljava/util/jar/Attributes;",
-        native_manifest_get_main_attributes,
-    );
-
-    let attributes_ctx = ClassContext {
-        class_name: "java/util/jar/Attributes".to_string(),
-        super_class: Some("java/lang/Object".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "raw".to_string(),
-            descriptor: "Ljava/lang/String;".to_string(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: Vec::new(),
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(attributes_ctx);
-    registry.natives_mut().register(
-        "java/util/jar/Attributes",
-        "getValue",
-        "(Ljava/lang/String;)Ljava/lang/String;",
-        native_attributes_get_value,
-    );
-
-    // ByteBufferInputStream — internal class for reading decompressed ZIP data.
-    let byte_buffer_is_ctx = ClassContext {
-        class_name: "duke/zip/ByteBufferInputStream".to_string(),
-        super_class: Some("java/io/InputStream".to_string()),
-        constant_pool: Vec::new(),
-        methods: Vec::new(),
-        fields: vec![FieldEntry {
-            name: "fd".into(),
-            descriptor: "I".into(),
-            is_static: false,
-        }],
-        static_fields: Vec::new(),
-        instance_field_count: 1,
-        interfaces: vec!["java/lang/AutoCloseable".to_string()],
-        bootstrap_methods: Vec::new(),
-    };
-    registry.register(byte_buffer_is_ctx);
-    registry.natives_mut().register(
-        "duke/zip/ByteBufferInputStream",
-        "read",
-        "()I",
-        native_file_input_stream_read,
-    );
-    registry.natives_mut().register(
-        "duke/zip/ByteBufferInputStream",
-        "read",
-        "([B)I",
-        native_file_input_stream_read_bytes,
-    );
-    registry.natives_mut().register(
-        "duke/zip/ByteBufferInputStream",
-        "close",
-        "()V",
-        native_file_input_stream_close,
-    );
-}
-
 #[inline]
-fn extract_slot_arg(args: &[Slot], idx: usize) -> Slot {
+pub(crate) fn extract_slot_arg(args: &[Slot], idx: usize) -> Slot {
     args.get(idx).copied().unwrap_or(Slot::Reference(None))
 }
 
 #[inline]
-fn extract_ref_arg(args: &[Slot], idx: usize) -> VmResult<u64> {
+pub(crate) fn extract_ref_arg(args: &[Slot], idx: usize) -> VmResult<u64> {
     match args.get(idx) {
         Some(Slot::Reference(Some(r))) => Ok(*r),
         _ => Err(VmError::NullPointerException),
@@ -3673,7 +38,7 @@ fn extract_ref_arg(args: &[Slot], idx: usize) -> VmResult<u64> {
 }
 
 #[inline]
-fn extract_io_fd(heap: &duke_gc::Heap, obj_ref: u64) -> VmResult<i32> {
+pub(crate) fn extract_io_fd(heap: &duke_gc::Heap, obj_ref: u64) -> VmResult<i32> {
     match heap.get(obj_ref)?.fields.first() {
         Some(Slot::Int(id)) => Ok(*id),
         _ => Err(VmError::JavaException {
@@ -3683,7 +48,7 @@ fn extract_io_fd(heap: &duke_gc::Heap, obj_ref: u64) -> VmResult<i32> {
 }
 
 #[inline]
-fn extract_io_fd_at(heap: &duke_gc::Heap, obj_ref: u64, idx: usize) -> VmResult<i32> {
+pub(crate) fn extract_io_fd_at(heap: &duke_gc::Heap, obj_ref: u64, idx: usize) -> VmResult<i32> {
     match heap.get(obj_ref)?.fields.get(idx) {
         Some(Slot::Int(id)) => Ok(*id),
         _ => Err(VmError::JavaException {
@@ -3693,7 +58,7 @@ fn extract_io_fd_at(heap: &duke_gc::Heap, obj_ref: u64, idx: usize) -> VmResult<
 }
 
 #[inline]
-fn extract_int_arg(args: &[Slot], idx: usize) -> VmResult<i32> {
+pub(crate) fn extract_int_arg(args: &[Slot], idx: usize) -> VmResult<i32> {
     match args.get(idx) {
         Some(Slot::Int(v)) => Ok(*v),
         _ => Err(VmError::TypeMismatch {
@@ -3704,7 +69,7 @@ fn extract_int_arg(args: &[Slot], idx: usize) -> VmResult<i32> {
 }
 
 #[inline]
-fn extract_long_arg(args: &[Slot], idx: usize) -> VmResult<i64> {
+pub(crate) fn extract_long_arg(args: &[Slot], idx: usize) -> VmResult<i64> {
     match args.get(idx) {
         Some(Slot::Long(v)) => Ok(*v),
         _ => Err(VmError::TypeMismatch {
@@ -3715,7 +80,7 @@ fn extract_long_arg(args: &[Slot], idx: usize) -> VmResult<i64> {
 }
 
 #[inline]
-fn extract_float_arg(args: &[Slot], idx: usize) -> VmResult<f32> {
+pub(crate) fn extract_float_arg(args: &[Slot], idx: usize) -> VmResult<f32> {
     match args.get(idx) {
         Some(Slot::Float(v)) => Ok(*v),
         _ => Err(VmError::TypeMismatch {
@@ -3726,7 +91,7 @@ fn extract_float_arg(args: &[Slot], idx: usize) -> VmResult<f32> {
 }
 
 #[inline]
-fn extract_double_arg(args: &[Slot], idx: usize) -> VmResult<f64> {
+pub(crate) fn extract_double_arg(args: &[Slot], idx: usize) -> VmResult<f64> {
     match args.get(idx) {
         Some(Slot::Double(v)) => Ok(*v),
         _ => Err(VmError::TypeMismatch {
@@ -3750,7 +115,7 @@ macro_rules! extract_print_arg {
     };
 }
 
-fn native_println_string(
+pub(crate) fn native_println_string(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -3775,7 +140,7 @@ fn native_println_string(
     Ok(None)
 }
 
-fn native_println_int(
+pub(crate) fn native_println_int(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -3787,7 +152,7 @@ fn native_println_int(
 }
 
 #[allow(clippy::unnecessary_wraps)] // must match NativeHandler signature
-fn native_println_void(
+pub(crate) fn native_println_void(
     _args: &[Slot],
     _heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -3797,7 +162,7 @@ fn native_println_void(
     Ok(None)
 }
 
-fn path_from_string_slot(
+pub(crate) fn path_from_string_slot(
     args: &[Slot],
     idx: usize,
     heap: &duke_gc::Heap,
@@ -3811,14 +176,17 @@ fn path_from_string_slot(
     Ok(std::path::PathBuf::from(path))
 }
 
-fn string_value_from_ref(heap: &duke_gc::Heap, string_ref: u64) -> VmResult<String> {
+pub(crate) fn string_value_from_ref(heap: &duke_gc::Heap, string_ref: u64) -> VmResult<String> {
     heap.get(string_ref)?
         .string_value
         .clone()
         .ok_or(VmError::NullPointerException)
 }
 
-fn file_path_from_ref(file_ref: u64, heap: &duke_gc::Heap) -> VmResult<std::path::PathBuf> {
+pub(crate) fn file_path_from_ref(
+    file_ref: u64,
+    heap: &duke_gc::Heap,
+) -> VmResult<std::path::PathBuf> {
     let path_ref = match heap.get(file_ref)?.fields.first() {
         Some(Slot::Reference(Some(r))) => *r,
         _ => return Err(VmError::NullPointerException),
@@ -3828,12 +196,15 @@ fn file_path_from_ref(file_ref: u64, heap: &duke_gc::Heap) -> VmResult<std::path
     )?))
 }
 
-fn file_path_from_this(args: &[Slot], heap: &duke_gc::Heap) -> VmResult<std::path::PathBuf> {
+pub(crate) fn file_path_from_this(
+    args: &[Slot],
+    heap: &duke_gc::Heap,
+) -> VmResult<std::path::PathBuf> {
     let this_ref = extract_ref_arg(args, 0)?;
     file_path_from_ref(this_ref, heap)
 }
 
-fn archive_path_from_slot(
+pub(crate) fn archive_path_from_slot(
     heap: &duke_gc::Heap,
     archive_ref: u64,
     slot_idx: usize,
@@ -3848,7 +219,7 @@ fn archive_path_from_slot(
     ))
 }
 
-fn boot_archive_path_from_ref(
+pub(crate) fn boot_archive_path_from_ref(
     registry: &ClassRegistry,
     heap: &duke_gc::Heap,
     archive_ref: u64,
@@ -3867,7 +238,7 @@ fn boot_archive_path_from_ref(
     }
 }
 
-fn launched_class_loader_archive_path(
+pub(crate) fn launched_class_loader_archive_path(
     registry: &ClassRegistry,
     heap: &duke_gc::Heap,
     loader_ref: u64,
@@ -3888,7 +259,7 @@ fn launched_class_loader_archive_path(
     boot_archive_path_from_ref(registry, heap, archive_ref)
 }
 
-fn archive_ref_from_slot(
+pub(crate) fn archive_ref_from_slot(
     heap: &duke_gc::Heap,
     obj_ref: u64,
     slot_idx: usize,
@@ -3903,7 +274,7 @@ fn archive_ref_from_slot(
     }
 }
 
-fn native_file_init(
+pub(crate) fn native_file_init(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -3919,7 +290,7 @@ fn native_file_init(
     Ok(None)
 }
 
-fn native_file_exists(
+pub(crate) fn native_file_exists(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -3929,7 +300,7 @@ fn native_file_exists(
     Ok(Some(Slot::Int(i32::from(path.exists()))))
 }
 
-fn native_file_is_file(
+pub(crate) fn native_file_is_file(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -3939,7 +310,7 @@ fn native_file_is_file(
     Ok(Some(Slot::Int(i32::from(path.is_file()))))
 }
 
-fn native_file_is_directory(
+pub(crate) fn native_file_is_directory(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -3949,7 +320,7 @@ fn native_file_is_directory(
     Ok(Some(Slot::Int(i32::from(path.is_dir()))))
 }
 
-fn file_stream_id_from_this(args: &[Slot], heap: &duke_gc::Heap) -> VmResult<i32> {
+pub(crate) fn file_stream_id_from_this(args: &[Slot], heap: &duke_gc::Heap) -> VmResult<i32> {
     let this_ref = extract_ref_arg(args, 0)?;
     match heap.get(this_ref)?.fields.first() {
         Some(Slot::Int(id)) if *id > 0 => Ok(*id),
@@ -3959,7 +330,7 @@ fn file_stream_id_from_this(args: &[Slot], heap: &duke_gc::Heap) -> VmResult<i32
     }
 }
 
-fn native_file_input_stream_init(
+pub(crate) fn native_file_input_stream_init(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -3976,7 +347,7 @@ fn native_file_input_stream_init(
     Ok(None)
 }
 
-fn native_file_input_stream_read(
+pub(crate) fn native_file_input_stream_read(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -3986,7 +357,7 @@ fn native_file_input_stream_read(
     Ok(Some(Slot::Int(heap.read_host_file_byte(file_id)?)))
 }
 
-fn native_file_input_stream_read_bytes(
+pub(crate) fn native_file_input_stream_read_bytes(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4016,7 +387,7 @@ fn native_file_input_stream_read_bytes(
     }
 }
 
-fn native_file_input_stream_close(
+pub(crate) fn native_file_input_stream_close(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4033,7 +404,7 @@ fn native_file_input_stream_close(
     Ok(None)
 }
 
-fn native_file_output_stream_init(
+pub(crate) fn native_file_output_stream_init(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4050,7 +421,7 @@ fn native_file_output_stream_init(
     Ok(None)
 }
 
-fn native_file_output_stream_write(
+pub(crate) fn native_file_output_stream_write(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4062,7 +433,7 @@ fn native_file_output_stream_write(
     Ok(None)
 }
 
-fn native_file_output_stream_write_bytes(
+pub(crate) fn native_file_output_stream_write_bytes(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4083,7 +454,7 @@ fn native_file_output_stream_write_bytes(
     Ok(None)
 }
 
-fn native_file_output_stream_close(
+pub(crate) fn native_file_output_stream_close(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4103,7 +474,7 @@ fn native_file_output_stream_close(
 // ── Networking natives ────────────────────────────────────────────────────
 
 /// Native: `ServerSocket.<init>(int port)` — binds to 0.0.0.0:{port}.
-fn native_server_socket_init(
+pub(crate) fn native_server_socket_init(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4124,7 +495,7 @@ fn native_server_socket_init(
 }
 
 /// Native: `ServerSocket.accept()` — blocks until a client connects, returns a Socket.
-fn native_server_socket_accept(
+pub(crate) fn native_server_socket_accept(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4148,7 +519,7 @@ fn native_server_socket_accept(
 }
 
 /// Native: `ServerSocket.getLocalPort()` — returns the bound port.
-fn native_server_socket_get_local_port(
+pub(crate) fn native_server_socket_get_local_port(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4164,7 +535,7 @@ fn native_server_socket_get_local_port(
 }
 
 /// Native: `ServerSocket.close()` — closes the OS listener and zeros the fd field.
-fn native_server_socket_close(
+pub(crate) fn native_server_socket_close(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4188,7 +559,7 @@ fn native_server_socket_close(
 }
 
 /// Native: `Socket.<init>(String host, int port)` — connects to host:port.
-fn native_socket_init(
+pub(crate) fn native_socket_init(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4214,7 +585,7 @@ fn native_socket_init(
 }
 
 /// Native: `Socket.getInputStream()` — allocates a `SocketInputStream` wrapping `fdRead`.
-fn native_socket_get_input_stream(
+pub(crate) fn native_socket_get_input_stream(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4235,7 +606,7 @@ fn native_socket_get_input_stream(
 }
 
 /// Native: `Socket.getOutputStream()` — allocates a `SocketOutputStream` wrapping `fdWrite`.
-fn native_socket_get_output_stream(
+pub(crate) fn native_socket_get_output_stream(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4256,7 +627,7 @@ fn native_socket_get_output_stream(
 }
 
 /// Native: `Socket.close()` — closes both OS handles (fdRead and fdWrite).
-fn native_socket_close(
+pub(crate) fn native_socket_close(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4276,7 +647,7 @@ fn native_socket_close(
 // ── ZIP / JAR natives ──────────────────────────────────────────────────
 
 /// Native: `ZipFile.<init>(String)` — open and index a ZIP/JAR archive.
-fn native_zip_file_init(
+pub(crate) fn native_zip_file_init(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4297,7 +668,7 @@ fn native_zip_file_init(
 }
 
 /// Native: `JarFile.<init>(File)` — open and index a JAR archive from a File object.
-fn native_jar_file_init_from_file(
+pub(crate) fn native_jar_file_init_from_file(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4312,7 +683,7 @@ fn native_jar_file_init_from_file(
     Ok(None)
 }
 
-fn native_jar_file_init_with_mode_and_version(
+pub(crate) fn native_jar_file_init_with_mode_and_version(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -4330,7 +701,7 @@ fn native_jar_file_init_with_mode_and_version(
     native_jar_file_init_from_file(&forwarded_args, heap, out, control)
 }
 
-fn native_jar_file_get_manifest(
+pub(crate) fn native_jar_file_get_manifest(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4345,7 +716,7 @@ fn native_jar_file_get_manifest(
     Ok(Some(Slot::Reference(Some(manifest_ref))))
 }
 
-fn native_boot_nested_jar_file_get_manifest(
+pub(crate) fn native_boot_nested_jar_file_get_manifest(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -4358,14 +729,17 @@ const BOOT_JAR_FILE_ARCHIVE_JAR_FILE_SLOT: usize = 1;
 const BOOT_EXPLODED_ARCHIVE_ROOT_DIRECTORY_SLOT: usize = 0;
 const BOOT_EXPLODED_ARCHIVE_MANIFEST_SLOT: usize = 2;
 
-fn allocate_manifest_from_bytes(heap: &mut duke_gc::Heap, bytes: &[u8]) -> VmResult<u64> {
+pub(crate) fn allocate_manifest_from_bytes(
+    heap: &mut duke_gc::Heap,
+    bytes: &[u8],
+) -> VmResult<u64> {
     let raw_ref = heap.allocate_string(String::from_utf8_lossy(bytes).into_owned());
     let manifest_ref = heap.allocate("java/util/jar/Manifest".to_string(), 1);
     heap.get_mut(manifest_ref)?.fields[0] = Slot::Reference(Some(raw_ref));
     Ok(manifest_ref)
 }
 
-fn native_boot_jar_file_archive_get_manifest(
+pub(crate) fn native_boot_jar_file_archive_get_manifest(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -4390,7 +764,7 @@ fn native_boot_jar_file_archive_get_manifest(
     native_jar_file_get_manifest(&[Slot::Reference(Some(jar_file_ref))], heap, out, control)
 }
 
-fn native_boot_archive_get_manifest(
+pub(crate) fn native_boot_archive_get_manifest(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -4411,7 +785,7 @@ fn native_boot_archive_get_manifest(
     }
 }
 
-fn native_boot_exploded_archive_get_manifest(
+pub(crate) fn native_boot_exploded_archive_get_manifest(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4462,7 +836,7 @@ fn native_boot_exploded_archive_get_manifest(
 
 /// Native: `ZipFile.getEntry(String) -> ZipEntry` — look up an entry by name.
 #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-fn native_zip_file_get_entry(
+pub(crate) fn native_zip_file_get_entry(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4495,7 +869,7 @@ fn native_zip_file_get_entry(
 }
 
 /// Native: `ZipFile.getInputStream(ZipEntry) -> InputStream`
-fn native_zip_file_get_input_stream(
+pub(crate) fn native_zip_file_get_input_stream(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4525,7 +899,7 @@ fn native_zip_file_get_input_stream(
 }
 
 /// Native: `ZipFile.close()`
-fn native_zip_file_close(
+pub(crate) fn native_zip_file_close(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4544,7 +918,7 @@ fn native_zip_file_close(
 
 /// Native: `ZipFile.size() -> int`
 #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-fn native_zip_file_size(
+pub(crate) fn native_zip_file_size(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4557,7 +931,7 @@ fn native_zip_file_size(
 }
 
 /// Native: `ZipEntry.getName() -> String`
-fn native_zip_entry_get_name(
+pub(crate) fn native_zip_entry_get_name(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4568,7 +942,7 @@ fn native_zip_entry_get_name(
 }
 
 /// Native: `ZipEntry.getCompressedSize() -> long`
-fn native_zip_entry_get_compressed_size(
+pub(crate) fn native_zip_entry_get_compressed_size(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4589,7 +963,7 @@ fn native_zip_entry_get_compressed_size(
 }
 
 /// Native: `ZipEntry.getSize() -> long`
-fn native_zip_entry_get_size(
+pub(crate) fn native_zip_entry_get_size(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4610,7 +984,7 @@ fn native_zip_entry_get_size(
 }
 
 /// Native: `ZipEntry.getMethod() -> int`
-fn native_zip_entry_get_method(
+pub(crate) fn native_zip_entry_get_method(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4622,7 +996,7 @@ fn native_zip_entry_get_method(
 
 /// Native: `String.length()` — returns string length as int.
 #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-fn native_string_length(
+pub(crate) fn native_string_length(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4635,7 +1009,7 @@ fn native_string_length(
 }
 
 /// Native: `String.equals(Object)` — compares string content.
-fn native_string_equals(
+pub(crate) fn native_string_equals(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4655,7 +1029,7 @@ fn native_string_equals(
 
 /// Native: `String.charAt(int)` — returns char at index as int.
 #[allow(clippy::cast_sign_loss)]
-fn native_string_char_at(
+pub(crate) fn native_string_char_at(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4676,7 +1050,7 @@ fn native_string_char_at(
 }
 
 /// Native: `Object.<init>()V` - root constructor is a no-op after null-checking `this`.
-fn native_object_init(
+pub(crate) fn native_object_init(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4687,7 +1061,7 @@ fn native_object_init(
 }
 
 /// Native: `Object.getClass()` — returns a lightweight `Class` object for the runtime type.
-fn native_object_get_class(
+pub(crate) fn native_object_get_class(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4700,7 +1074,7 @@ fn native_object_get_class(
 }
 
 /// Native: `Object.equals(Object)` — default Java object identity comparison.
-fn native_object_equals(
+pub(crate) fn native_object_equals(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4712,7 +1086,7 @@ fn native_object_equals(
 }
 
 /// Native: `Object.hashCode()` — returns heap address as hash.
-fn native_object_hashcode(
+pub(crate) fn native_object_hashcode(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4727,7 +1101,7 @@ fn native_object_hashcode(
 
 /// Native: `Object.toString()` — delegates to `heap_object_to_string` so String,
 /// boxed primitives, and opaque objects all produce the correct Java representation.
-fn native_object_tostring(
+pub(crate) fn native_object_tostring(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4740,7 +1114,7 @@ fn native_object_tostring(
 }
 
 /// Native: `Object.clone()` — shallow-copies a heap object.
-fn native_object_clone(
+pub(crate) fn native_object_clone(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4766,7 +1140,7 @@ fn native_object_clone(
 ///
 /// Signature: `args[0]` = this (Throwable), `args[1]` = suppressed (Throwable)
 #[allow(clippy::unnecessary_wraps)]
-fn native_throwable_add_suppressed(
+pub(crate) fn native_throwable_add_suppressed(
     _args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _stdout: &mut dyn Write,
@@ -4777,7 +1151,7 @@ fn native_throwable_add_suppressed(
 
 /// Native: `Enum.<init>(Ljava/lang/String;I)V` — stores name + ordinal.
 /// args: `[this_ref, name_ref, ordinal_int]`
-fn native_enum_init(
+pub(crate) fn native_enum_init(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4798,7 +1172,7 @@ fn native_enum_init(
 }
 
 /// Native: `Enum.ordinal()I`
-fn native_enum_ordinal(
+pub(crate) fn native_enum_ordinal(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4813,7 +1187,7 @@ fn native_enum_ordinal(
 }
 
 /// Native: `Enum.name()Ljava/lang/String;`
-fn native_enum_name(
+pub(crate) fn native_enum_name(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4830,7 +1204,7 @@ fn native_enum_name(
 /// Native: `Enum.valueOf(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;`
 /// Searches heap for enum constants of the given class matching the name.
 #[allow(clippy::cast_possible_truncation)]
-fn native_enum_valueof(
+pub(crate) fn native_enum_valueof(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4867,7 +1241,7 @@ fn native_enum_valueof(
 // Reflection natives
 // ---------------------------------------------------------------------------
 
-fn native_class_get_name(
+pub(crate) fn native_class_get_name(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4879,7 +1253,7 @@ fn native_class_get_name(
     Ok(Some(Slot::Reference(Some(name_ref))))
 }
 
-fn native_class_get_package_name(
+pub(crate) fn native_class_get_package_name(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4899,7 +1273,7 @@ fn native_class_get_package_name(
 }
 
 /// Native: `Class.desiredAssertionStatus()` - Duke currently runs with assertions disabled.
-fn native_class_desired_assertion_status(
+pub(crate) fn native_class_desired_assertion_status(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4910,7 +1284,7 @@ fn native_class_desired_assertion_status(
 }
 
 #[allow(clippy::unnecessary_wraps)]
-fn native_false_boolean(
+pub(crate) fn native_false_boolean(
     _args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4920,7 +1294,7 @@ fn native_false_boolean(
 }
 
 #[allow(clippy::unnecessary_wraps)]
-fn native_zero_long(
+pub(crate) fn native_zero_long(
     _args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4930,7 +1304,7 @@ fn native_zero_long(
 }
 
 #[allow(clippy::unnecessary_wraps)]
-fn native_void_noop(
+pub(crate) fn native_void_noop(
     _args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4939,7 +1313,7 @@ fn native_void_noop(
     Ok(None)
 }
 
-fn native_class_for_name(
+pub(crate) fn native_class_for_name(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -4966,7 +1340,7 @@ fn native_class_for_name(
     }
 }
 
-fn native_class_for_name_with_loader(
+pub(crate) fn native_class_for_name_with_loader(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5008,7 +1382,7 @@ fn native_class_for_name_with_loader(
     }
 }
 
-fn native_class_get_class_loader(
+pub(crate) fn native_class_get_class_loader(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5023,7 +1397,7 @@ fn native_class_get_class_loader(
 }
 
 #[allow(clippy::unnecessary_wraps)]
-fn native_class_loader_register_as_parallel_capable(
+pub(crate) fn native_class_loader_register_as_parallel_capable(
     _args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5032,7 +1406,7 @@ fn native_class_loader_register_as_parallel_capable(
     Ok(Some(Slot::Int(1)))
 }
 
-fn allocate_string_backed_object(
+pub(crate) fn allocate_string_backed_object(
     heap: &mut duke_gc::Heap,
     class_name: &str,
     value: String,
@@ -5043,7 +1417,7 @@ fn allocate_string_backed_object(
     Ok(obj_ref)
 }
 
-fn first_reference_field(heap: &duke_gc::Heap, obj_ref: u64) -> VmResult<Option<u64>> {
+pub(crate) fn first_reference_field(heap: &duke_gc::Heap, obj_ref: u64) -> VmResult<Option<u64>> {
     match heap.get(obj_ref)?.fields.first() {
         Some(Slot::Reference(Some(r))) => Ok(Some(*r)),
         Some(Slot::Reference(None)) => Ok(None),
@@ -5051,14 +1425,14 @@ fn first_reference_field(heap: &duke_gc::Heap, obj_ref: u64) -> VmResult<Option<
     }
 }
 
-fn string_backed_object_value(heap: &duke_gc::Heap, obj_ref: u64) -> VmResult<String> {
+pub(crate) fn string_backed_object_value(heap: &duke_gc::Heap, obj_ref: u64) -> VmResult<String> {
     let Some(value_ref) = first_reference_field(heap, obj_ref)? else {
         return Err(VmError::NullPointerException);
     };
     string_value_from_ref(heap, value_ref)
 }
 
-fn path_to_file_url(path: &std::path::Path) -> String {
+pub(crate) fn path_to_file_url(path: &std::path::Path) -> String {
     let mut normalized = path.to_string_lossy().replace('\\', "/");
     if cfg!(windows) {
         if let Some(stripped) = normalized.strip_prefix("//?/UNC/") {
@@ -5082,7 +1456,7 @@ const fn decode_pct_hex(byte: u8) -> Option<u8> {
     }
 }
 
-fn percent_decode(input: &str) -> String {
+pub(crate) fn percent_decode(input: &str) -> String {
     let bytes = input.as_bytes();
     let mut out = String::with_capacity(input.len());
     let mut i = 0usize;
@@ -5102,7 +1476,7 @@ fn percent_decode(input: &str) -> String {
     out
 }
 
-fn file_url_to_path(url: &str) -> VmResult<std::path::PathBuf> {
+pub(crate) fn file_url_to_path(url: &str) -> VmResult<std::path::PathBuf> {
     let Some(rest) = url.strip_prefix("file://") else {
         return Err(VmError::JavaException {
             class_name: "java/lang/IllegalArgumentException".to_string(),
@@ -5117,7 +1491,7 @@ fn file_url_to_path(url: &str) -> VmResult<std::path::PathBuf> {
     }
 }
 
-fn native_class_get_protection_domain(
+pub(crate) fn native_class_get_protection_domain(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5143,7 +1517,7 @@ fn native_class_get_protection_domain(
     Ok(Some(Slot::Reference(Some(pd_ref))))
 }
 
-fn native_protection_domain_get_code_source(
+pub(crate) fn native_protection_domain_get_code_source(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5156,7 +1530,7 @@ fn native_protection_domain_get_code_source(
     }
 }
 
-fn native_code_source_get_location(
+pub(crate) fn native_code_source_get_location(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5169,7 +1543,7 @@ fn native_code_source_get_location(
     }
 }
 
-fn native_url_to_uri(
+pub(crate) fn native_url_to_uri(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5182,7 +1556,7 @@ fn native_url_to_uri(
 }
 
 #[allow(clippy::unnecessary_wraps)]
-fn native_url_set_url_stream_handler_factory(
+pub(crate) fn native_url_set_url_stream_handler_factory(
     _args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5191,7 +1565,7 @@ fn native_url_set_url_stream_handler_factory(
     Ok(None)
 }
 
-fn native_path_of(
+pub(crate) fn native_path_of(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5208,7 +1582,7 @@ fn native_path_of(
     Ok(Some(Slot::Reference(Some(path_ref))))
 }
 
-fn native_path_to_file(
+pub(crate) fn native_path_to_file(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5226,7 +1600,7 @@ fn native_path_to_file(
     Ok(Some(Slot::Reference(Some(file_ref))))
 }
 
-fn native_paths_get(
+pub(crate) fn native_paths_get(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5262,7 +1636,7 @@ fn native_paths_get(
 }
 
 #[allow(clippy::unnecessary_wraps)] // must match NativeHandler signature
-fn native_posix_file_permissions_as_file_attribute(
+pub(crate) fn native_posix_file_permissions_as_file_attribute(
     _args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5272,7 +1646,7 @@ fn native_posix_file_permissions_as_file_attribute(
     Ok(Some(Slot::Reference(Some(attribute_ref))))
 }
 
-fn manifest_attribute_value(manifest_bytes: &[u8], key: &str) -> Option<String> {
+pub(crate) fn manifest_attribute_value(manifest_bytes: &[u8], key: &str) -> Option<String> {
     let text = std::str::from_utf8(manifest_bytes).ok()?;
     for line in text.lines() {
         if let Some(value) = line.strip_prefix(key)
@@ -5284,7 +1658,7 @@ fn manifest_attribute_value(manifest_bytes: &[u8], key: &str) -> Option<String> 
     None
 }
 
-fn native_manifest_get_main_attributes(
+pub(crate) fn native_manifest_get_main_attributes(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5300,7 +1674,7 @@ fn native_manifest_get_main_attributes(
     Ok(Some(Slot::Reference(Some(attributes_ref))))
 }
 
-fn native_attributes_get_value(
+pub(crate) fn native_attributes_get_value(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5325,7 +1699,7 @@ const BOOT_ARCHIVE_ENTRY_NAME_SLOT: usize = 0;
 const BOOT_ARCHIVE_ENTRY_DIRECTORY_SLOT: usize = 1;
 
 #[cfg(test)]
-fn boot_archive_entry_name(heap: &duke_gc::Heap, entry_ref: u64) -> VmResult<String> {
+pub(crate) fn boot_archive_entry_name(heap: &duke_gc::Heap, entry_ref: u64) -> VmResult<String> {
     let Some(Slot::Reference(Some(name_ref))) = heap
         .get(entry_ref)?
         .fields
@@ -5337,7 +1711,10 @@ fn boot_archive_entry_name(heap: &duke_gc::Heap, entry_ref: u64) -> VmResult<Str
     string_value_from_ref(heap, name_ref)
 }
 
-fn boot_archive_entry_is_directory_flag(heap: &duke_gc::Heap, entry_ref: u64) -> VmResult<bool> {
+pub(crate) fn boot_archive_entry_is_directory_flag(
+    heap: &duke_gc::Heap,
+    entry_ref: u64,
+) -> VmResult<bool> {
     match heap
         .get(entry_ref)?
         .fields
@@ -5352,7 +1729,7 @@ fn boot_archive_entry_is_directory_flag(heap: &duke_gc::Heap, entry_ref: u64) ->
     }
 }
 
-fn native_boot_archive_entry_name(
+pub(crate) fn native_boot_archive_entry_name(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5370,7 +1747,7 @@ fn native_boot_archive_entry_name(
     Ok(Some(slot))
 }
 
-fn native_boot_archive_entry_is_directory(
+pub(crate) fn native_boot_archive_entry_is_directory(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5382,7 +1759,7 @@ fn native_boot_archive_entry_is_directory(
     ))))
 }
 
-fn boot_archive_hashset_add_url(
+pub(crate) fn boot_archive_hashset_add_url(
     set_ref: u64,
     url_spec: String,
     heap: &mut duke_gc::Heap,
@@ -5402,7 +1779,7 @@ fn boot_archive_hashset_add_url(
     Ok(())
 }
 
-fn allocate_boot_archive_entry(
+pub(crate) fn allocate_boot_archive_entry(
     heap: &mut duke_gc::Heap,
     entry_name: &str,
     is_directory: bool,
@@ -5415,7 +1792,7 @@ fn allocate_boot_archive_entry(
     Ok(entry_ref)
 }
 
-fn boot_archive_predicate_accepts(
+pub(crate) fn boot_archive_predicate_accepts(
     predicate_ref: u64,
     entry_name: &str,
     is_directory: bool,
@@ -5452,7 +1829,7 @@ fn boot_archive_predicate_accepts(
     }
 }
 
-fn open_boot_archive_reader(path: &std::path::Path) -> VmResult<duke_loader::ZipReader> {
+pub(crate) fn open_boot_archive_reader(path: &std::path::Path) -> VmResult<duke_loader::ZipReader> {
     duke_loader::ZipReader::open(path).map_err(|err| match err {
         duke_loader::LoadError::Io { .. } => VmError::JavaException {
             class_name: "java/io/IOException".to_string(),
@@ -5463,7 +1840,11 @@ fn open_boot_archive_reader(path: &std::path::Path) -> VmResult<duke_loader::Zip
     })
 }
 
-fn archive_file_ref_at(heap: &duke_gc::Heap, archive_ref: u64, slot: usize) -> VmResult<u64> {
+pub(crate) fn archive_file_ref_at(
+    heap: &duke_gc::Heap,
+    archive_ref: u64,
+    slot: usize,
+) -> VmResult<u64> {
     match heap.get(archive_ref)?.fields.get(slot).copied() {
         Some(Slot::Reference(Some(file_ref))) => Ok(file_ref),
         Some(Slot::Reference(None)) => Err(VmError::NullPointerException),
@@ -5474,13 +1855,13 @@ fn archive_file_ref_at(heap: &duke_gc::Heap, archive_ref: u64, slot: usize) -> V
     }
 }
 
-fn patch_forwarded_slot_if_needed(heap: &duke_gc::Heap, slot: &mut Slot) {
+pub(crate) fn patch_forwarded_slot_if_needed(heap: &duke_gc::Heap, slot: &mut Slot) {
     if heap.has_pending_forwards() {
         heap.apply_forward(slot);
     }
 }
 
-fn patch_forwarded_ref_if_needed(heap: &duke_gc::Heap, reference: &mut u64) {
+pub(crate) fn patch_forwarded_ref_if_needed(heap: &duke_gc::Heap, reference: &mut u64) {
     let mut slot = Slot::Reference(Some(*reference));
     patch_forwarded_slot_if_needed(heap, &mut slot);
     if let Slot::Reference(Some(new_ref)) = slot {
@@ -5488,7 +1869,7 @@ fn patch_forwarded_ref_if_needed(heap: &duke_gc::Heap, reference: &mut u64) {
     }
 }
 
-fn native_boot_jar_file_archive_get_class_path_urls(
+pub(crate) fn native_boot_jar_file_archive_get_class_path_urls(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -5525,7 +1906,9 @@ fn native_boot_jar_file_archive_get_class_path_urls(
     Ok(Some(Slot::Reference(Some(set_ref))))
 }
 
-fn list_directory_children_sorted(path: &std::path::Path) -> VmResult<Vec<std::path::PathBuf>> {
+pub(crate) fn list_directory_children_sorted(
+    path: &std::path::Path,
+) -> VmResult<Vec<std::path::PathBuf>> {
     let iter = std::fs::read_dir(path).map_err(|_| VmError::JavaException {
         class_name: "java/io/IOException".to_string(),
     })?;
@@ -5544,7 +1927,7 @@ fn list_directory_children_sorted(path: &std::path::Path) -> VmResult<Vec<std::p
     Ok(children)
 }
 
-fn exploded_archive_relative_entry_name(
+pub(crate) fn exploded_archive_relative_entry_name(
     root_path: &std::path::Path,
     entry_path: &std::path::Path,
     is_directory: bool,
@@ -5560,7 +1943,7 @@ fn exploded_archive_relative_entry_name(
     relative
 }
 
-fn native_boot_exploded_archive_get_class_path_urls(
+pub(crate) fn native_boot_exploded_archive_get_class_path_urls(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -5620,7 +2003,7 @@ fn native_boot_exploded_archive_get_class_path_urls(
     Ok(Some(Slot::Reference(Some(set_ref))))
 }
 
-fn native_boot_launched_class_loader_init(
+pub(crate) fn native_boot_launched_class_loader_init(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5653,7 +2036,7 @@ fn native_boot_launched_class_loader_init(
     }
 }
 
-fn native_class_get_declared_method(
+pub(crate) fn native_class_get_declared_method(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5689,7 +2072,7 @@ fn native_class_get_declared_method(
     Ok(Some(Slot::Reference(Some(method_ref))))
 }
 
-fn native_class_get_method(
+pub(crate) fn native_class_get_method(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5723,7 +2106,7 @@ fn native_class_get_method(
     Ok(Some(Slot::Reference(Some(method_ref))))
 }
 
-fn lookup_reflected_constructor(
+pub(crate) fn lookup_reflected_constructor(
     reflected: ReflectedClassInfo,
     parameter_descriptor: &str,
     public_only: bool,
@@ -5735,7 +2118,7 @@ fn lookup_reflected_constructor(
     })
 }
 
-fn reflected_constructors(
+pub(crate) fn reflected_constructors(
     reflected: ReflectedClassInfo,
     public_only: bool,
 ) -> Vec<ReflectedMethodInfo> {
@@ -5746,7 +2129,7 @@ fn reflected_constructors(
         .collect()
 }
 
-fn native_class_get_declared_field(
+pub(crate) fn native_class_get_declared_field(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5781,7 +2164,7 @@ fn native_class_get_declared_field(
     Ok(Some(Slot::Reference(Some(field_ref))))
 }
 
-fn native_class_get_declared_constructor(
+pub(crate) fn native_class_get_declared_constructor(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5813,7 +2196,7 @@ fn native_class_get_declared_constructor(
     Ok(Some(Slot::Reference(Some(constructor_ref))))
 }
 
-fn native_class_get_field(
+pub(crate) fn native_class_get_field(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5845,7 +2228,7 @@ fn native_class_get_field(
     Ok(Some(Slot::Reference(Some(field_ref))))
 }
 
-fn native_class_get_constructor(
+pub(crate) fn native_class_get_constructor(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5877,7 +2260,7 @@ fn native_class_get_constructor(
     Ok(Some(Slot::Reference(Some(constructor_ref))))
 }
 
-fn native_class_new_instance(
+pub(crate) fn native_class_new_instance(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     output: &mut dyn Write,
@@ -5917,7 +2300,7 @@ fn native_class_new_instance(
     }
 }
 
-fn native_class_get_declared_methods(
+pub(crate) fn native_class_get_declared_methods(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5947,7 +2330,7 @@ fn native_class_get_declared_methods(
     Ok(Some(Slot::Reference(Some(array_ref))))
 }
 
-fn native_class_get_declared_constructors(
+pub(crate) fn native_class_get_declared_constructors(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -5976,7 +2359,7 @@ fn native_class_get_declared_constructors(
     Ok(Some(Slot::Reference(Some(array_ref))))
 }
 
-fn native_class_get_methods(
+pub(crate) fn native_class_get_methods(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6003,7 +2386,7 @@ fn native_class_get_methods(
     Ok(Some(Slot::Reference(Some(array_ref))))
 }
 
-fn native_class_get_constructors(
+pub(crate) fn native_class_get_constructors(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6032,7 +2415,7 @@ fn native_class_get_constructors(
     Ok(Some(Slot::Reference(Some(array_ref))))
 }
 
-fn native_class_get_declared_fields(
+pub(crate) fn native_class_get_declared_fields(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6061,7 +2444,7 @@ fn native_class_get_declared_fields(
     Ok(Some(Slot::Reference(Some(array_ref))))
 }
 
-fn native_class_get_fields(
+pub(crate) fn native_class_get_fields(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6088,7 +2471,7 @@ fn native_class_get_fields(
     Ok(Some(Slot::Reference(Some(array_ref))))
 }
 
-fn native_reflect_method_get_name(
+pub(crate) fn native_reflect_method_get_name(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6098,7 +2481,7 @@ fn native_reflect_method_get_name(
     Ok(Some(reflection_member_name_slot(heap, method_ref)?))
 }
 
-fn native_reflect_constructor_get_name(
+pub(crate) fn native_reflect_constructor_get_name(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6111,7 +2494,7 @@ fn native_reflect_constructor_get_name(
     )?))
 }
 
-fn native_reflect_method_get_return_type(
+pub(crate) fn native_reflect_method_get_return_type(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6128,7 +2511,7 @@ fn native_reflect_method_get_return_type(
     )?))
 }
 
-fn native_reflect_field_get_type(
+pub(crate) fn native_reflect_field_get_type(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6145,7 +2528,7 @@ fn native_reflect_field_get_type(
     )?))
 }
 
-fn native_reflection_member_get_declaring_class(
+pub(crate) fn native_reflection_member_get_declaring_class(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6157,7 +2540,7 @@ fn native_reflection_member_get_declaring_class(
     )?))
 }
 
-fn native_reflect_method_get_parameter_count(
+pub(crate) fn native_reflect_method_get_parameter_count(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6169,7 +2552,7 @@ fn native_reflect_method_get_parameter_count(
     Ok(Some(Slot::Int(count)))
 }
 
-fn native_reflect_executable_get_parameter_types(
+pub(crate) fn native_reflect_executable_get_parameter_types(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6199,7 +2582,7 @@ fn native_reflect_executable_get_parameter_types(
     Ok(Some(Slot::Reference(Some(array_ref))))
 }
 
-fn native_reflect_field_get_name(
+pub(crate) fn native_reflect_field_get_name(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6209,7 +2592,7 @@ fn native_reflect_field_get_name(
     Ok(Some(reflection_member_name_slot(heap, field_ref)?))
 }
 
-fn native_reflection_member_set_accessible(
+pub(crate) fn native_reflection_member_set_accessible(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6225,7 +2608,7 @@ fn native_reflection_member_set_accessible(
     Ok(None)
 }
 
-fn native_reflect_field_get(
+pub(crate) fn native_reflect_field_get(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     output: &mut dyn Write,
@@ -6265,7 +2648,7 @@ fn native_reflect_field_get(
     )?))
 }
 
-fn native_reflect_field_set(
+pub(crate) fn native_reflect_field_set(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     output: &mut dyn Write,
@@ -6305,7 +2688,7 @@ fn native_reflect_field_set(
     Ok(None)
 }
 
-fn native_reflect_method_invoke(
+pub(crate) fn native_reflect_method_invoke(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     output: &mut dyn Write,
@@ -6352,7 +2735,7 @@ fn native_reflect_method_invoke(
     }
 }
 
-fn native_reflect_constructor_new_instance(
+pub(crate) fn native_reflect_constructor_new_instance(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     output: &mut dyn Write,
@@ -6395,7 +2778,7 @@ fn native_reflect_constructor_new_instance(
 }
 
 /// Native: `String.valueOf(int)` — static method, returns string of int.
-fn native_string_value_of_int(
+pub(crate) fn native_string_value_of_int(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6408,7 +2791,7 @@ fn native_string_value_of_int(
 }
 
 /// Native: `PrintStream.print(String)` — no newline.
-fn native_print_string(
+pub(crate) fn native_print_string(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -6435,7 +2818,7 @@ fn native_print_string(
 
 /// Native: `PrintStream.print(int)` — no newline.
 #[allow(clippy::unnecessary_wraps)]
-fn native_print_int(
+pub(crate) fn native_print_int(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -6450,7 +2833,7 @@ fn native_print_int(
 // println overloads (long, float, double, boolean, char, object)
 // ---------------------------------------------------------------------------
 
-fn native_println_long(
+pub(crate) fn native_println_long(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -6461,7 +2844,7 @@ fn native_println_long(
     Ok(None)
 }
 
-fn native_println_float(
+pub(crate) fn native_println_float(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -6472,7 +2855,7 @@ fn native_println_float(
     Ok(None)
 }
 
-fn native_println_double(
+pub(crate) fn native_println_double(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -6483,7 +2866,7 @@ fn native_println_double(
     Ok(None)
 }
 
-fn native_println_boolean(
+pub(crate) fn native_println_boolean(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -6494,7 +2877,7 @@ fn native_println_boolean(
     Ok(None)
 }
 
-fn native_println_char(
+pub(crate) fn native_println_char(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -6511,7 +2894,7 @@ fn native_println_char(
 /// Checks `string_value` first (handles String/StringBuilder).
 /// For boxed primitives, extracts the stored value from `fields[0]`.
 /// Falls back to `class_name@hex_ref` for opaque objects.
-fn heap_object_to_string(obj: &duke_gc::HeapObject, obj_ref: u64) -> String {
+pub(crate) fn heap_object_to_string(obj: &duke_gc::HeapObject, obj_ref: u64) -> String {
     if let Some(s) = &obj.string_value {
         return s.clone();
     }
@@ -6554,7 +2937,7 @@ fn heap_object_to_string(obj: &duke_gc::HeapObject, obj_ref: u64) -> String {
     format!("{}@{:x}", obj.class_name, obj_ref)
 }
 
-fn native_println_object(
+pub(crate) fn native_println_object(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -6579,7 +2962,7 @@ fn native_println_object(
 // print overloads (long, float, double, boolean, char, object)
 // ---------------------------------------------------------------------------
 
-fn native_print_long(
+pub(crate) fn native_print_long(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -6590,7 +2973,7 @@ fn native_print_long(
     Ok(None)
 }
 
-fn native_print_float(
+pub(crate) fn native_print_float(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -6601,7 +2984,7 @@ fn native_print_float(
     Ok(None)
 }
 
-fn native_print_double(
+pub(crate) fn native_print_double(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -6612,7 +2995,7 @@ fn native_print_double(
     Ok(None)
 }
 
-fn native_print_boolean(
+pub(crate) fn native_print_boolean(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -6623,7 +3006,7 @@ fn native_print_boolean(
     Ok(None)
 }
 
-fn native_print_char(
+pub(crate) fn native_print_char(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -6635,7 +3018,7 @@ fn native_print_char(
 }
 
 #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-fn native_print_object(
+pub(crate) fn native_print_object(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -6660,7 +3043,7 @@ fn native_print_object(
 // System.exit
 // ---------------------------------------------------------------------------
 
-fn native_system_exit(
+pub(crate) fn native_system_exit(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6676,11 +3059,11 @@ fn native_system_exit(
 static SYSTEM_PROPERTY_OVERRIDES: std::sync::OnceLock<std::sync::Mutex<HashMap<String, String>>> =
     std::sync::OnceLock::new();
 
-fn system_property_overrides() -> &'static std::sync::Mutex<HashMap<String, String>> {
+pub(crate) fn system_property_overrides() -> &'static std::sync::Mutex<HashMap<String, String>> {
     SYSTEM_PROPERTY_OVERRIDES.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
 }
 
-fn system_property_value(key: &str) -> Option<String> {
+pub(crate) fn system_property_value(key: &str) -> Option<String> {
     let override_value = system_property_overrides()
         .lock()
         .expect("system property overrides mutex poisoned")
@@ -6718,7 +3101,7 @@ fn system_property_value(key: &str) -> Option<String> {
     }
 }
 
-fn native_system_get_property(
+pub(crate) fn native_system_get_property(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6732,7 +3115,7 @@ fn native_system_get_property(
     Ok(Some(result))
 }
 
-fn native_system_set_property(
+pub(crate) fn native_system_set_property(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6753,7 +3136,7 @@ fn native_system_set_property(
     Ok(Some(result))
 }
 
-fn native_system_get_property_with_default(
+pub(crate) fn native_system_get_property_with_default(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6768,7 +3151,7 @@ fn native_system_get_property_with_default(
     Ok(Some(result))
 }
 
-fn system_time_to_epoch_millis(now: std::time::SystemTime) -> i64 {
+pub(crate) fn system_time_to_epoch_millis(now: std::time::SystemTime) -> i64 {
     now.duration_since(std::time::UNIX_EPOCH)
         .map_or(0, |duration| {
             i64::try_from(duration.as_millis()).unwrap_or(i64::MAX)
@@ -6776,7 +3159,7 @@ fn system_time_to_epoch_millis(now: std::time::SystemTime) -> i64 {
 }
 
 #[allow(clippy::unnecessary_wraps)] // must match NativeHandler signature
-fn native_system_current_time_millis(
+pub(crate) fn native_system_current_time_millis(
     _args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6789,13 +3172,13 @@ fn native_system_current_time_millis(
 
 static NANO_TIME_ORIGIN: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
 
-fn monotonic_nano_time_now() -> i64 {
+pub(crate) fn monotonic_nano_time_now() -> i64 {
     let origin = NANO_TIME_ORIGIN.get_or_init(std::time::Instant::now);
     i64::try_from(origin.elapsed().as_nanos()).unwrap_or(i64::MAX)
 }
 
 #[allow(clippy::unnecessary_wraps)] // must match NativeHandler signature
-fn native_system_nano_time(
+pub(crate) fn native_system_nano_time(
     _args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6807,7 +3190,7 @@ fn native_system_nano_time(
 const THREAD_TARGET_SLOT: usize = 0;
 const THREAD_ID_SLOT: usize = 1;
 
-fn native_thread_current_thread(
+pub(crate) fn native_thread_current_thread(
     _args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6820,7 +3203,7 @@ fn native_thread_current_thread(
     Ok(Some(Slot::Reference(Some(thread_ref))))
 }
 
-fn native_thread_init(
+pub(crate) fn native_thread_init(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6833,7 +3216,7 @@ fn native_thread_init(
     Ok(None)
 }
 
-fn native_thread_init_runnable(
+pub(crate) fn native_thread_init_runnable(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6847,7 +3230,7 @@ fn native_thread_init_runnable(
     Ok(None)
 }
 
-fn native_thread_start(
+pub(crate) fn native_thread_start(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6858,7 +3241,7 @@ fn native_thread_start(
     Ok(None)
 }
 
-fn native_thread_join(
+pub(crate) fn native_thread_join(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6877,7 +3260,7 @@ fn native_thread_join(
     Ok(None)
 }
 
-fn native_thread_sleep(
+pub(crate) fn native_thread_sleep(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6901,7 +3284,7 @@ fn native_thread_sleep(
 
 /// Native: `String.substring(int)` — substring from begin to end.
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-fn native_string_substring(
+pub(crate) fn native_string_substring(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6928,7 +3311,7 @@ fn native_string_substring(
 
 /// Native: `String.substring(int, int)` — substring from begin to end (exclusive).
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-fn native_string_substring_range(
+pub(crate) fn native_string_substring_range(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6955,7 +3338,7 @@ fn native_string_substring_range(
 }
 
 /// Native: `String.indexOf(String)` — find first occurrence of target.
-fn native_string_indexof(
+pub(crate) fn native_string_indexof(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6976,7 +3359,7 @@ fn native_string_indexof(
 }
 
 /// Native: `String.contains(CharSequence)` — check if string contains target.
-fn native_string_contains(
+pub(crate) fn native_string_contains(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -6995,7 +3378,7 @@ fn native_string_contains(
 
 /// Native: `String.isEmpty()` — check if string is empty.
 #[allow(clippy::unnecessary_wraps)]
-fn native_string_isempty(
+pub(crate) fn native_string_isempty(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7026,7 +3409,7 @@ const fn ordering_to_int(o: std::cmp::Ordering) -> i32 {
 }
 
 /// Native: `String.compareTo(String)` — delegates to the Object overload.
-fn native_string_compareto(
+pub(crate) fn native_string_compareto(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     out: &mut dyn Write,
@@ -7036,7 +3419,7 @@ fn native_string_compareto(
 }
 
 /// Native: `String.compareTo(Object)` — lexicographic comparison via Object descriptor.
-fn native_string_compareto_object(
+pub(crate) fn native_string_compareto_object(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7057,7 +3440,7 @@ fn native_string_compareto_object(
 }
 
 /// Native: `String.startsWith(String)` — check if string starts with prefix.
-fn native_string_startswith(
+pub(crate) fn native_string_startswith(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7075,7 +3458,7 @@ fn native_string_startswith(
 }
 
 /// Native: `String.endsWith(String)` — check if string ends with suffix.
-fn native_string_endswith(
+pub(crate) fn native_string_endswith(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7093,7 +3476,7 @@ fn native_string_endswith(
 }
 
 /// Native: `String.trim()` — remove leading and trailing whitespace.
-fn native_string_trim(
+pub(crate) fn native_string_trim(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7108,7 +3491,7 @@ fn native_string_trim(
 
 /// Native: `String.toCharArray()` — convert string to char array.
 #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-fn native_string_tochararray(
+pub(crate) fn native_string_tochararray(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7127,7 +3510,7 @@ fn native_string_tochararray(
 // ---- Integer natives ----
 
 /// Native: `Integer.parseInt(String)` — parses string to int.
-fn native_integer_parseint(
+pub(crate) fn native_integer_parseint(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7138,7 +3521,7 @@ fn native_integer_parseint(
 }
 
 /// Native: `Integer.parseInt(String,int)` — parses string to int with radix.
-fn native_integer_parseint_radix(
+pub(crate) fn native_integer_parseint_radix(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7149,7 +3532,7 @@ fn native_integer_parseint_radix(
 }
 
 /// Native: `Integer.valueOf(int)` — boxes int into Integer object.
-fn native_integer_valueof(
+pub(crate) fn native_integer_valueof(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7162,7 +3545,7 @@ fn native_integer_valueof(
 }
 
 /// Native: `Integer.valueOf(String)` — parses and boxes int.
-fn native_integer_valueof_string(
+pub(crate) fn native_integer_valueof_string(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7175,7 +3558,7 @@ fn native_integer_valueof_string(
 }
 
 /// Native: `Integer.valueOf(String,int)` — parses and boxes int with radix.
-fn native_integer_valueof_string_radix(
+pub(crate) fn native_integer_valueof_string_radix(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7188,7 +3571,7 @@ fn native_integer_valueof_string_radix(
 }
 
 /// Native: `Integer.decode(String)` — parses prefixed string and boxes int.
-fn native_integer_decode(
+pub(crate) fn native_integer_decode(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7201,7 +3584,7 @@ fn native_integer_decode(
 }
 
 /// Native: `Integer.intValue()` — unboxes Integer to int.
-fn native_integer_intvalue(
+pub(crate) fn native_integer_intvalue(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7213,7 +3596,7 @@ fn native_integer_intvalue(
 }
 
 /// Native: `Integer.toString(int)` — static, converts int to String.
-fn native_integer_tostring_static(
+pub(crate) fn native_integer_tostring_static(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7225,7 +3608,7 @@ fn native_integer_tostring_static(
 }
 
 /// Native: `Integer.toHexString(int)` — unsigned lowercase hex string.
-fn native_integer_tohexstring_static(
+pub(crate) fn native_integer_tohexstring_static(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7237,7 +3620,7 @@ fn native_integer_tohexstring_static(
 }
 
 /// Native: `Integer.toOctalString(int)` — unsigned octal string.
-fn native_integer_tooctalstring_static(
+pub(crate) fn native_integer_tooctalstring_static(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7249,7 +3632,7 @@ fn native_integer_tooctalstring_static(
 }
 
 /// Native: `Integer.toBinaryString(int)` — unsigned binary string.
-fn native_integer_tobinarystring_static(
+pub(crate) fn native_integer_tobinarystring_static(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7261,7 +3644,7 @@ fn native_integer_tobinarystring_static(
 }
 
 /// Native: `Integer.toUnsignedLong(int)` — widen via unsigned 32-bit interpretation.
-fn native_integer_tounsignedlong_static(
+pub(crate) fn native_integer_tounsignedlong_static(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7272,7 +3655,7 @@ fn native_integer_tounsignedlong_static(
 }
 
 /// Native: `Integer.compareUnsigned(int,int)` — compares ints as unsigned 32-bit values.
-fn native_integer_compareunsigned_static(
+pub(crate) fn native_integer_compareunsigned_static(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7284,7 +3667,7 @@ fn native_integer_compareunsigned_static(
 }
 
 /// Native: `Integer.compareTo(Object)` — compares two boxed Integers.
-fn native_integer_compareto(
+pub(crate) fn native_integer_compareto(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7310,7 +3693,7 @@ fn native_integer_compareto(
 // ---- String.valueOf overloads ----
 
 /// Native: `String.valueOf(long)` — converts long to String.
-fn native_string_value_of_long(
+pub(crate) fn native_string_value_of_long(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7322,7 +3705,7 @@ fn native_string_value_of_long(
 }
 
 /// Native: `String.valueOf(double)` — converts double to String.
-fn native_string_value_of_double(
+pub(crate) fn native_string_value_of_double(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7334,7 +3717,7 @@ fn native_string_value_of_double(
 }
 
 /// Native: `String.valueOf(float)` — converts float to String.
-fn native_string_value_of_float(
+pub(crate) fn native_string_value_of_float(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7346,7 +3729,7 @@ fn native_string_value_of_float(
 }
 
 /// Native: `String.valueOf(boolean)` — converts boolean to String.
-fn native_string_value_of_boolean(
+pub(crate) fn native_string_value_of_boolean(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7366,7 +3749,7 @@ fn native_string_value_of_boolean(
 }
 
 /// Native: `String.valueOf(char)` — converts char to String.
-fn native_string_value_of_char(
+pub(crate) fn native_string_value_of_char(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7386,7 +3769,7 @@ fn native_string_value_of_char(
 }
 
 /// Native: `String.valueOf(Object)` — converts Object to String.
-fn native_string_value_of_object(
+pub(crate) fn native_string_value_of_object(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7412,7 +3795,7 @@ fn native_string_value_of_object(
 // ---- String.concat ----
 
 /// Native: `String.concat(String)` — concatenates two strings.
-fn native_string_concat(
+pub(crate) fn native_string_concat(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7431,7 +3814,7 @@ fn native_string_concat(
 }
 
 /// Formats a single boxed slot value using the given format specifier.
-fn format_arg(
+pub(crate) fn format_arg(
     spec: char,
     precision: Option<usize>,
     slot: &Slot,
@@ -7474,7 +3857,7 @@ fn format_arg(
 }
 
 /// Native: `String.format(Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;`
-fn native_string_format(
+pub(crate) fn native_string_format(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7563,7 +3946,7 @@ fn native_string_format(
 // ---- Extended String natives ----
 
 /// Native: `String.toUpperCase()` — returns a new uppercase String.
-fn native_string_touppercase(
+pub(crate) fn native_string_touppercase(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7576,7 +3959,7 @@ fn native_string_touppercase(
 }
 
 /// Native: `String.toLowerCase()` — returns a new lowercase String.
-fn native_string_tolowercase(
+pub(crate) fn native_string_tolowercase(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7590,7 +3973,7 @@ fn native_string_tolowercase(
 
 /// Native: `String.replace(char, char)` — replaces all occurrences of old char with new char.
 #[allow(clippy::cast_sign_loss)]
-fn native_string_replace_char(
+pub(crate) fn native_string_replace_char(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7606,7 +3989,7 @@ fn native_string_replace_char(
 }
 
 /// Native: `String.replace(CharSequence, CharSequence)` — replaces all occurrences of target with replacement.
-fn native_string_replace_charsequence(
+pub(crate) fn native_string_replace_charsequence(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7632,7 +4015,7 @@ fn native_string_replace_charsequence(
 }
 
 /// Native: `String.split(String)` — splits string by delimiter, returns String array.
-fn native_string_split(
+pub(crate) fn native_string_split(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7657,7 +4040,7 @@ fn native_string_split(
 
 /// Native: `String.hashCode()` — Java's hash algorithm: `s[0]*31^(n-1) + s[1]*31^(n-2) + ... + s[n-1]`.
 #[allow(clippy::cast_possible_wrap)]
-fn native_string_hashcode(
+pub(crate) fn native_string_hashcode(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7674,7 +4057,7 @@ fn native_string_hashcode(
 
 /// Native: `String.toString()` — identity, returns `this`.
 #[allow(clippy::unnecessary_wraps)]
-fn native_string_tostring(
+pub(crate) fn native_string_tostring(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7686,7 +4069,7 @@ fn native_string_tostring(
 // ---- Math natives ----
 
 /// Native: `Math.max(int, int)` — returns the larger value.
-fn native_math_max_int(
+pub(crate) fn native_math_max_int(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7698,7 +4081,7 @@ fn native_math_max_int(
 }
 
 /// Native: `Math.min(int, int)` — returns the smaller value.
-fn native_math_min_int(
+pub(crate) fn native_math_min_int(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7710,7 +4093,7 @@ fn native_math_min_int(
 }
 
 /// Native: `Math.abs(int)` — returns absolute value.
-fn native_math_abs_int(
+pub(crate) fn native_math_abs_int(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7721,7 +4104,7 @@ fn native_math_abs_int(
 }
 
 /// Native: `Math.floorMod(int, int)` — remainder with the divisor's sign.
-fn native_math_floor_mod_int(
+pub(crate) fn native_math_floor_mod_int(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7744,7 +4127,7 @@ fn native_math_floor_mod_int(
 // ---- Extended Math natives ----
 
 /// Native: `Math.sqrt(double)` — returns square root.
-fn native_math_sqrt(
+pub(crate) fn native_math_sqrt(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7755,7 +4138,7 @@ fn native_math_sqrt(
 }
 
 /// Native: `Math.pow(double, double)` — returns a raised to the power b.
-fn native_math_pow(
+pub(crate) fn native_math_pow(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7767,7 +4150,7 @@ fn native_math_pow(
 }
 
 /// Native: `Math.floor(double)` — returns floor value.
-fn native_math_floor(
+pub(crate) fn native_math_floor(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7778,7 +4161,7 @@ fn native_math_floor(
 }
 
 /// Native: `Math.ceil(double)` — returns ceiling value.
-fn native_math_ceil(
+pub(crate) fn native_math_ceil(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7790,7 +4173,7 @@ fn native_math_ceil(
 
 /// Native: `Math.round(double)` — returns closest long.
 #[allow(clippy::cast_possible_truncation)]
-fn native_math_round_double(
+pub(crate) fn native_math_round_double(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7801,7 +4184,7 @@ fn native_math_round_double(
 }
 
 /// Native: `Math.abs(long)` — returns absolute value.
-fn native_math_abs_long(
+pub(crate) fn native_math_abs_long(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7812,7 +4195,7 @@ fn native_math_abs_long(
 }
 
 /// Native: `Math.abs(double)` — returns absolute value.
-fn native_math_abs_double(
+pub(crate) fn native_math_abs_double(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7823,7 +4206,7 @@ fn native_math_abs_double(
 }
 
 /// Native: `Math.max(long, long)` — returns the larger value.
-fn native_math_max_long(
+pub(crate) fn native_math_max_long(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7835,7 +4218,7 @@ fn native_math_max_long(
 }
 
 /// Native: `Math.min(long, long)` — returns the smaller value.
-fn native_math_min_long(
+pub(crate) fn native_math_min_long(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7847,7 +4230,7 @@ fn native_math_min_long(
 }
 
 /// Native: `Math.max(double, double)` — returns the larger value.
-fn native_math_max_double(
+pub(crate) fn native_math_max_double(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7859,7 +4242,7 @@ fn native_math_max_double(
 }
 
 /// Native: `Math.min(double, double)` — returns the smaller value.
-fn native_math_min_double(
+pub(crate) fn native_math_min_double(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7873,7 +4256,7 @@ fn native_math_min_double(
 // ---- Long class natives ----
 
 /// Native: `Long.parseLong(String)` — parses string to long.
-fn native_long_parselong(
+pub(crate) fn native_long_parselong(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7884,7 +4267,7 @@ fn native_long_parselong(
 }
 
 /// Native: `Long.parseLong(String,int)` — parses string to long with radix.
-fn native_long_parselong_radix(
+pub(crate) fn native_long_parselong_radix(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7895,7 +4278,7 @@ fn native_long_parselong_radix(
 }
 
 /// Native: `Long.valueOf(long)` — boxes long into Long object.
-fn native_long_valueof(
+pub(crate) fn native_long_valueof(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7908,7 +4291,7 @@ fn native_long_valueof(
 }
 
 /// Native: `Long.valueOf(String)` — parses and boxes long.
-fn native_long_valueof_string(
+pub(crate) fn native_long_valueof_string(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7921,7 +4304,7 @@ fn native_long_valueof_string(
 }
 
 /// Native: `Long.valueOf(String,int)` — parses and boxes long with radix.
-fn native_long_valueof_string_radix(
+pub(crate) fn native_long_valueof_string_radix(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7934,7 +4317,7 @@ fn native_long_valueof_string_radix(
 }
 
 /// Native: `Long.decode(String)` — parses prefixed string and boxes long.
-fn native_long_decode(
+pub(crate) fn native_long_decode(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7947,7 +4330,7 @@ fn native_long_decode(
 }
 
 /// Native: `Long.longValue()` — unboxes Long to long.
-fn native_long_longvalue(
+pub(crate) fn native_long_longvalue(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7959,7 +4342,7 @@ fn native_long_longvalue(
 }
 
 /// Native: `Long.toString(long)` — static, converts long to String.
-fn native_long_tostring_static(
+pub(crate) fn native_long_tostring_static(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7971,7 +4354,7 @@ fn native_long_tostring_static(
 }
 
 /// Native: `Long.toHexString(long)` — unsigned lowercase hex string.
-fn native_long_tohexstring_static(
+pub(crate) fn native_long_tohexstring_static(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -7991,7 +4374,7 @@ fn native_long_tohexstring_static(
 }
 
 /// Native: `Long.toOctalString(long)` — unsigned octal string.
-fn native_long_tooctalstring_static(
+pub(crate) fn native_long_tooctalstring_static(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8011,7 +4394,7 @@ fn native_long_tooctalstring_static(
 }
 
 /// Native: `Long.toBinaryString(long)` — unsigned binary string.
-fn native_long_tobinarystring_static(
+pub(crate) fn native_long_tobinarystring_static(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8031,7 +4414,7 @@ fn native_long_tobinarystring_static(
 }
 
 /// Native: `Long.compareUnsigned(long,long)` — compares longs as unsigned 64-bit values.
-fn native_long_compareunsigned_static(
+pub(crate) fn native_long_compareunsigned_static(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8043,7 +4426,7 @@ fn native_long_compareunsigned_static(
 }
 
 /// Native: `Long.compareTo(Object)` — compares two boxed Longs.
-fn native_long_compareto(
+pub(crate) fn native_long_compareto(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8069,7 +4452,7 @@ fn native_long_compareto(
 // ---- Double class natives ----
 
 /// Native: `Double.parseDouble(String)` — parses string to double.
-fn native_double_parsedouble(
+pub(crate) fn native_double_parsedouble(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8093,7 +4476,7 @@ fn native_double_parsedouble(
 }
 
 /// Native: `Double.valueOf(double)` — boxes double into Double object.
-fn native_double_valueof(
+pub(crate) fn native_double_valueof(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8106,7 +4489,7 @@ fn native_double_valueof(
 }
 
 /// Native: `Double.doubleValue()` — unboxes Double to double.
-fn native_double_doublevalue(
+pub(crate) fn native_double_doublevalue(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8119,7 +4502,7 @@ fn native_double_doublevalue(
 
 // ---- Float class native ----
 
-fn native_float_valueof(
+pub(crate) fn native_float_valueof(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8131,7 +4514,7 @@ fn native_float_valueof(
     Ok(Some(Slot::Reference(Some(r))))
 }
 
-fn native_float_floatvalue(
+pub(crate) fn native_float_floatvalue(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8142,7 +4525,7 @@ fn native_float_floatvalue(
     Ok(Some(val))
 }
 
-fn native_float_compareto(
+pub(crate) fn native_float_compareto(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8166,7 +4549,7 @@ fn native_float_compareto(
 }
 
 /// Native: `Float.parseFloat(String)` — parses string to float.
-fn native_float_parsefloat(
+pub(crate) fn native_float_parsefloat(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8191,7 +4574,7 @@ fn native_float_parsefloat(
 
 // ---- Boolean class native ----
 
-fn native_boolean_valueof(
+pub(crate) fn native_boolean_valueof(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8203,7 +4586,7 @@ fn native_boolean_valueof(
     Ok(Some(Slot::Reference(Some(r))))
 }
 
-fn native_boolean_booleanvalue(
+pub(crate) fn native_boolean_booleanvalue(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8214,7 +4597,7 @@ fn native_boolean_booleanvalue(
     Ok(Some(val))
 }
 
-fn native_boolean_compareto(
+pub(crate) fn native_boolean_compareto(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8238,7 +4621,7 @@ fn native_boolean_compareto(
 }
 
 /// Native: `Boolean.parseBoolean(String)` — case-insensitive "true" → 1, else 0.
-fn native_boolean_parseboolean(
+pub(crate) fn native_boolean_parseboolean(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8258,7 +4641,7 @@ fn native_boolean_parseboolean(
     }
 }
 
-fn parse_bounded_i32_from_string_arg(
+pub(crate) fn parse_bounded_i32_from_string_arg(
     args: &[Slot],
     heap: &duke_gc::Heap,
     min: i32,
@@ -8268,7 +4651,7 @@ fn parse_bounded_i32_from_string_arg(
     parse_bounded_i32_with_radix(&s, 10, min, max)
 }
 
-fn parse_bounded_i32_from_string_and_radix_args(
+pub(crate) fn parse_bounded_i32_from_string_and_radix_args(
     args: &[Slot],
     heap: &duke_gc::Heap,
     min: i32,
@@ -8279,7 +4662,12 @@ fn parse_bounded_i32_from_string_and_radix_args(
     parse_bounded_i32_with_radix(&s, radix, min, max)
 }
 
-fn parse_bounded_i32_with_radix(s: &str, radix: u32, min: i32, max: i32) -> VmResult<i32> {
+pub(crate) fn parse_bounded_i32_with_radix(
+    s: &str,
+    radix: u32,
+    min: i32,
+    max: i32,
+) -> VmResult<i32> {
     let val = i32::from_str_radix(s.trim(), radix).map_err(|_| VmError::JavaException {
         class_name: "java/lang/NumberFormatException".to_string(),
     })?;
@@ -8291,24 +4679,30 @@ fn parse_bounded_i32_with_radix(s: &str, radix: u32, min: i32, max: i32) -> VmRe
     Ok(val)
 }
 
-fn parse_i64_from_string_arg(args: &[Slot], heap: &duke_gc::Heap) -> VmResult<i64> {
+pub(crate) fn parse_i64_from_string_arg(args: &[Slot], heap: &duke_gc::Heap) -> VmResult<i64> {
     let s = extract_string_arg_value(args, 0, heap)?;
     parse_i64_with_radix(&s, 10)
 }
 
-fn parse_i64_from_string_and_radix_args(args: &[Slot], heap: &duke_gc::Heap) -> VmResult<i64> {
+pub(crate) fn parse_i64_from_string_and_radix_args(
+    args: &[Slot],
+    heap: &duke_gc::Heap,
+) -> VmResult<i64> {
     let s = extract_string_arg_value(args, 0, heap)?;
     let radix = extract_parse_radix_arg(args, 1)?;
     parse_i64_with_radix(&s, radix)
 }
 
-fn parse_i64_with_radix(s: &str, radix: u32) -> VmResult<i64> {
+pub(crate) fn parse_i64_with_radix(s: &str, radix: u32) -> VmResult<i64> {
     i64::from_str_radix(s.trim(), radix).map_err(|_| VmError::JavaException {
         class_name: "java/lang/NumberFormatException".to_string(),
     })
 }
 
-fn parse_i32_decode_from_string_arg(args: &[Slot], heap: &duke_gc::Heap) -> VmResult<i32> {
+pub(crate) fn parse_i32_decode_from_string_arg(
+    args: &[Slot],
+    heap: &duke_gc::Heap,
+) -> VmResult<i32> {
     let s = extract_string_arg_value(args, 0, heap)?;
     let val = parse_i128_decode(&s)?;
     if val < i128::from(i32::MIN) || val > i128::from(i32::MAX) {
@@ -8321,7 +4715,10 @@ fn parse_i32_decode_from_string_arg(args: &[Slot], heap: &duke_gc::Heap) -> VmRe
     })
 }
 
-fn parse_i64_decode_from_string_arg(args: &[Slot], heap: &duke_gc::Heap) -> VmResult<i64> {
+pub(crate) fn parse_i64_decode_from_string_arg(
+    args: &[Slot],
+    heap: &duke_gc::Heap,
+) -> VmResult<i64> {
     let s = extract_string_arg_value(args, 0, heap)?;
     let val = parse_i128_decode(&s)?;
     if val < i128::from(i64::MIN) || val > i128::from(i64::MAX) {
@@ -8334,7 +4731,7 @@ fn parse_i64_decode_from_string_arg(args: &[Slot], heap: &duke_gc::Heap) -> VmRe
     })
 }
 
-fn parse_i128_decode(s: &str) -> VmResult<i128> {
+pub(crate) fn parse_i128_decode(s: &str) -> VmResult<i128> {
     let trimmed = s.trim();
     if trimmed.is_empty() {
         return Err(VmError::JavaException {
@@ -8372,12 +4769,16 @@ fn parse_i128_decode(s: &str) -> VmResult<i128> {
     Ok(if negative { -magnitude } else { magnitude })
 }
 
-fn extract_string_arg_value(args: &[Slot], index: usize, heap: &duke_gc::Heap) -> VmResult<String> {
+pub(crate) fn extract_string_arg_value(
+    args: &[Slot],
+    index: usize,
+    heap: &duke_gc::Heap,
+) -> VmResult<String> {
     let str_ref = extract_ref_arg(args, index)?;
     Ok(heap.get(str_ref)?.string_value.clone().unwrap_or_default())
 }
 
-fn extract_parse_radix_arg(args: &[Slot], index: usize) -> VmResult<u32> {
+pub(crate) fn extract_parse_radix_arg(args: &[Slot], index: usize) -> VmResult<u32> {
     let radix = extract_int_arg(args, index)?;
     if !(2..=36).contains(&radix) {
         return Err(VmError::JavaException {
@@ -8387,7 +4788,7 @@ fn extract_parse_radix_arg(args: &[Slot], index: usize) -> VmResult<u32> {
     Ok(u32::try_from(radix).unwrap_or(0))
 }
 
-fn native_byte_parsebyte(
+pub(crate) fn native_byte_parsebyte(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8398,7 +4799,7 @@ fn native_byte_parsebyte(
     Ok(Some(Slot::Int(val)))
 }
 
-fn native_byte_parsebyte_radix(
+pub(crate) fn native_byte_parsebyte_radix(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8413,7 +4814,7 @@ fn native_byte_parsebyte_radix(
     Ok(Some(Slot::Int(val)))
 }
 
-fn native_byte_valueof(
+pub(crate) fn native_byte_valueof(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8425,7 +4826,7 @@ fn native_byte_valueof(
     Ok(Some(Slot::Reference(Some(r))))
 }
 
-fn native_byte_valueof_string(
+pub(crate) fn native_byte_valueof_string(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8438,7 +4839,7 @@ fn native_byte_valueof_string(
     Ok(Some(Slot::Reference(Some(r))))
 }
 
-fn native_byte_valueof_string_radix(
+pub(crate) fn native_byte_valueof_string_radix(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8455,7 +4856,7 @@ fn native_byte_valueof_string_radix(
     Ok(Some(Slot::Reference(Some(r))))
 }
 
-fn native_byte_bytevalue(
+pub(crate) fn native_byte_bytevalue(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8466,7 +4867,7 @@ fn native_byte_bytevalue(
     Ok(Some(val))
 }
 
-fn native_byte_compareto(
+pub(crate) fn native_byte_compareto(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8489,7 +4890,7 @@ fn native_byte_compareto(
     Ok(Some(Slot::Int(ordering_to_int(a.cmp(&b)))))
 }
 
-fn native_short_parseshort(
+pub(crate) fn native_short_parseshort(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8500,7 +4901,7 @@ fn native_short_parseshort(
     Ok(Some(Slot::Int(val)))
 }
 
-fn native_short_parseshort_radix(
+pub(crate) fn native_short_parseshort_radix(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8515,7 +4916,7 @@ fn native_short_parseshort_radix(
     Ok(Some(Slot::Int(val)))
 }
 
-fn native_short_valueof(
+pub(crate) fn native_short_valueof(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8527,7 +4928,7 @@ fn native_short_valueof(
     Ok(Some(Slot::Reference(Some(r))))
 }
 
-fn native_short_valueof_string(
+pub(crate) fn native_short_valueof_string(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8540,7 +4941,7 @@ fn native_short_valueof_string(
     Ok(Some(Slot::Reference(Some(r))))
 }
 
-fn native_short_valueof_string_radix(
+pub(crate) fn native_short_valueof_string_radix(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8557,7 +4958,7 @@ fn native_short_valueof_string_radix(
     Ok(Some(Slot::Reference(Some(r))))
 }
 
-fn native_short_shortvalue(
+pub(crate) fn native_short_shortvalue(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8568,7 +4969,7 @@ fn native_short_shortvalue(
     Ok(Some(val))
 }
 
-fn native_short_compareto(
+pub(crate) fn native_short_compareto(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8591,7 +4992,7 @@ fn native_short_compareto(
     Ok(Some(Slot::Int(ordering_to_int(a.cmp(&b)))))
 }
 
-fn native_char_compareto(
+pub(crate) fn native_char_compareto(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -8616,7 +5017,7 @@ fn native_char_compareto(
 
 /// Execute a `StringConcatFactory` recipe: walk the recipe string, replacing
 /// `\u{1}` placeholders with stringified dynamic args from the operand stack.
-fn execute_string_concat_recipe(
+pub(crate) fn execute_string_concat_recipe(
     recipe: &str,
     dynamic_args: &[Slot],
     arg_types: &[char],
@@ -8652,7 +5053,7 @@ fn execute_string_concat_recipe(
 
 /// Convert a Slot to its string representation (like Java's String.valueOf).
 /// `type_hint` is the JVM type descriptor char: 'Z' for boolean, 'I' for int, etc.
-fn stringify_slot(
+pub(crate) fn stringify_slot(
     slot: &Slot,
     type_hint: char,
     heap: &duke_gc::Heap,
@@ -8687,7 +5088,7 @@ fn stringify_slot(
 }
 
 /// Format a float like Java's Float.toString.
-fn format_java_float(v: f32) -> String {
+pub(crate) fn format_java_float(v: f32) -> String {
     if v.is_nan() {
         return "NaN".to_string();
     }
@@ -8699,7 +5100,7 @@ fn format_java_float(v: f32) -> String {
 }
 
 /// Format a double like Java's Double.toString.
-fn format_java_double(v: f64) -> String {
+pub(crate) fn format_java_double(v: f64) -> String {
     if v.is_nan() {
         return "NaN".to_string();
     }
@@ -9899,7 +6300,7 @@ pub fn execute(
 /// Must be called before first active use of a class (new, getstatic, putstatic, invokestatic).
 /// `triggered_by` names the class that caused this init (empty string for the entry-point class).
 #[allow(clippy::used_underscore_binding, clippy::cast_possible_truncation)]
-fn ensure_initialized(
+pub(crate) fn ensure_initialized(
     registry: &mut ClassRegistry,
     loader: &dyn ClassLoader,
     heap: &mut duke_gc::Heap,
@@ -9948,7 +6349,7 @@ fn ensure_initialized(
     Ok(())
 }
 
-fn primitive_wrapper_type_descriptor(class_name: &str) -> Option<&'static str> {
+pub(crate) fn primitive_wrapper_type_descriptor(class_name: &str) -> Option<&'static str> {
     match class_name {
         "java/lang/Boolean" => Some("Z"),
         "java/lang/Byte" => Some("B"),
@@ -9963,7 +6364,7 @@ fn primitive_wrapper_type_descriptor(class_name: &str) -> Option<&'static str> {
     }
 }
 
-fn initialize_primitive_wrapper_type_field(
+pub(crate) fn initialize_primitive_wrapper_type_field(
     registry: &mut ClassRegistry,
     heap: &mut duke_gc::Heap,
     class_name: &str,
@@ -10041,7 +6442,7 @@ struct InterpreterCallbackOps<'a> {
 }
 
 #[allow(clippy::too_many_arguments, clippy::option_option)]
-fn callback_invoke_registered_lambda(
+pub(crate) fn callback_invoke_registered_lambda(
     registry: &mut ClassRegistry,
     loader: &dyn ClassLoader,
     heap: &mut duke_gc::Heap,
@@ -10380,7 +6781,7 @@ impl ExecutionState {
 }
 
 #[cfg(feature = "telemetry")]
-fn refresh_current_method_name(
+pub(crate) fn refresh_current_method_name(
     current_method: &mut String,
     registry: &ClassRegistry,
     current_class: &str,
@@ -10398,7 +6799,7 @@ fn refresh_current_method_name(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn activate_method_state(
+pub(crate) fn activate_method_state(
     frame: &mut Frame,
     method_idx: &mut usize,
     pc_to_idx: &mut std::sync::Arc<std::collections::HashMap<usize, usize>>,
@@ -10442,7 +6843,7 @@ enum ExecutionOutcome {
 /// yielding the VM lock, enabling fair interleaving of Java threads.
 const DEFAULT_THREAD_QUANTUM: usize = 1024;
 
-fn finish_native_call(
+pub(crate) fn finish_native_call(
     native_control: &mut NativeControl,
     frame: &mut Frame,
     idx: &mut usize,
@@ -10459,7 +6860,7 @@ fn finish_native_call(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn prepare_execution_state(
+pub(crate) fn prepare_execution_state(
     registry: &mut ClassRegistry,
     loader: &dyn ClassLoader,
     heap: &mut duke_gc::Heap,
@@ -10756,7 +7157,7 @@ pub fn execute_class(
     clippy::items_after_statements,
     clippy::used_underscore_binding
 )]
-fn run_execution(
+pub(crate) fn run_execution(
     state: &mut ExecutionState,
     registry: &mut ClassRegistry,
     loader: &dyn ClassLoader,
@@ -15753,7 +12154,7 @@ fn parse_arg_descriptors(descriptor: &str) -> Vec<String> {
 ///
 /// Per JVMS §2.3/2.4: numeric types default to 0, reference/array types to null.
 #[inline]
-fn default_slot_for_descriptor(desc: &str) -> Slot {
+pub(crate) fn default_slot_for_descriptor(desc: &str) -> Slot {
     match desc.chars().next() {
         Some('J') => Slot::Long(0),
         Some('F') => Slot::Float(0.0),
@@ -16277,7 +12678,7 @@ fn native_arraylist_add(
 
 /// Native: `ArrayList.get(I)Object` — returns element at index.
 #[allow(clippy::cast_sign_loss)]
-fn native_arraylist_get(
+pub(crate) fn native_arraylist_get(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -16552,7 +12953,7 @@ fn native_collections_sort(
 
 /// Native: `ArrayListIterator.<init>` — no-op; fields set directly by `native_arraylist_iterator`.
 #[allow(clippy::unnecessary_wraps)]
-fn native_arraylist_iter_init(
+pub(crate) fn native_arraylist_iter_init(
     _args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -16587,7 +12988,7 @@ fn native_arraylist_iter_hasnext(
 
 /// Native: `ArrayListIterator.next()Object` — returns element at cursor, advances cursor.
 #[allow(clippy::cast_sign_loss)]
-fn native_arraylist_iter_next(
+pub(crate) fn native_arraylist_iter_next(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -16625,7 +13026,7 @@ fn native_arraylist_iter_next(
 
 /// Native: `Double.isNaN(D)Z` — returns 1 if value is NaN.
 #[allow(clippy::unnecessary_wraps)]
-fn native_double_isnan(
+pub(crate) fn native_double_isnan(
     args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -17200,7 +13601,7 @@ fn native_hashset_iterator(
 
 /// Native: `HashSetIterator.<init>` — no-op; fields are set by `native_hashset_iterator`.
 #[allow(clippy::unnecessary_wraps)]
-fn native_hashset_iter_init(
+pub(crate) fn native_hashset_iter_init(
     _args: &[Slot],
     _heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -17235,7 +13636,7 @@ fn native_hashset_iter_hasnext(
 
 /// Native: `HashSetIterator.next()Object` — returns element at cursor, advances cursor.
 #[allow(clippy::cast_sign_loss)]
-fn native_hashset_iter_next(
+pub(crate) fn native_hashset_iter_next(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
     _out: &mut dyn Write,
@@ -17560,6 +13961,7 @@ fn patch_forwarded_slots(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::stdlib::bootstrap_stdlib;
 
     macro_rules! wrap_simple_native_for_tests {
         ($($name:ident),* $(,)?) => {

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -1,0 +1,3631 @@
+//! Standard library registration.
+
+#[allow(clippy::wildcard_imports)]
+use crate::*;
+use duke_runtime::Slot;
+
+/// Bootstrap minimal JDK standard library classes for native method support.
+///
+/// Creates synthetic `java/lang/System` and `java/io/PrintStream` classes and
+/// registers native `println` handlers for `(Ljava/lang/String;)V`, `(I)V`,
+/// and `()V`.
+#[allow(clippy::too_many_lines)]
+pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) {
+    // Allocate a PrintStream object on the heap.
+    let ps_ref = heap.allocate("java/io/PrintStream".to_string(), 0);
+
+    // Create java/lang/System ClassContext with a single static field `out`.
+    let system_ctx = ClassContext {
+        class_name: "java/lang/System".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "out".to_string(),
+            descriptor: "Ljava/io/PrintStream;".to_string(),
+            is_static: true,
+        }],
+        static_fields: vec![Slot::Reference(Some(ps_ref))],
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(system_ctx);
+
+    // Create java/io/PrintStream ClassContext (empty — all methods are native).
+    let ps_ctx = ClassContext {
+        class_name: "java/io/PrintStream".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(ps_ctx);
+
+    // Register native println handlers.
+    registry.natives_mut().register(
+        "java/io/PrintStream",
+        "println",
+        "(Ljava/lang/String;)V",
+        native_println_string,
+    );
+    registry
+        .natives_mut()
+        .register("java/io/PrintStream", "println", "(I)V", native_println_int);
+    registry
+        .natives_mut()
+        .register("java/io/PrintStream", "println", "()V", native_println_void);
+
+    let file_ctx = ClassContext {
+        class_name: "java/io/File".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "path".to_string(),
+            descriptor: "Ljava/lang/String;".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(file_ctx);
+    registry.natives_mut().register(
+        "java/io/File",
+        "<init>",
+        "(Ljava/lang/String;)V",
+        native_file_init,
+    );
+    registry
+        .natives_mut()
+        .register("java/io/File", "exists", "()Z", native_file_exists);
+    registry
+        .natives_mut()
+        .register("java/io/File", "isFile", "()Z", native_file_is_file);
+    registry.natives_mut().register(
+        "java/io/File",
+        "isDirectory",
+        "()Z",
+        native_file_is_directory,
+    );
+
+    let io_exception_ctx = ClassContext {
+        class_name: "java/io/IOException".to_string(),
+        super_class: Some("java/lang/Exception".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(io_exception_ctx);
+
+    let file_not_found_ctx = ClassContext {
+        class_name: "java/io/FileNotFoundException".to_string(),
+        super_class: Some("java/io/IOException".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(file_not_found_ctx);
+
+    let socket_exception_ctx = ClassContext {
+        class_name: "java/net/SocketException".to_string(),
+        super_class: Some("java/io/IOException".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(socket_exception_ctx);
+
+    let bind_exception_ctx = ClassContext {
+        class_name: "java/net/BindException".to_string(),
+        super_class: Some("java/net/SocketException".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(bind_exception_ctx);
+
+    let connect_exception_ctx = ClassContext {
+        class_name: "java/net/ConnectException".to_string(),
+        super_class: Some("java/net/SocketException".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(connect_exception_ctx);
+
+    let input_stream_ctx = ClassContext {
+        class_name: "java/io/InputStream".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: vec!["java/lang/AutoCloseable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(input_stream_ctx);
+
+    let output_stream_ctx = ClassContext {
+        class_name: "java/io/OutputStream".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: vec!["java/lang/AutoCloseable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(output_stream_ctx);
+
+    let process_ctx = ClassContext {
+        class_name: "java/lang/Process".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(process_ctx);
+
+    let process_impl_ctx = ClassContext {
+        class_name: "java/lang/ProcessImpl".to_string(),
+        super_class: Some("java/lang/Process".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "pid".to_string(),
+                descriptor: "I".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "stdinFd".to_string(),
+                descriptor: "I".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "stdoutFd".to_string(),
+                descriptor: "I".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "stderrFd".to_string(),
+                descriptor: "I".to_string(),
+                is_static: false,
+            },
+        ],
+        static_fields: Vec::new(),
+        instance_field_count: 4,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(process_impl_ctx);
+    registry.natives_mut().register(
+        "java/lang/ProcessImpl",
+        "getInputStream",
+        "()Ljava/io/InputStream;",
+        native_process_get_input_stream,
+    );
+    registry.natives_mut().register(
+        "java/lang/ProcessImpl",
+        "getErrorStream",
+        "()Ljava/io/InputStream;",
+        native_process_get_error_stream,
+    );
+    registry.natives_mut().register(
+        "java/lang/ProcessImpl",
+        "getOutputStream",
+        "()Ljava/io/OutputStream;",
+        native_process_get_output_stream,
+    );
+    registry.natives_mut().register(
+        "java/lang/ProcessImpl",
+        "waitFor",
+        "()I",
+        native_process_wait_for,
+    );
+    registry.natives_mut().register(
+        "java/lang/ProcessImpl",
+        "exitValue",
+        "()I",
+        native_process_exit_value,
+    );
+    registry.natives_mut().register(
+        "java/lang/ProcessImpl",
+        "destroy",
+        "()V",
+        native_process_destroy,
+    );
+
+    let process_builder_ctx = ClassContext {
+        class_name: "java/lang/ProcessBuilder".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "command".to_string(),
+                descriptor: "[Ljava/lang/String;".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "directory".to_string(),
+                descriptor: "Ljava/io/File;".to_string(),
+                is_static: false,
+            },
+        ],
+        static_fields: Vec::new(),
+        instance_field_count: 2,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(process_builder_ctx);
+    registry.natives_mut().register(
+        "java/lang/ProcessBuilder",
+        "<init>",
+        "([Ljava/lang/String;)V",
+        native_process_builder_init,
+    );
+    registry.natives_mut().register(
+        "java/lang/ProcessBuilder",
+        "directory",
+        "(Ljava/io/File;)Ljava/lang/ProcessBuilder;",
+        native_process_builder_directory,
+    );
+    registry.natives_mut().register(
+        "java/lang/ProcessBuilder",
+        "start",
+        "()Ljava/lang/Process;",
+        native_process_builder_start,
+    );
+
+    let runtime_ctx = ClassContext {
+        class_name: "java/lang/Runtime".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(runtime_ctx);
+    registry.natives_mut().register(
+        "java/lang/Runtime",
+        "getRuntime",
+        "()Ljava/lang/Runtime;",
+        native_runtime_get_runtime,
+    );
+    registry.natives_mut().register(
+        "java/lang/Runtime",
+        "exec",
+        "([Ljava/lang/String;)Ljava/lang/Process;",
+        native_runtime_exec_array,
+    );
+    registry.natives_mut().register(
+        "java/lang/Runtime",
+        "exec",
+        "([Ljava/lang/String;[Ljava/lang/String;Ljava/io/File;)Ljava/lang/Process;",
+        native_runtime_exec_array_dir,
+    );
+
+    let process_input_stream_ctx = ClassContext {
+        class_name: "duke/process/ProcessInputStream".to_string(),
+        super_class: Some("java/io/InputStream".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "fd".to_string(),
+            descriptor: "I".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/AutoCloseable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(process_input_stream_ctx);
+    registry.natives_mut().register(
+        "duke/process/ProcessInputStream",
+        "read",
+        "()I",
+        native_file_input_stream_read,
+    );
+    registry.natives_mut().register(
+        "duke/process/ProcessInputStream",
+        "read",
+        "([B)I",
+        native_file_input_stream_read_bytes,
+    );
+    registry.natives_mut().register(
+        "duke/process/ProcessInputStream",
+        "close",
+        "()V",
+        native_file_input_stream_close,
+    );
+
+    let process_error_stream_ctx = ClassContext {
+        class_name: "duke/process/ProcessErrorStream".to_string(),
+        super_class: Some("java/io/InputStream".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "fd".to_string(),
+            descriptor: "I".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/AutoCloseable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(process_error_stream_ctx);
+    registry.natives_mut().register(
+        "duke/process/ProcessErrorStream",
+        "read",
+        "()I",
+        native_file_input_stream_read,
+    );
+    registry.natives_mut().register(
+        "duke/process/ProcessErrorStream",
+        "read",
+        "([B)I",
+        native_file_input_stream_read_bytes,
+    );
+    registry.natives_mut().register(
+        "duke/process/ProcessErrorStream",
+        "close",
+        "()V",
+        native_file_input_stream_close,
+    );
+
+    let process_output_stream_ctx = ClassContext {
+        class_name: "duke/process/ProcessOutputStream".to_string(),
+        super_class: Some("java/io/OutputStream".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "fd".to_string(),
+            descriptor: "I".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/AutoCloseable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(process_output_stream_ctx);
+    registry.natives_mut().register(
+        "duke/process/ProcessOutputStream",
+        "write",
+        "(I)V",
+        native_file_output_stream_write,
+    );
+    registry.natives_mut().register(
+        "duke/process/ProcessOutputStream",
+        "write",
+        "([B)V",
+        native_file_output_stream_write_bytes,
+    );
+    registry.natives_mut().register(
+        "duke/process/ProcessOutputStream",
+        "close",
+        "()V",
+        native_file_output_stream_close,
+    );
+
+    let file_input_stream_ctx = ClassContext {
+        class_name: "java/io/FileInputStream".to_string(),
+        super_class: Some("java/io/InputStream".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "fd".to_string(),
+            descriptor: "I".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/AutoCloseable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(file_input_stream_ctx);
+    registry.natives_mut().register(
+        "java/io/FileInputStream",
+        "<init>",
+        "(Ljava/lang/String;)V",
+        native_file_input_stream_init,
+    );
+    registry.natives_mut().register(
+        "java/io/FileInputStream",
+        "read",
+        "()I",
+        native_file_input_stream_read,
+    );
+    registry.natives_mut().register(
+        "java/io/FileInputStream",
+        "read",
+        "([B)I",
+        native_file_input_stream_read_bytes,
+    );
+    registry.natives_mut().register(
+        "java/io/FileInputStream",
+        "close",
+        "()V",
+        native_file_input_stream_close,
+    );
+
+    let file_output_stream_ctx = ClassContext {
+        class_name: "java/io/FileOutputStream".to_string(),
+        super_class: Some("java/io/OutputStream".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "fd".to_string(),
+            descriptor: "I".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/AutoCloseable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(file_output_stream_ctx);
+    registry.natives_mut().register(
+        "java/io/FileOutputStream",
+        "<init>",
+        "(Ljava/lang/String;)V",
+        native_file_output_stream_init,
+    );
+    registry.natives_mut().register(
+        "java/io/FileOutputStream",
+        "write",
+        "(I)V",
+        native_file_output_stream_write,
+    );
+    registry.natives_mut().register(
+        "java/io/FileOutputStream",
+        "write",
+        "([B)V",
+        native_file_output_stream_write_bytes,
+    );
+    registry.natives_mut().register(
+        "java/io/FileOutputStream",
+        "close",
+        "()V",
+        native_file_output_stream_close,
+    );
+
+    let server_socket_ctx = ClassContext {
+        class_name: "java/net/ServerSocket".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "fd".to_string(),
+                descriptor: "I".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "port".to_string(),
+                descriptor: "I".to_string(),
+                is_static: false,
+            },
+        ],
+        static_fields: Vec::new(),
+        instance_field_count: 2,
+        interfaces: vec!["java/lang/AutoCloseable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(server_socket_ctx);
+    registry.natives_mut().register(
+        "java/net/ServerSocket",
+        "<init>",
+        "(I)V",
+        native_server_socket_init,
+    );
+    registry.natives_mut().register(
+        "java/net/ServerSocket",
+        "accept",
+        "()Ljava/net/Socket;",
+        native_server_socket_accept,
+    );
+    registry.natives_mut().register(
+        "java/net/ServerSocket",
+        "getLocalPort",
+        "()I",
+        native_server_socket_get_local_port,
+    );
+    registry.natives_mut().register(
+        "java/net/ServerSocket",
+        "close",
+        "()V",
+        native_server_socket_close,
+    );
+
+    let socket_ctx = ClassContext {
+        class_name: "java/net/Socket".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "fdRead".to_string(),
+                descriptor: "I".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "fdWrite".to_string(),
+                descriptor: "I".to_string(),
+                is_static: false,
+            },
+        ],
+        static_fields: Vec::new(),
+        instance_field_count: 2,
+        interfaces: vec!["java/lang/AutoCloseable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(socket_ctx);
+    registry.natives_mut().register(
+        "java/net/Socket",
+        "<init>",
+        "(Ljava/lang/String;I)V",
+        native_socket_init,
+    );
+    registry.natives_mut().register(
+        "java/net/Socket",
+        "getInputStream",
+        "()Ljava/io/InputStream;",
+        native_socket_get_input_stream,
+    );
+    registry.natives_mut().register(
+        "java/net/Socket",
+        "getOutputStream",
+        "()Ljava/io/OutputStream;",
+        native_socket_get_output_stream,
+    );
+    registry
+        .natives_mut()
+        .register("java/net/Socket", "close", "()V", native_socket_close);
+
+    let socket_input_stream_ctx = ClassContext {
+        class_name: "duke/net/SocketInputStream".to_string(),
+        super_class: Some("java/io/InputStream".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "fd".to_string(),
+            descriptor: "I".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/AutoCloseable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(socket_input_stream_ctx);
+    registry.natives_mut().register(
+        "duke/net/SocketInputStream",
+        "read",
+        "()I",
+        native_file_input_stream_read,
+    );
+    registry.natives_mut().register(
+        "duke/net/SocketInputStream",
+        "read",
+        "([B)I",
+        native_file_input_stream_read_bytes,
+    );
+    registry.natives_mut().register(
+        "duke/net/SocketInputStream",
+        "close",
+        "()V",
+        native_file_input_stream_close,
+    );
+
+    let socket_output_stream_ctx = ClassContext {
+        class_name: "duke/net/SocketOutputStream".to_string(),
+        super_class: Some("java/io/OutputStream".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "fd".to_string(),
+            descriptor: "I".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/AutoCloseable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(socket_output_stream_ctx);
+    registry.natives_mut().register(
+        "duke/net/SocketOutputStream",
+        "write",
+        "(I)V",
+        native_file_output_stream_write,
+    );
+    registry.natives_mut().register(
+        "duke/net/SocketOutputStream",
+        "write",
+        "([B)V",
+        native_file_output_stream_write_bytes,
+    );
+    registry.natives_mut().register(
+        "duke/net/SocketOutputStream",
+        "close",
+        "()V",
+        native_file_output_stream_close,
+    );
+
+    // Register java/lang/String ClassContext (empty — instance methods are native).
+    let string_ctx = ClassContext {
+        class_name: "java/lang/String".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: vec![
+            "java/lang/Comparable".to_string(),
+            "java/io/Serializable".to_string(),
+            "java/lang/CharSequence".to_string(),
+        ],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(string_ctx);
+
+    // String instance methods
+    registry
+        .natives_mut()
+        .register("java/lang/String", "length", "()I", native_string_length);
+    registry.natives_mut().register(
+        "java/lang/String",
+        "equals",
+        "(Ljava/lang/Object;)Z",
+        native_string_equals,
+    );
+    registry
+        .natives_mut()
+        .register("java/lang/String", "charAt", "(I)C", native_string_char_at);
+    registry.natives_mut().register(
+        "java/lang/String",
+        "substring",
+        "(I)Ljava/lang/String;",
+        native_string_substring,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "substring",
+        "(II)Ljava/lang/String;",
+        native_string_substring_range,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "indexOf",
+        "(Ljava/lang/String;)I",
+        native_string_indexof,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "contains",
+        "(Ljava/lang/CharSequence;)Z",
+        native_string_contains,
+    );
+    registry
+        .natives_mut()
+        .register("java/lang/String", "isEmpty", "()Z", native_string_isempty);
+    registry.natives_mut().register(
+        "java/lang/String",
+        "compareTo",
+        "(Ljava/lang/String;)I",
+        native_string_compareto,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "compareTo",
+        "(Ljava/lang/Object;)I",
+        native_string_compareto_object,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "startsWith",
+        "(Ljava/lang/String;)Z",
+        native_string_startswith,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "endsWith",
+        "(Ljava/lang/String;)Z",
+        native_string_endswith,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "trim",
+        "()Ljava/lang/String;",
+        native_string_trim,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "toCharArray",
+        "()[C",
+        native_string_tochararray,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "toUpperCase",
+        "()Ljava/lang/String;",
+        native_string_touppercase,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "toLowerCase",
+        "()Ljava/lang/String;",
+        native_string_tolowercase,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "replace",
+        "(CC)Ljava/lang/String;",
+        native_string_replace_char,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "replace",
+        "(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/lang/String;",
+        native_string_replace_charsequence,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "split",
+        "(Ljava/lang/String;)[Ljava/lang/String;",
+        native_string_split,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "hashCode",
+        "()I",
+        native_string_hashcode,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "toString",
+        "()Ljava/lang/String;",
+        native_string_tostring,
+    );
+
+    // String static methods
+    registry.natives_mut().register(
+        "java/lang/String",
+        "valueOf",
+        "(I)Ljava/lang/String;",
+        native_string_value_of_int,
+    );
+
+    // PrintStream.print (no newline)
+    registry.natives_mut().register(
+        "java/io/PrintStream",
+        "print",
+        "(Ljava/lang/String;)V",
+        native_print_string,
+    );
+    registry
+        .natives_mut()
+        .register("java/io/PrintStream", "print", "(I)V", native_print_int);
+
+    // println overloads
+    registry.natives_mut().register(
+        "java/io/PrintStream",
+        "println",
+        "(J)V",
+        native_println_long,
+    );
+    registry.natives_mut().register(
+        "java/io/PrintStream",
+        "println",
+        "(F)V",
+        native_println_float,
+    );
+    registry.natives_mut().register(
+        "java/io/PrintStream",
+        "println",
+        "(D)V",
+        native_println_double,
+    );
+    registry.natives_mut().register(
+        "java/io/PrintStream",
+        "println",
+        "(Z)V",
+        native_println_boolean,
+    );
+    registry.natives_mut().register(
+        "java/io/PrintStream",
+        "println",
+        "(C)V",
+        native_println_char,
+    );
+    registry.natives_mut().register(
+        "java/io/PrintStream",
+        "println",
+        "(Ljava/lang/Object;)V",
+        native_println_object,
+    );
+
+    // print overloads
+    registry
+        .natives_mut()
+        .register("java/io/PrintStream", "print", "(J)V", native_print_long);
+    registry
+        .natives_mut()
+        .register("java/io/PrintStream", "print", "(F)V", native_print_float);
+    registry
+        .natives_mut()
+        .register("java/io/PrintStream", "print", "(D)V", native_print_double);
+    registry
+        .natives_mut()
+        .register("java/io/PrintStream", "print", "(Z)V", native_print_boolean);
+    registry
+        .natives_mut()
+        .register("java/io/PrintStream", "print", "(C)V", native_print_char);
+    registry.natives_mut().register(
+        "java/io/PrintStream",
+        "print",
+        "(Ljava/lang/Object;)V",
+        native_print_object,
+    );
+
+    // System.exit (static)
+    registry
+        .natives_mut()
+        .register("java/lang/System", "exit", "(I)V", native_system_exit);
+    registry.natives_mut().register(
+        "java/lang/System",
+        "currentTimeMillis",
+        "()J",
+        native_system_current_time_millis,
+    );
+    registry.natives_mut().register(
+        "java/lang/System",
+        "nanoTime",
+        "()J",
+        native_system_nano_time,
+    );
+    registry.natives_mut().register(
+        "java/lang/System",
+        "getProperty",
+        "(Ljava/lang/String;)Ljava/lang/String;",
+        native_system_get_property,
+    );
+    registry.natives_mut().register(
+        "java/lang/System",
+        "getProperty",
+        "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
+        native_system_get_property_with_default,
+    );
+    registry.natives_mut().register(
+        "java/lang/System",
+        "setProperty",
+        "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
+        native_system_set_property,
+    );
+
+    // Register synthetic exception hierarchy so is_assignable_from can walk it.
+    // java/lang/Object (root — no super)
+    let object_ctx = ClassContext {
+        class_name: "java/lang/Object".to_string(),
+        super_class: None,
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(object_ctx);
+
+    // Object instance methods
+    registry
+        .natives_mut()
+        .register("java/lang/Object", "<init>", "()V", native_object_init);
+    registry.natives_mut().register(
+        "java/lang/Object",
+        "equals",
+        "(Ljava/lang/Object;)Z",
+        native_object_equals,
+    );
+    registry.natives_mut().register(
+        "java/lang/Object",
+        "hashCode",
+        "()I",
+        native_object_hashcode,
+    );
+    registry.natives_mut().register(
+        "java/lang/Object",
+        "toString",
+        "()Ljava/lang/String;",
+        native_object_tostring,
+    );
+    registry.natives_mut().register(
+        "java/lang/Object",
+        "clone",
+        "()Ljava/lang/Object;",
+        native_object_clone,
+    );
+    registry.natives_mut().register(
+        "java/lang/Object",
+        "getClass",
+        "()Ljava/lang/Class;",
+        native_object_get_class,
+    );
+
+    // java/lang/Class — lightweight stub for class literals
+    let class_ctx = ClassContext {
+        class_name: "java/lang/Class".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(class_ctx);
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "forName",
+        "(Ljava/lang/String;)Ljava/lang/Class;",
+        native_class_for_name,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "forName",
+        "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;",
+        native_class_for_name_with_loader,
+    );
+    registry.natives_mut().register(
+        "java/lang/Class",
+        "getName",
+        "()Ljava/lang/String;",
+        native_class_get_name,
+    );
+    registry.natives_mut().register(
+        "java/lang/Class",
+        "getPackageName",
+        "()Ljava/lang/String;",
+        native_class_get_package_name,
+    );
+    registry.natives_mut().register(
+        "java/lang/Class",
+        "desiredAssertionStatus",
+        "()Z",
+        native_class_desired_assertion_status,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "getDeclaredMethods",
+        "()[Ljava/lang/reflect/Method;",
+        native_class_get_declared_methods,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "getDeclaredFields",
+        "()[Ljava/lang/reflect/Field;",
+        native_class_get_declared_fields,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "getDeclaredConstructors",
+        "()[Ljava/lang/reflect/Constructor;",
+        native_class_get_declared_constructors,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "getMethods",
+        "()[Ljava/lang/reflect/Method;",
+        native_class_get_methods,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "getFields",
+        "()[Ljava/lang/reflect/Field;",
+        native_class_get_fields,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "getConstructors",
+        "()[Ljava/lang/reflect/Constructor;",
+        native_class_get_constructors,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "getDeclaredMethod",
+        "(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;",
+        native_class_get_declared_method,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "getDeclaredField",
+        "(Ljava/lang/String;)Ljava/lang/reflect/Field;",
+        native_class_get_declared_field,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "getDeclaredConstructor",
+        "([Ljava/lang/Class;)Ljava/lang/reflect/Constructor;",
+        native_class_get_declared_constructor,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "getMethod",
+        "(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;",
+        native_class_get_method,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "getField",
+        "(Ljava/lang/String;)Ljava/lang/reflect/Field;",
+        native_class_get_field,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "getConstructor",
+        "([Ljava/lang/Class;)Ljava/lang/reflect/Constructor;",
+        native_class_get_constructor,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "newInstance",
+        "()Ljava/lang/Object;",
+        native_class_new_instance,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "getProtectionDomain",
+        "()Ljava/security/ProtectionDomain;",
+        native_class_get_protection_domain,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/Class",
+        "getClassLoader",
+        "()Ljava/lang/ClassLoader;",
+        native_class_get_class_loader,
+    );
+    registry.natives_mut().register(
+        "jdk/internal/misc/CDS",
+        "isDumpingClassList0",
+        "()Z",
+        native_false_boolean,
+    );
+    registry.natives_mut().register(
+        "jdk/internal/misc/CDS",
+        "isDumpingArchive0",
+        "()Z",
+        native_false_boolean,
+    );
+    registry.natives_mut().register(
+        "jdk/internal/misc/CDS",
+        "isSharingEnabled0",
+        "()Z",
+        native_false_boolean,
+    );
+    registry.natives_mut().register(
+        "jdk/internal/misc/CDS",
+        "getRandomSeedForDumping",
+        "()J",
+        native_zero_long,
+    );
+    registry.natives_mut().register(
+        "jdk/internal/misc/CDS",
+        "initializeFromArchive",
+        "(Ljava/lang/Class;)V",
+        native_void_noop,
+    );
+    registry.natives_mut().register(
+        "jdk/internal/misc/CDS",
+        "defineArchivedModules",
+        "(Ljava/lang/ClassLoader;Ljava/lang/ClassLoader;)V",
+        native_void_noop,
+    );
+    registry.natives_mut().register(
+        "jdk/internal/misc/CDS",
+        "logLambdaFormInvoker",
+        "(Ljava/lang/String;)V",
+        native_void_noop,
+    );
+
+    let protection_domain_ctx = ClassContext {
+        class_name: "java/security/ProtectionDomain".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "codeSource".to_string(),
+            descriptor: "Ljava/security/CodeSource;".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(protection_domain_ctx);
+    registry.natives_mut().register(
+        "java/security/ProtectionDomain",
+        "getCodeSource",
+        "()Ljava/security/CodeSource;",
+        native_protection_domain_get_code_source,
+    );
+
+    let code_source_ctx = ClassContext {
+        class_name: "java/security/CodeSource".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "location".to_string(),
+            descriptor: "Ljava/net/URL;".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(code_source_ctx);
+    registry.natives_mut().register(
+        "java/security/CodeSource",
+        "getLocation",
+        "()Ljava/net/URL;",
+        native_code_source_get_location,
+    );
+
+    let url_ctx = ClassContext {
+        class_name: "java/net/URL".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "spec".to_string(),
+            descriptor: "Ljava/lang/String;".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(url_ctx);
+    registry.natives_mut().register(
+        "java/net/URL",
+        "toURI",
+        "()Ljava/net/URI;",
+        native_url_to_uri,
+    );
+    registry.natives_mut().register(
+        "java/net/URL",
+        "setURLStreamHandlerFactory",
+        "(Ljava/net/URLStreamHandlerFactory;)V",
+        native_url_set_url_stream_handler_factory,
+    );
+
+    let uri_ctx = ClassContext {
+        class_name: "java/net/URI".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "spec".to_string(),
+            descriptor: "Ljava/lang/String;".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(uri_ctx);
+
+    let path_ctx = ClassContext {
+        class_name: "java/nio/file/Path".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "path".to_string(),
+            descriptor: "Ljava/lang/String;".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(path_ctx);
+    registry.natives_mut().register(
+        "java/nio/file/Path",
+        "of",
+        "(Ljava/net/URI;)Ljava/nio/file/Path;",
+        native_path_of,
+    );
+    registry.natives_mut().register(
+        "java/nio/file/Path",
+        "toFile",
+        "()Ljava/io/File;",
+        native_path_to_file,
+    );
+    let paths_ctx = ClassContext {
+        class_name: "java/nio/file/Paths".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(paths_ctx);
+    registry.natives_mut().register(
+        "java/nio/file/Paths",
+        "get",
+        "(Ljava/lang/String;[Ljava/lang/String;)Ljava/nio/file/Path;",
+        native_paths_get,
+    );
+
+    let file_attribute_ctx = ClassContext {
+        class_name: "java/nio/file/attribute/FileAttribute".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(file_attribute_ctx);
+
+    let posix_owner_read_ref =
+        heap.allocate("java/nio/file/attribute/PosixFilePermission".to_string(), 0);
+    let posix_owner_write_ref =
+        heap.allocate("java/nio/file/attribute/PosixFilePermission".to_string(), 0);
+    let posix_owner_execute_ref =
+        heap.allocate("java/nio/file/attribute/PosixFilePermission".to_string(), 0);
+    let posix_file_permission_ctx = ClassContext {
+        class_name: "java/nio/file/attribute/PosixFilePermission".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "OWNER_READ".to_string(),
+                descriptor: "Ljava/nio/file/attribute/PosixFilePermission;".to_string(),
+                is_static: true,
+            },
+            FieldEntry {
+                name: "OWNER_WRITE".to_string(),
+                descriptor: "Ljava/nio/file/attribute/PosixFilePermission;".to_string(),
+                is_static: true,
+            },
+            FieldEntry {
+                name: "OWNER_EXECUTE".to_string(),
+                descriptor: "Ljava/nio/file/attribute/PosixFilePermission;".to_string(),
+                is_static: true,
+            },
+        ],
+        static_fields: vec![
+            Slot::Reference(Some(posix_owner_read_ref)),
+            Slot::Reference(Some(posix_owner_write_ref)),
+            Slot::Reference(Some(posix_owner_execute_ref)),
+        ],
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(posix_file_permission_ctx);
+
+    let posix_file_permissions_ctx = ClassContext {
+        class_name: "java/nio/file/attribute/PosixFilePermissions".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(posix_file_permissions_ctx);
+    registry.natives_mut().register(
+        "java/nio/file/attribute/PosixFilePermissions",
+        "asFileAttribute",
+        "(Ljava/util/Set;)Ljava/nio/file/attribute/FileAttribute;",
+        native_posix_file_permissions_as_file_attribute,
+    );
+    let boot_archive_entry_ctx = ClassContext {
+        class_name: "duke/boot/ArchiveEntry".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "name".to_string(),
+                descriptor: "Ljava/lang/String;".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "directory".to_string(),
+                descriptor: "Z".to_string(),
+                is_static: false,
+            },
+        ],
+        static_fields: Vec::new(),
+        instance_field_count: 2,
+        interfaces: vec!["org/springframework/boot/loader/launch/Archive$Entry".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(boot_archive_entry_ctx);
+    registry.natives_mut().register(
+        "duke/boot/ArchiveEntry",
+        "name",
+        "()Ljava/lang/String;",
+        native_boot_archive_entry_name,
+    );
+    registry.natives_mut().register(
+        "duke/boot/ArchiveEntry",
+        "isDirectory",
+        "()Z",
+        native_boot_archive_entry_is_directory,
+    );
+    registry.natives_mut().register_callback(
+        "org/springframework/boot/loader/launch/JarFileArchive",
+        "getClassPathUrls",
+        "(Ljava/util/function/Predicate;Ljava/util/function/Predicate;)Ljava/util/Set;",
+        native_boot_jar_file_archive_get_class_path_urls,
+    );
+    registry.natives_mut().register(
+        "org/springframework/boot/loader/launch/Archive",
+        "getManifest",
+        "()Ljava/util/jar/Manifest;",
+        native_boot_archive_get_manifest,
+    );
+    registry.natives_mut().register(
+        "org/springframework/boot/loader/launch/JarFileArchive",
+        "getManifest",
+        "()Ljava/util/jar/Manifest;",
+        native_boot_jar_file_archive_get_manifest,
+    );
+    registry.natives_mut().register_callback(
+        "org/springframework/boot/loader/launch/ExplodedArchive",
+        "getClassPathUrls",
+        "(Ljava/util/function/Predicate;Ljava/util/function/Predicate;)Ljava/util/Set;",
+        native_boot_exploded_archive_get_class_path_urls,
+    );
+    registry.natives_mut().register(
+        "org/springframework/boot/loader/launch/ExplodedArchive",
+        "getManifest",
+        "()Ljava/util/jar/Manifest;",
+        native_boot_exploded_archive_get_manifest,
+    );
+    registry.natives_mut().register_callback(
+        "org/springframework/boot/loader/launch/LaunchedClassLoader",
+        "<init>",
+        "(ZLorg/springframework/boot/loader/launch/Archive;[Ljava/net/URL;Ljava/lang/ClassLoader;)V",
+        native_boot_launched_class_loader_init,
+    );
+
+    let reflect_method_ctx = ClassContext {
+        class_name: "java/lang/reflect/Method".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "declaringClass".to_string(),
+                descriptor: "Ljava/lang/Class;".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "name".to_string(),
+                descriptor: "Ljava/lang/String;".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "descriptor".to_string(),
+                descriptor: "Ljava/lang/String;".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "publicFlag".to_string(),
+                descriptor: "Z".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "staticFlag".to_string(),
+                descriptor: "Z".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "accessibleFlag".to_string(),
+                descriptor: "Z".to_string(),
+                is_static: false,
+            },
+        ],
+        static_fields: Vec::new(),
+        instance_field_count: 6,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(reflect_method_ctx);
+    registry.natives_mut().register(
+        "java/lang/reflect/Method",
+        "getName",
+        "()Ljava/lang/String;",
+        native_reflect_method_get_name,
+    );
+    registry.natives_mut().register(
+        "java/lang/reflect/Method",
+        "getDeclaringClass",
+        "()Ljava/lang/Class;",
+        native_reflection_member_get_declaring_class,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/reflect/Method",
+        "getReturnType",
+        "()Ljava/lang/Class;",
+        native_reflect_method_get_return_type,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/reflect/Method",
+        "invoke",
+        "(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;",
+        native_reflect_method_invoke,
+    );
+    registry.natives_mut().register(
+        "java/lang/reflect/Method",
+        "setAccessible",
+        "(Z)V",
+        native_reflection_member_set_accessible,
+    );
+    registry.natives_mut().register(
+        "java/lang/reflect/Method",
+        "getParameterCount",
+        "()I",
+        native_reflect_method_get_parameter_count,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/reflect/Method",
+        "getParameterTypes",
+        "()[Ljava/lang/Class;",
+        native_reflect_executable_get_parameter_types,
+    );
+
+    let reflect_constructor_ctx = ClassContext {
+        class_name: "java/lang/reflect/Constructor".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "declaringClass".to_string(),
+                descriptor: "Ljava/lang/Class;".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "name".to_string(),
+                descriptor: "Ljava/lang/String;".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "descriptor".to_string(),
+                descriptor: "Ljava/lang/String;".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "publicFlag".to_string(),
+                descriptor: "Z".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "staticFlag".to_string(),
+                descriptor: "Z".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "accessibleFlag".to_string(),
+                descriptor: "Z".to_string(),
+                is_static: false,
+            },
+        ],
+        static_fields: Vec::new(),
+        instance_field_count: 6,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(reflect_constructor_ctx);
+    registry.natives_mut().register(
+        "java/lang/reflect/Constructor",
+        "getName",
+        "()Ljava/lang/String;",
+        native_reflect_constructor_get_name,
+    );
+    registry.natives_mut().register(
+        "java/lang/reflect/Constructor",
+        "getDeclaringClass",
+        "()Ljava/lang/Class;",
+        native_reflection_member_get_declaring_class,
+    );
+    registry.natives_mut().register(
+        "java/lang/reflect/Constructor",
+        "setAccessible",
+        "(Z)V",
+        native_reflection_member_set_accessible,
+    );
+    registry.natives_mut().register(
+        "java/lang/reflect/Constructor",
+        "getParameterCount",
+        "()I",
+        native_reflect_method_get_parameter_count,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/reflect/Constructor",
+        "getParameterTypes",
+        "()[Ljava/lang/Class;",
+        native_reflect_executable_get_parameter_types,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/reflect/Constructor",
+        "newInstance",
+        "([Ljava/lang/Object;)Ljava/lang/Object;",
+        native_reflect_constructor_new_instance,
+    );
+
+    let reflect_field_ctx = ClassContext {
+        class_name: "java/lang/reflect/Field".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "declaringClass".to_string(),
+                descriptor: "Ljava/lang/Class;".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "name".to_string(),
+                descriptor: "Ljava/lang/String;".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "descriptor".to_string(),
+                descriptor: "Ljava/lang/String;".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "publicFlag".to_string(),
+                descriptor: "Z".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "staticFlag".to_string(),
+                descriptor: "Z".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "accessibleFlag".to_string(),
+                descriptor: "Z".to_string(),
+                is_static: false,
+            },
+        ],
+        static_fields: Vec::new(),
+        instance_field_count: 6,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(reflect_field_ctx);
+    registry.natives_mut().register(
+        "java/lang/reflect/Field",
+        "getName",
+        "()Ljava/lang/String;",
+        native_reflect_field_get_name,
+    );
+    registry.natives_mut().register(
+        "java/lang/reflect/Field",
+        "getDeclaringClass",
+        "()Ljava/lang/Class;",
+        native_reflection_member_get_declaring_class,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/reflect/Field",
+        "getType",
+        "()Ljava/lang/Class;",
+        native_reflect_field_get_type,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/reflect/Field",
+        "get",
+        "(Ljava/lang/Object;)Ljava/lang/Object;",
+        native_reflect_field_get,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/reflect/Field",
+        "set",
+        "(Ljava/lang/Object;Ljava/lang/Object;)V",
+        native_reflect_field_set,
+    );
+    registry.natives_mut().register(
+        "java/lang/reflect/Field",
+        "setAccessible",
+        "(Z)V",
+        native_reflection_member_set_accessible,
+    );
+
+    let runnable_ctx = ClassContext {
+        class_name: "java/lang/Runnable".to_string(),
+        super_class: None,
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(runnable_ctx);
+
+    let class_loader_ctx = ClassContext {
+        class_name: "java/lang/ClassLoader".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(class_loader_ctx);
+    registry.natives_mut().register(
+        "java/lang/ClassLoader",
+        "registerAsParallelCapable",
+        "()Z",
+        native_class_loader_register_as_parallel_capable,
+    );
+
+    let thread_ctx = ClassContext {
+        class_name: "java/lang/Thread".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "target".to_string(),
+                descriptor: "Ljava/lang/Runnable;".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "threadId".to_string(),
+                descriptor: "I".to_string(),
+                is_static: false,
+            },
+        ],
+        static_fields: Vec::new(),
+        instance_field_count: 2,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(thread_ctx);
+    registry
+        .natives_mut()
+        .register("java/lang/Thread", "<init>", "()V", native_thread_init);
+    registry.natives_mut().register(
+        "java/lang/Thread",
+        "<init>",
+        "(Ljava/lang/Runnable;)V",
+        native_thread_init_runnable,
+    );
+    registry.natives_mut().register(
+        "java/lang/Thread",
+        "currentThread",
+        "()Ljava/lang/Thread;",
+        native_thread_current_thread,
+    );
+    registry
+        .natives_mut()
+        .register("java/lang/Thread", "start", "()V", native_thread_start);
+    registry
+        .natives_mut()
+        .register("java/lang/Thread", "join", "()V", native_thread_join);
+    registry
+        .natives_mut()
+        .register("java/lang/Thread", "sleep", "(J)V", native_thread_sleep);
+    registry.natives_mut().register(
+        "java/lang/Thread",
+        "setContextClassLoader",
+        "(Ljava/lang/ClassLoader;)V",
+        native_void_noop,
+    );
+
+    // java/lang/Throwable extends Object
+    let throwable_ctx = ClassContext {
+        class_name: "java/lang/Throwable".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(throwable_ctx);
+    registry.natives_mut().register(
+        "java/lang/Throwable",
+        "addSuppressed",
+        "(Ljava/lang/Throwable;)V",
+        native_throwable_add_suppressed,
+    );
+    registry
+        .natives_mut()
+        .register("java/lang/Throwable", "<init>", "()V", native_object_init);
+    registry.natives_mut().register(
+        "java/lang/Throwable",
+        "<init>",
+        "(Ljava/lang/String;)V",
+        native_object_init,
+    );
+
+    // java/lang/Exception extends Throwable
+    let exception_ctx = ClassContext {
+        class_name: "java/lang/Exception".to_string(),
+        super_class: Some("java/lang/Throwable".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(exception_ctx);
+    registry
+        .natives_mut()
+        .register("java/lang/Exception", "<init>", "()V", native_object_init);
+    registry.natives_mut().register(
+        "java/lang/Exception",
+        "<init>",
+        "(Ljava/lang/String;)V",
+        native_object_init,
+    );
+
+    // java/lang/RuntimeException extends Exception
+    let rte_ctx = ClassContext {
+        class_name: "java/lang/RuntimeException".to_string(),
+        super_class: Some("java/lang/Exception".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(rte_ctx);
+    registry.natives_mut().register(
+        "java/lang/RuntimeException",
+        "<init>",
+        "()V",
+        native_object_init,
+    );
+    registry.natives_mut().register(
+        "java/lang/RuntimeException",
+        "<init>",
+        "(Ljava/lang/String;)V",
+        native_object_init,
+    );
+
+    let illegal_argument_ctx = ClassContext {
+        class_name: "java/lang/IllegalArgumentException".to_string(),
+        super_class: Some("java/lang/RuntimeException".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(illegal_argument_ctx);
+
+    let illegal_thread_state_ctx = ClassContext {
+        class_name: "java/lang/IllegalThreadStateException".to_string(),
+        super_class: Some("java/lang/IllegalArgumentException".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(illegal_thread_state_ctx);
+
+    let reflective_operation_ctx = ClassContext {
+        class_name: "java/lang/ReflectiveOperationException".to_string(),
+        super_class: Some("java/lang/Exception".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(reflective_operation_ctx);
+
+    let class_not_found_ctx = ClassContext {
+        class_name: "java/lang/ClassNotFoundException".to_string(),
+        super_class: Some("java/lang/ReflectiveOperationException".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(class_not_found_ctx);
+
+    let no_such_method_ctx = ClassContext {
+        class_name: "java/lang/NoSuchMethodException".to_string(),
+        super_class: Some("java/lang/ReflectiveOperationException".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(no_such_method_ctx);
+
+    let no_such_field_ctx = ClassContext {
+        class_name: "java/lang/NoSuchFieldException".to_string(),
+        super_class: Some("java/lang/ReflectiveOperationException".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(no_such_field_ctx);
+
+    let illegal_access_ctx = ClassContext {
+        class_name: "java/lang/IllegalAccessException".to_string(),
+        super_class: Some("java/lang/ReflectiveOperationException".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(illegal_access_ctx);
+
+    let instantiation_ctx = ClassContext {
+        class_name: "java/lang/InstantiationException".to_string(),
+        super_class: Some("java/lang/ReflectiveOperationException".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(instantiation_ctx);
+
+    let invocation_target_ctx = ClassContext {
+        class_name: "java/lang/reflect/InvocationTargetException".to_string(),
+        super_class: Some("java/lang/ReflectiveOperationException".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(invocation_target_ctx);
+
+    // java/lang/AutoCloseable — marker interface for try-with-resources.
+    // Registered so is_assignable_from correctly handles queries like
+    // "does TryWithResources$Res implement AutoCloseable?" without
+    // erroring on an unknown class.
+    let autocloseable_ctx = ClassContext {
+        class_name: "java/lang/AutoCloseable".to_string(),
+        super_class: None, // interface — no super class
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(autocloseable_ctx);
+
+    // java/lang/Enum — abstract superclass for all enums.
+    // Fields: name (String) at index 0, ordinal (int) at index 1.
+    let enum_ctx = ClassContext {
+        class_name: "java/lang/Enum".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "name".to_string(),
+                descriptor: "Ljava/lang/String;".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "ordinal".to_string(),
+                descriptor: "I".to_string(),
+                is_static: false,
+            },
+        ],
+        static_fields: Vec::new(),
+        instance_field_count: 2,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(enum_ctx);
+    registry.natives_mut().register(
+        "java/lang/Enum",
+        "<init>",
+        "(Ljava/lang/String;I)V",
+        native_enum_init,
+    );
+    registry
+        .natives_mut()
+        .register("java/lang/Enum", "ordinal", "()I", native_enum_ordinal);
+    registry.natives_mut().register(
+        "java/lang/Enum",
+        "name",
+        "()Ljava/lang/String;",
+        native_enum_name,
+    );
+    registry.natives_mut().register(
+        "java/lang/Enum",
+        "valueOf",
+        "(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;",
+        native_enum_valueof,
+    );
+
+    // java/lang/Integer — boxed int with value field + numeric constants
+    let integer_ctx = ClassContext {
+        class_name: "java/lang/Integer".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "value".to_string(),
+                descriptor: "I".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "MAX_VALUE".to_string(),
+                descriptor: "I".to_string(),
+                is_static: true,
+            },
+            FieldEntry {
+                name: "MIN_VALUE".to_string(),
+                descriptor: "I".to_string(),
+                is_static: true,
+            },
+            FieldEntry {
+                name: "TYPE".to_string(),
+                descriptor: "Ljava/lang/Class;".to_string(),
+                is_static: true,
+            },
+        ],
+        static_fields: vec![
+            Slot::Int(i32::MAX),
+            Slot::Int(i32::MIN),
+            Slot::Reference(None),
+        ],
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/Comparable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(integer_ctx);
+    registry.natives_mut().register(
+        "java/lang/Integer",
+        "parseInt",
+        "(Ljava/lang/String;)I",
+        native_integer_parseint,
+    );
+    registry.natives_mut().register(
+        "java/lang/Integer",
+        "parseInt",
+        "(Ljava/lang/String;I)I",
+        native_integer_parseint_radix,
+    );
+    registry.natives_mut().register(
+        "java/lang/Integer",
+        "valueOf",
+        "(Ljava/lang/String;)Ljava/lang/Integer;",
+        native_integer_valueof_string,
+    );
+    registry.natives_mut().register(
+        "java/lang/Integer",
+        "valueOf",
+        "(Ljava/lang/String;I)Ljava/lang/Integer;",
+        native_integer_valueof_string_radix,
+    );
+    registry.natives_mut().register(
+        "java/lang/Integer",
+        "decode",
+        "(Ljava/lang/String;)Ljava/lang/Integer;",
+        native_integer_decode,
+    );
+    registry.natives_mut().register(
+        "java/lang/Integer",
+        "valueOf",
+        "(I)Ljava/lang/Integer;",
+        native_integer_valueof,
+    );
+    registry.natives_mut().register(
+        "java/lang/Integer",
+        "intValue",
+        "()I",
+        native_integer_intvalue,
+    );
+    registry.natives_mut().register(
+        "java/lang/Integer",
+        "toString",
+        "(I)Ljava/lang/String;",
+        native_integer_tostring_static,
+    );
+    registry.natives_mut().register(
+        "java/lang/Integer",
+        "toHexString",
+        "(I)Ljava/lang/String;",
+        native_integer_tohexstring_static,
+    );
+    registry.natives_mut().register(
+        "java/lang/Integer",
+        "toOctalString",
+        "(I)Ljava/lang/String;",
+        native_integer_tooctalstring_static,
+    );
+    registry.natives_mut().register(
+        "java/lang/Integer",
+        "toBinaryString",
+        "(I)Ljava/lang/String;",
+        native_integer_tobinarystring_static,
+    );
+    registry.natives_mut().register(
+        "java/lang/Integer",
+        "toUnsignedLong",
+        "(I)J",
+        native_integer_tounsignedlong_static,
+    );
+    registry.natives_mut().register(
+        "java/lang/Integer",
+        "compareUnsigned",
+        "(II)I",
+        native_integer_compareunsigned_static,
+    );
+    registry.natives_mut().register(
+        "java/lang/Integer",
+        "compareTo",
+        "(Ljava/lang/Object;)I",
+        native_integer_compareto,
+    );
+    registry.natives_mut().register(
+        "java/lang/Integer",
+        "compareTo",
+        "(Ljava/lang/Integer;)I",
+        native_integer_compareto,
+    );
+
+    // java/lang/Long — boxed long with value field + numeric constants
+    let long_ctx = ClassContext {
+        class_name: "java/lang/Long".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "value".to_string(),
+                descriptor: "J".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "MAX_VALUE".to_string(),
+                descriptor: "J".to_string(),
+                is_static: true,
+            },
+            FieldEntry {
+                name: "MIN_VALUE".to_string(),
+                descriptor: "J".to_string(),
+                is_static: true,
+            },
+            FieldEntry {
+                name: "TYPE".to_string(),
+                descriptor: "Ljava/lang/Class;".to_string(),
+                is_static: true,
+            },
+        ],
+        static_fields: vec![
+            Slot::Long(i64::MAX),
+            Slot::Long(i64::MIN),
+            Slot::Reference(None),
+        ],
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/Comparable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(long_ctx);
+    registry.natives_mut().register(
+        "java/lang/Long",
+        "parseLong",
+        "(Ljava/lang/String;)J",
+        native_long_parselong,
+    );
+    registry.natives_mut().register(
+        "java/lang/Long",
+        "parseLong",
+        "(Ljava/lang/String;I)J",
+        native_long_parselong_radix,
+    );
+    registry.natives_mut().register(
+        "java/lang/Long",
+        "valueOf",
+        "(Ljava/lang/String;)Ljava/lang/Long;",
+        native_long_valueof_string,
+    );
+    registry.natives_mut().register(
+        "java/lang/Long",
+        "valueOf",
+        "(Ljava/lang/String;I)Ljava/lang/Long;",
+        native_long_valueof_string_radix,
+    );
+    registry.natives_mut().register(
+        "java/lang/Long",
+        "decode",
+        "(Ljava/lang/String;)Ljava/lang/Long;",
+        native_long_decode,
+    );
+    registry.natives_mut().register(
+        "java/lang/Long",
+        "valueOf",
+        "(J)Ljava/lang/Long;",
+        native_long_valueof,
+    );
+    registry
+        .natives_mut()
+        .register("java/lang/Long", "longValue", "()J", native_long_longvalue);
+    registry.natives_mut().register(
+        "java/lang/Long",
+        "toString",
+        "(J)Ljava/lang/String;",
+        native_long_tostring_static,
+    );
+    registry.natives_mut().register(
+        "java/lang/Long",
+        "toHexString",
+        "(J)Ljava/lang/String;",
+        native_long_tohexstring_static,
+    );
+    registry.natives_mut().register(
+        "java/lang/Long",
+        "toOctalString",
+        "(J)Ljava/lang/String;",
+        native_long_tooctalstring_static,
+    );
+    registry.natives_mut().register(
+        "java/lang/Long",
+        "toBinaryString",
+        "(J)Ljava/lang/String;",
+        native_long_tobinarystring_static,
+    );
+    registry.natives_mut().register(
+        "java/lang/Long",
+        "compareUnsigned",
+        "(JJ)I",
+        native_long_compareunsigned_static,
+    );
+    registry.natives_mut().register(
+        "java/lang/Long",
+        "compareTo",
+        "(Ljava/lang/Object;)I",
+        native_long_compareto,
+    );
+    registry.natives_mut().register(
+        "java/lang/Long",
+        "compareTo",
+        "(Ljava/lang/Long;)I",
+        native_long_compareto,
+    );
+
+    // java/lang/Double — boxed double with value field + numeric constants
+    let double_ctx = ClassContext {
+        class_name: "java/lang/Double".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "value".to_string(),
+                descriptor: "D".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "MAX_VALUE".to_string(),
+                descriptor: "D".to_string(),
+                is_static: true,
+            },
+            FieldEntry {
+                name: "MIN_VALUE".to_string(),
+                descriptor: "D".to_string(),
+                is_static: true,
+            },
+            FieldEntry {
+                name: "NaN".to_string(),
+                descriptor: "D".to_string(),
+                is_static: true,
+            },
+            FieldEntry {
+                name: "POSITIVE_INFINITY".to_string(),
+                descriptor: "D".to_string(),
+                is_static: true,
+            },
+            FieldEntry {
+                name: "NEGATIVE_INFINITY".to_string(),
+                descriptor: "D".to_string(),
+                is_static: true,
+            },
+            FieldEntry {
+                name: "TYPE".to_string(),
+                descriptor: "Ljava/lang/Class;".to_string(),
+                is_static: true,
+            },
+        ],
+        static_fields: vec![
+            Slot::Double(f64::MAX),
+            Slot::Double(5e-324_f64),
+            Slot::Double(f64::NAN),
+            Slot::Double(f64::INFINITY),
+            Slot::Double(f64::NEG_INFINITY),
+            Slot::Reference(None),
+        ],
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/Comparable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(double_ctx);
+    registry.natives_mut().register(
+        "java/lang/Double",
+        "parseDouble",
+        "(Ljava/lang/String;)D",
+        native_double_parsedouble,
+    );
+    registry.natives_mut().register(
+        "java/lang/Double",
+        "valueOf",
+        "(D)Ljava/lang/Double;",
+        native_double_valueof,
+    );
+    registry.natives_mut().register(
+        "java/lang/Double",
+        "doubleValue",
+        "()D",
+        native_double_doublevalue,
+    );
+    registry
+        .natives_mut()
+        .register("java/lang/Double", "isNaN", "(D)Z", native_double_isnan);
+    registry.natives_mut().register(
+        "java/lang/Double",
+        "compareTo",
+        "(Ljava/lang/Object;)I",
+        native_double_compareto,
+    );
+    registry.natives_mut().register(
+        "java/lang/Double",
+        "compareTo",
+        "(Ljava/lang/Double;)I",
+        native_double_compareto,
+    );
+
+    // java/lang/Float — boxed float with value field
+    let float_ctx = ClassContext {
+        class_name: "java/lang/Float".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "value".to_string(),
+                descriptor: "F".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "TYPE".to_string(),
+                descriptor: "Ljava/lang/Class;".to_string(),
+                is_static: true,
+            },
+        ],
+        static_fields: vec![Slot::Reference(None)],
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/Comparable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(float_ctx);
+    registry.natives_mut().register(
+        "java/lang/Float",
+        "parseFloat",
+        "(Ljava/lang/String;)F",
+        native_float_parsefloat,
+    );
+    registry.natives_mut().register(
+        "java/lang/Float",
+        "valueOf",
+        "(F)Ljava/lang/Float;",
+        native_float_valueof,
+    );
+    registry.natives_mut().register(
+        "java/lang/Float",
+        "floatValue",
+        "()F",
+        native_float_floatvalue,
+    );
+    registry.natives_mut().register(
+        "java/lang/Float",
+        "compareTo",
+        "(Ljava/lang/Object;)I",
+        native_float_compareto,
+    );
+    registry.natives_mut().register(
+        "java/lang/Float",
+        "compareTo",
+        "(Ljava/lang/Float;)I",
+        native_float_compareto,
+    );
+
+    // java/lang/Boolean — boxed boolean + static utility
+    let boolean_ctx = ClassContext {
+        class_name: "java/lang/Boolean".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "value".to_string(),
+                descriptor: "Z".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "TYPE".to_string(),
+                descriptor: "Ljava/lang/Class;".to_string(),
+                is_static: true,
+            },
+        ],
+        static_fields: vec![Slot::Reference(None)],
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/Comparable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(boolean_ctx);
+    registry.natives_mut().register(
+        "java/lang/Boolean",
+        "parseBoolean",
+        "(Ljava/lang/String;)Z",
+        native_boolean_parseboolean,
+    );
+    registry.natives_mut().register(
+        "java/lang/Boolean",
+        "valueOf",
+        "(Z)Ljava/lang/Boolean;",
+        native_boolean_valueof,
+    );
+    registry.natives_mut().register(
+        "java/lang/Boolean",
+        "booleanValue",
+        "()Z",
+        native_boolean_booleanvalue,
+    );
+    registry.natives_mut().register(
+        "java/lang/Boolean",
+        "compareTo",
+        "(Ljava/lang/Object;)I",
+        native_boolean_compareto,
+    );
+    registry.natives_mut().register(
+        "java/lang/Boolean",
+        "compareTo",
+        "(Ljava/lang/Boolean;)I",
+        native_boolean_compareto,
+    );
+
+    let byte_ctx = ClassContext {
+        class_name: "java/lang/Byte".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "value".to_string(),
+                descriptor: "B".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "TYPE".to_string(),
+                descriptor: "Ljava/lang/Class;".to_string(),
+                is_static: true,
+            },
+        ],
+        static_fields: vec![Slot::Reference(None)],
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/Comparable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(byte_ctx);
+    registry.natives_mut().register(
+        "java/lang/Byte",
+        "parseByte",
+        "(Ljava/lang/String;)B",
+        native_byte_parsebyte,
+    );
+    registry.natives_mut().register(
+        "java/lang/Byte",
+        "parseByte",
+        "(Ljava/lang/String;I)B",
+        native_byte_parsebyte_radix,
+    );
+    registry.natives_mut().register(
+        "java/lang/Byte",
+        "valueOf",
+        "(Ljava/lang/String;)Ljava/lang/Byte;",
+        native_byte_valueof_string,
+    );
+    registry.natives_mut().register(
+        "java/lang/Byte",
+        "valueOf",
+        "(Ljava/lang/String;I)Ljava/lang/Byte;",
+        native_byte_valueof_string_radix,
+    );
+    registry.natives_mut().register(
+        "java/lang/Byte",
+        "valueOf",
+        "(B)Ljava/lang/Byte;",
+        native_byte_valueof,
+    );
+    registry
+        .natives_mut()
+        .register("java/lang/Byte", "byteValue", "()B", native_byte_bytevalue);
+    registry.natives_mut().register(
+        "java/lang/Byte",
+        "compareTo",
+        "(Ljava/lang/Object;)I",
+        native_byte_compareto,
+    );
+    registry.natives_mut().register(
+        "java/lang/Byte",
+        "compareTo",
+        "(Ljava/lang/Byte;)I",
+        native_byte_compareto,
+    );
+
+    let short_ctx = ClassContext {
+        class_name: "java/lang/Short".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "value".to_string(),
+                descriptor: "S".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "TYPE".to_string(),
+                descriptor: "Ljava/lang/Class;".to_string(),
+                is_static: true,
+            },
+        ],
+        static_fields: vec![Slot::Reference(None)],
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/Comparable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(short_ctx);
+    registry.natives_mut().register(
+        "java/lang/Short",
+        "parseShort",
+        "(Ljava/lang/String;)S",
+        native_short_parseshort,
+    );
+    registry.natives_mut().register(
+        "java/lang/Short",
+        "parseShort",
+        "(Ljava/lang/String;I)S",
+        native_short_parseshort_radix,
+    );
+    registry.natives_mut().register(
+        "java/lang/Short",
+        "valueOf",
+        "(Ljava/lang/String;)Ljava/lang/Short;",
+        native_short_valueof_string,
+    );
+    registry.natives_mut().register(
+        "java/lang/Short",
+        "valueOf",
+        "(Ljava/lang/String;I)Ljava/lang/Short;",
+        native_short_valueof_string_radix,
+    );
+    registry.natives_mut().register(
+        "java/lang/Short",
+        "valueOf",
+        "(S)Ljava/lang/Short;",
+        native_short_valueof,
+    );
+    registry.natives_mut().register(
+        "java/lang/Short",
+        "shortValue",
+        "()S",
+        native_short_shortvalue,
+    );
+    registry.natives_mut().register(
+        "java/lang/Short",
+        "compareTo",
+        "(Ljava/lang/Object;)I",
+        native_short_compareto,
+    );
+    registry.natives_mut().register(
+        "java/lang/Short",
+        "compareTo",
+        "(Ljava/lang/Short;)I",
+        native_short_compareto,
+    );
+
+    let void_ctx = ClassContext {
+        class_name: "java/lang/Void".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "TYPE".to_string(),
+            descriptor: "Ljava/lang/Class;".to_string(),
+            is_static: true,
+        }],
+        static_fields: vec![Slot::Reference(None)],
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(void_ctx);
+
+    // java/lang/Math — static math utilities with PI and E constants
+    let math_ctx = ClassContext {
+        class_name: "java/lang/Math".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "PI".to_string(),
+                descriptor: "D".to_string(),
+                is_static: true,
+            },
+            FieldEntry {
+                name: "E".to_string(),
+                descriptor: "D".to_string(),
+                is_static: true,
+            },
+        ],
+        static_fields: vec![
+            Slot::Double(std::f64::consts::PI),
+            Slot::Double(std::f64::consts::E),
+        ],
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(math_ctx);
+    registry
+        .natives_mut()
+        .register("java/lang/Math", "max", "(II)I", native_math_max_int);
+    registry
+        .natives_mut()
+        .register("java/lang/Math", "min", "(II)I", native_math_min_int);
+    registry
+        .natives_mut()
+        .register("java/lang/Math", "abs", "(I)I", native_math_abs_int);
+    registry.natives_mut().register(
+        "java/lang/Math",
+        "floorMod",
+        "(II)I",
+        native_math_floor_mod_int,
+    );
+    registry
+        .natives_mut()
+        .register("java/lang/Math", "sqrt", "(D)D", native_math_sqrt);
+    registry
+        .natives_mut()
+        .register("java/lang/Math", "pow", "(DD)D", native_math_pow);
+    registry
+        .natives_mut()
+        .register("java/lang/Math", "floor", "(D)D", native_math_floor);
+    registry
+        .natives_mut()
+        .register("java/lang/Math", "ceil", "(D)D", native_math_ceil);
+    registry
+        .natives_mut()
+        .register("java/lang/Math", "round", "(D)J", native_math_round_double);
+    registry
+        .natives_mut()
+        .register("java/lang/Math", "abs", "(J)J", native_math_abs_long);
+    registry
+        .natives_mut()
+        .register("java/lang/Math", "abs", "(D)D", native_math_abs_double);
+    registry
+        .natives_mut()
+        .register("java/lang/Math", "max", "(JJ)J", native_math_max_long);
+    registry
+        .natives_mut()
+        .register("java/lang/Math", "min", "(JJ)J", native_math_min_long);
+    registry
+        .natives_mut()
+        .register("java/lang/Math", "max", "(DD)D", native_math_max_double);
+    registry
+        .natives_mut()
+        .register("java/lang/Math", "min", "(DD)D", native_math_min_double);
+
+    // String.valueOf overloads (int already registered above)
+    registry.natives_mut().register(
+        "java/lang/String",
+        "valueOf",
+        "(J)Ljava/lang/String;",
+        native_string_value_of_long,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "valueOf",
+        "(D)Ljava/lang/String;",
+        native_string_value_of_double,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "valueOf",
+        "(F)Ljava/lang/String;",
+        native_string_value_of_float,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "valueOf",
+        "(Z)Ljava/lang/String;",
+        native_string_value_of_boolean,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "valueOf",
+        "(C)Ljava/lang/String;",
+        native_string_value_of_char,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "valueOf",
+        "(Ljava/lang/Object;)Ljava/lang/String;",
+        native_string_value_of_object,
+    );
+
+    // String.concat
+    registry.natives_mut().register(
+        "java/lang/String",
+        "concat",
+        "(Ljava/lang/String;)Ljava/lang/String;",
+        native_string_concat,
+    );
+
+    // String.format(String, Object[]) -> String
+    registry.natives_mut().register(
+        "java/lang/String",
+        "format",
+        "(Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;",
+        native_string_format,
+    );
+
+    // java/lang/StringBuilder — mutable string buffer
+    let sb_ctx = ClassContext {
+        class_name: "java/lang/StringBuilder".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: vec!["java/lang/CharSequence".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(sb_ctx);
+
+    // StringBuilder.<init>()V
+    registry
+        .natives_mut()
+        .register("java/lang/StringBuilder", "<init>", "()V", native_sb_init);
+    // StringBuilder.<init>(String)V
+    registry.natives_mut().register(
+        "java/lang/StringBuilder",
+        "<init>",
+        "(Ljava/lang/String;)V",
+        native_sb_init_string,
+    );
+    // StringBuilder.append(String)
+    registry.natives_mut().register(
+        "java/lang/StringBuilder",
+        "append",
+        "(Ljava/lang/String;)Ljava/lang/StringBuilder;",
+        native_sb_append_string,
+    );
+    // StringBuilder.append(int)
+    registry.natives_mut().register(
+        "java/lang/StringBuilder",
+        "append",
+        "(I)Ljava/lang/StringBuilder;",
+        native_sb_append_int,
+    );
+    // StringBuilder.append(long)
+    registry.natives_mut().register(
+        "java/lang/StringBuilder",
+        "append",
+        "(J)Ljava/lang/StringBuilder;",
+        native_sb_append_long,
+    );
+    // StringBuilder.append(double)
+    registry.natives_mut().register(
+        "java/lang/StringBuilder",
+        "append",
+        "(D)Ljava/lang/StringBuilder;",
+        native_sb_append_double,
+    );
+    // StringBuilder.append(float)
+    registry.natives_mut().register(
+        "java/lang/StringBuilder",
+        "append",
+        "(F)Ljava/lang/StringBuilder;",
+        native_sb_append_float,
+    );
+    // StringBuilder.append(boolean)
+    registry.natives_mut().register(
+        "java/lang/StringBuilder",
+        "append",
+        "(Z)Ljava/lang/StringBuilder;",
+        native_sb_append_boolean,
+    );
+    // StringBuilder.append(char)
+    registry.natives_mut().register(
+        "java/lang/StringBuilder",
+        "append",
+        "(C)Ljava/lang/StringBuilder;",
+        native_sb_append_char,
+    );
+    // StringBuilder.toString()
+    registry.natives_mut().register(
+        "java/lang/StringBuilder",
+        "toString",
+        "()Ljava/lang/String;",
+        native_sb_tostring,
+    );
+    // StringBuilder.length()
+    registry
+        .natives_mut()
+        .register("java/lang/StringBuilder", "length", "()I", native_sb_length);
+
+    // java/lang/Character — static character utilities + boxed char
+    let character_ctx = ClassContext {
+        class_name: "java/lang/Character".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "value".to_string(),
+                descriptor: "C".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "TYPE".to_string(),
+                descriptor: "Ljava/lang/Class;".to_string(),
+                is_static: true,
+            },
+        ],
+        static_fields: vec![Slot::Reference(None)],
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/Comparable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(character_ctx);
+
+    // Character.isDigit(C)Z
+    registry.natives_mut().register(
+        "java/lang/Character",
+        "isDigit",
+        "(C)Z",
+        native_char_is_digit,
+    );
+    // Character.isLetter(C)Z
+    registry.natives_mut().register(
+        "java/lang/Character",
+        "isLetter",
+        "(C)Z",
+        native_char_is_letter,
+    );
+    // Character.isWhitespace(C)Z
+    registry.natives_mut().register(
+        "java/lang/Character",
+        "isWhitespace",
+        "(C)Z",
+        native_char_is_whitespace,
+    );
+    // Character.isUpperCase(C)Z
+    registry.natives_mut().register(
+        "java/lang/Character",
+        "isUpperCase",
+        "(C)Z",
+        native_char_is_uppercase,
+    );
+    // Character.isLowerCase(C)Z
+    registry.natives_mut().register(
+        "java/lang/Character",
+        "isLowerCase",
+        "(C)Z",
+        native_char_is_lowercase,
+    );
+    // Character.toUpperCase(C)C
+    registry.natives_mut().register(
+        "java/lang/Character",
+        "toUpperCase",
+        "(C)C",
+        native_char_to_uppercase,
+    );
+    // Character.toLowerCase(C)C
+    registry.natives_mut().register(
+        "java/lang/Character",
+        "toLowerCase",
+        "(C)C",
+        native_char_to_lowercase,
+    );
+    // Character.isLetterOrDigit(C)Z
+    registry.natives_mut().register(
+        "java/lang/Character",
+        "isLetterOrDigit",
+        "(C)Z",
+        native_char_is_letter_or_digit,
+    );
+    // Character.valueOf(C)Ljava/lang/Character;
+    registry.natives_mut().register(
+        "java/lang/Character",
+        "valueOf",
+        "(C)Ljava/lang/Character;",
+        native_char_valueof,
+    );
+    // Character.charValue()C
+    registry.natives_mut().register(
+        "java/lang/Character",
+        "charValue",
+        "()C",
+        native_char_charvalue,
+    );
+    registry.natives_mut().register(
+        "java/lang/Character",
+        "compareTo",
+        "(Ljava/lang/Object;)I",
+        native_char_compareto,
+    );
+    registry.natives_mut().register(
+        "java/lang/Character",
+        "compareTo",
+        "(Ljava/lang/Character;)I",
+        native_char_compareto,
+    );
+
+    let collection_ctx = ClassContext {
+        class_name: "java/util/Collection".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(collection_ctx);
+    registry.natives_mut().register(
+        "java/util/Collection",
+        "toArray",
+        "()[Ljava/lang/Object;",
+        native_collection_to_array,
+    );
+    registry.natives_mut().register(
+        "java/util/Collection",
+        "toArray",
+        "([Ljava/lang/Object;)[Ljava/lang/Object;",
+        native_collection_to_array_with_seed_array,
+    );
+
+    // java/util/ArrayList — dynamic list backed by growable fields
+    // fields[0] = size (Int), fields[1..] = elements (pushed dynamically)
+    let arraylist_ctx = ClassContext {
+        class_name: "java/util/ArrayList".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "size".to_string(),
+            descriptor: "I".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: vec![
+            "java/util/List".to_string(),
+            "java/util/Collection".to_string(),
+            "java/lang/Iterable".to_string(),
+        ],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(arraylist_ctx);
+    registry.natives_mut().register(
+        "java/util/ArrayList",
+        "<init>",
+        "()V",
+        native_arraylist_init,
+    );
+    registry.natives_mut().register(
+        "java/util/ArrayList",
+        "add",
+        "(Ljava/lang/Object;)Z",
+        native_arraylist_add,
+    );
+    registry.natives_mut().register(
+        "java/util/ArrayList",
+        "get",
+        "(I)Ljava/lang/Object;",
+        native_arraylist_get,
+    );
+    registry
+        .natives_mut()
+        .register("java/util/ArrayList", "size", "()I", native_arraylist_size);
+    registry.natives_mut().register(
+        "java/util/ArrayList",
+        "toArray",
+        "()[Ljava/lang/Object;",
+        native_collection_to_array,
+    );
+    registry.natives_mut().register(
+        "java/util/ArrayList",
+        "toArray",
+        "([Ljava/lang/Object;)[Ljava/lang/Object;",
+        native_collection_to_array_with_seed_array,
+    );
+    registry.natives_mut().register(
+        "java/util/ArrayList",
+        "iterator",
+        "()Ljava/util/Iterator;",
+        native_arraylist_iterator,
+    );
+    registry.natives_mut().register_callback(
+        "java/util/ArrayList",
+        "sort",
+        "(Ljava/util/Comparator;)V",
+        array_list_sort,
+    );
+
+    // duke/util/ArrayListIterator — internal iterator for ArrayList
+    // fields[0] = ArrayList reference, fields[1] = current index (Int)
+    let iter_ctx = ClassContext {
+        class_name: "duke/util/ArrayListIterator".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "list".to_string(),
+                descriptor: "Ljava/util/ArrayList;".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "index".to_string(),
+                descriptor: "I".to_string(),
+                is_static: false,
+            },
+        ],
+        static_fields: Vec::new(),
+        instance_field_count: 2,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(iter_ctx);
+    registry.natives_mut().register(
+        "duke/util/ArrayListIterator",
+        "<init>",
+        "()V",
+        native_arraylist_iter_init,
+    );
+    registry.natives_mut().register(
+        "duke/util/ArrayListIterator",
+        "hasNext",
+        "()Z",
+        native_arraylist_iter_hasnext,
+    );
+    registry.natives_mut().register(
+        "duke/util/ArrayListIterator",
+        "next",
+        "()Ljava/lang/Object;",
+        native_arraylist_iter_next,
+    );
+
+    // java/util/Arrays — static array utilities
+    let arrays_ctx = ClassContext {
+        class_name: "java/util/Arrays".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(arrays_ctx);
+    registry
+        .natives_mut()
+        .register("java/util/Arrays", "fill", "([II)V", native_arrays_fill_int);
+    registry.natives_mut().register(
+        "java/util/Arrays",
+        "fill",
+        "([Ljava/lang/Object;Ljava/lang/Object;)V",
+        native_arrays_fill_object,
+    );
+    registry.natives_mut().register(
+        "java/util/Arrays",
+        "copyOf",
+        "([II)[I",
+        native_arrays_copyof_int,
+    );
+    registry.natives_mut().register(
+        "java/util/Arrays",
+        "copyOf",
+        "([Ljava/lang/Object;I)[Ljava/lang/Object;",
+        native_arrays_copyof_object,
+    );
+    registry
+        .natives_mut()
+        .register("java/util/Arrays", "sort", "([I)V", native_arrays_sort_int);
+
+    // java/util/HashMap — hash map backed by flat key/value pair list in fields
+    // fields[0] = Int(size), fields[1]=key0, fields[2]=val0, fields[3]=key1, ...
+    let hashmap_ctx = ClassContext {
+        class_name: "java/util/HashMap".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "size".to_string(),
+            descriptor: "I".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(hashmap_ctx);
+    registry
+        .natives_mut()
+        .register("java/util/HashMap", "<init>", "()V", native_hashmap_init);
+    registry.natives_mut().register(
+        "java/util/HashMap",
+        "put",
+        "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+        native_hashmap_put,
+    );
+    registry.natives_mut().register(
+        "java/util/HashMap",
+        "get",
+        "(Ljava/lang/Object;)Ljava/lang/Object;",
+        native_hashmap_get,
+    );
+    registry.natives_mut().register(
+        "java/util/HashMap",
+        "containsKey",
+        "(Ljava/lang/Object;)Z",
+        native_hashmap_contains_key,
+    );
+    registry
+        .natives_mut()
+        .register("java/util/HashMap", "size", "()I", native_hashmap_size);
+    registry.natives_mut().register(
+        "java/util/HashMap",
+        "remove",
+        "(Ljava/lang/Object;)Ljava/lang/Object;",
+        native_hashmap_remove,
+    );
+    registry.natives_mut().register(
+        "java/util/HashMap",
+        "isEmpty",
+        "()Z",
+        native_hashmap_is_empty,
+    );
+    registry.natives_mut().register(
+        "java/util/HashMap",
+        "getOrDefault",
+        "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+        native_hashmap_get_or_default,
+    );
+
+    // java/util/HashSet — set backed by unique elements in fields
+    // fields[0] = Int(size), fields[1..] = elements (unique, no duplicates)
+    let hashset_ctx = ClassContext {
+        class_name: "java/util/HashSet".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "size".to_string(),
+            descriptor: "I".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: vec![
+            "java/util/Set".to_string(),
+            "java/util/Collection".to_string(),
+            "java/lang/Iterable".to_string(),
+        ],
+        bootstrap_methods: Vec::new(),
+    };
+    let set_ctx = ClassContext {
+        class_name: "java/util/Set".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(set_ctx);
+    registry.natives_mut().register(
+        "java/util/Set",
+        "of",
+        "([Ljava/lang/Object;)Ljava/util/Set;",
+        native_set_of,
+    );
+    registry.register(hashset_ctx);
+    registry
+        .natives_mut()
+        .register("java/util/HashSet", "<init>", "()V", native_hashset_init);
+    registry.natives_mut().register_callback(
+        "java/util/HashSet",
+        "<init>",
+        "(Ljava/util/Collection;)V",
+        native_hashset_init_from_collection,
+    );
+    registry.natives_mut().register(
+        "java/util/HashSet",
+        "add",
+        "(Ljava/lang/Object;)Z",
+        native_hashset_add,
+    );
+    registry.natives_mut().register(
+        "java/util/HashSet",
+        "contains",
+        "(Ljava/lang/Object;)Z",
+        native_hashset_contains,
+    );
+    registry.natives_mut().register(
+        "java/util/HashSet",
+        "remove",
+        "(Ljava/lang/Object;)Z",
+        native_hashset_remove,
+    );
+    registry
+        .natives_mut()
+        .register("java/util/HashSet", "size", "()I", native_hashset_size);
+    registry.natives_mut().register(
+        "java/util/HashSet",
+        "isEmpty",
+        "()Z",
+        native_hashset_is_empty,
+    );
+    registry.natives_mut().register(
+        "java/util/HashSet",
+        "iterator",
+        "()Ljava/util/Iterator;",
+        native_hashset_iterator,
+    );
+    registry.natives_mut().register(
+        "java/util/HashSet",
+        "toArray",
+        "()[Ljava/lang/Object;",
+        native_collection_to_array,
+    );
+    registry.natives_mut().register(
+        "java/util/HashSet",
+        "toArray",
+        "([Ljava/lang/Object;)[Ljava/lang/Object;",
+        native_collection_to_array_with_seed_array,
+    );
+
+    let hashset_iter_ctx = ClassContext {
+        class_name: "duke/util/HashSetIterator".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "set".to_string(),
+                descriptor: "Ljava/util/HashSet;".to_string(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "index".to_string(),
+                descriptor: "I".to_string(),
+                is_static: false,
+            },
+        ],
+        static_fields: Vec::new(),
+        instance_field_count: 2,
+        interfaces: vec!["java/util/Iterator".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(hashset_iter_ctx);
+    registry.natives_mut().register(
+        "duke/util/HashSetIterator",
+        "<init>",
+        "()V",
+        native_hashset_iter_init,
+    );
+    registry.natives_mut().register(
+        "duke/util/HashSetIterator",
+        "hasNext",
+        "()Z",
+        native_hashset_iter_hasnext,
+    );
+    registry.natives_mut().register(
+        "duke/util/HashSetIterator",
+        "next",
+        "()Ljava/lang/Object;",
+        native_hashset_iter_next,
+    );
+
+    // java/util/Collections — static utility class
+    // Only sort(List) is supported; delegates to ArrayList.sort(null).
+    let collections_ctx = ClassContext {
+        class_name: "java/util/Collections".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(collections_ctx);
+    registry.natives_mut().register_callback(
+        "java/util/Collections",
+        "sort",
+        "(Ljava/util/List;)V",
+        native_collections_sort,
+    );
+
+    // ── java.util.zip ──────────────────────────────────────────────────
+
+    let zip_exception_ctx = ClassContext {
+        class_name: "java/util/zip/ZipException".to_string(),
+        super_class: Some("java/io/IOException".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(zip_exception_ctx);
+
+    // ZipEntry: [name: Ref, compressedSize_lo: Int, compressedSize_hi: Int,
+    //            size_lo: Int, size_hi: Int, method: Int]  → 6 fields
+    let zip_entry_ctx = ClassContext {
+        class_name: "java/util/zip/ZipEntry".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![
+            FieldEntry {
+                name: "name".into(),
+                descriptor: "Ljava/lang/String;".into(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "compressedSize_lo".into(),
+                descriptor: "I".into(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "compressedSize_hi".into(),
+                descriptor: "I".into(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "size_lo".into(),
+                descriptor: "I".into(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "size_hi".into(),
+                descriptor: "I".into(),
+                is_static: false,
+            },
+            FieldEntry {
+                name: "method".into(),
+                descriptor: "I".into(),
+                is_static: false,
+            },
+        ],
+        static_fields: Vec::new(),
+        instance_field_count: 6,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(zip_entry_ctx);
+    registry.natives_mut().register(
+        "java/util/zip/ZipEntry",
+        "getName",
+        "()Ljava/lang/String;",
+        native_zip_entry_get_name,
+    );
+    registry.natives_mut().register(
+        "java/util/zip/ZipEntry",
+        "getCompressedSize",
+        "()J",
+        native_zip_entry_get_compressed_size,
+    );
+    registry.natives_mut().register(
+        "java/util/zip/ZipEntry",
+        "getSize",
+        "()J",
+        native_zip_entry_get_size,
+    );
+    registry.natives_mut().register(
+        "java/util/zip/ZipEntry",
+        "getMethod",
+        "()I",
+        native_zip_entry_get_method,
+    );
+
+    // ZipFile: [fd: Int] → 1 field
+    let zip_file_ctx = ClassContext {
+        class_name: "java/util/zip/ZipFile".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "fd".into(),
+            descriptor: "I".into(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/AutoCloseable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(zip_file_ctx);
+    registry.natives_mut().register(
+        "java/util/zip/ZipFile",
+        "<init>",
+        "(Ljava/lang/String;)V",
+        native_zip_file_init,
+    );
+    registry.natives_mut().register(
+        "java/util/zip/ZipFile",
+        "getEntry",
+        "(Ljava/lang/String;)Ljava/util/zip/ZipEntry;",
+        native_zip_file_get_entry,
+    );
+    registry.natives_mut().register(
+        "java/util/zip/ZipFile",
+        "getInputStream",
+        "(Ljava/util/zip/ZipEntry;)Ljava/io/InputStream;",
+        native_zip_file_get_input_stream,
+    );
+    registry.natives_mut().register(
+        "java/util/zip/ZipFile",
+        "close",
+        "()V",
+        native_zip_file_close,
+    );
+    registry
+        .natives_mut()
+        .register("java/util/zip/ZipFile", "size", "()I", native_zip_file_size);
+
+    // JarFile extends ZipFile — inherits everything for now.
+    let jar_file_ctx = ClassContext {
+        class_name: "java/util/jar/JarFile".to_string(),
+        super_class: Some("java/util/zip/ZipFile".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(jar_file_ctx);
+    registry.natives_mut().register(
+        "java/util/jar/JarFile",
+        "<init>",
+        "(Ljava/io/File;)V",
+        native_jar_file_init_from_file,
+    );
+    registry.natives_mut().register(
+        "java/util/jar/JarFile",
+        "<init>",
+        "(Ljava/io/File;ZILjava/lang/Runtime$Version;)V",
+        native_jar_file_init_with_mode_and_version,
+    );
+    registry.natives_mut().register(
+        "java/util/jar/JarFile",
+        "getManifest",
+        "()Ljava/util/jar/Manifest;",
+        native_jar_file_get_manifest,
+    );
+    registry.natives_mut().register(
+        "org/springframework/boot/loader/jar/NestedJarFile",
+        "getManifest",
+        "()Ljava/util/jar/Manifest;",
+        native_boot_nested_jar_file_get_manifest,
+    );
+    registry.natives_mut().register(
+        "org/springframework/boot/loader/net/protocol/jar/UrlJarFile",
+        "getManifest",
+        "()Ljava/util/jar/Manifest;",
+        native_boot_nested_jar_file_get_manifest,
+    );
+    registry.natives_mut().register(
+        "org/springframework/boot/loader/net/protocol/jar/UrlNestedJarFile",
+        "getManifest",
+        "()Ljava/util/jar/Manifest;",
+        native_boot_nested_jar_file_get_manifest,
+    );
+
+    let manifest_ctx = ClassContext {
+        class_name: "java/util/jar/Manifest".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "raw".to_string(),
+            descriptor: "Ljava/lang/String;".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(manifest_ctx);
+    registry.natives_mut().register(
+        "java/util/jar/Manifest",
+        "getMainAttributes",
+        "()Ljava/util/jar/Attributes;",
+        native_manifest_get_main_attributes,
+    );
+
+    let attributes_ctx = ClassContext {
+        class_name: "java/util/jar/Attributes".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "raw".to_string(),
+            descriptor: "Ljava/lang/String;".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(attributes_ctx);
+    registry.natives_mut().register(
+        "java/util/jar/Attributes",
+        "getValue",
+        "(Ljava/lang/String;)Ljava/lang/String;",
+        native_attributes_get_value,
+    );
+
+    // ByteBufferInputStream — internal class for reading decompressed ZIP data.
+    let byte_buffer_is_ctx = ClassContext {
+        class_name: "duke/zip/ByteBufferInputStream".to_string(),
+        super_class: Some("java/io/InputStream".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "fd".into(),
+            descriptor: "I".into(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: vec!["java/lang/AutoCloseable".to_string()],
+        bootstrap_methods: Vec::new(),
+    };
+    registry.register(byte_buffer_is_ctx);
+    registry.natives_mut().register(
+        "duke/zip/ByteBufferInputStream",
+        "read",
+        "()I",
+        native_file_input_stream_read,
+    );
+    registry.natives_mut().register(
+        "duke/zip/ByteBufferInputStream",
+        "read",
+        "([B)I",
+        native_file_input_stream_read_bytes,
+    );
+    registry.natives_mut().register(
+        "duke/zip/ByteBufferInputStream",
+        "close",
+        "()V",
+        native_file_input_stream_close,
+    );
+}


### PR DESCRIPTION
🕸️ Tangle: The `crates/duke-interpreter/src/lib.rs` file was suffering from the "Blob" anti-pattern, containing nearly 18,000 lines of code including both the massive ~3600-line `bootstrap_stdlib` function and all the internal native handler functions, making the file a monolithic dumping ground.

📐 Blueprint: Extracted `bootstrap_stdlib` to a dedicated `stdlib.rs` module. To prevent circular dependencies, the internal native handler functions and extraction helpers in `lib.rs` were made `pub(crate)`, allowing `stdlib.rs` to call them securely while remaining within the module boundary. Re-exported `bootstrap_stdlib` from `lib.rs` to preserve the public API.

🧱 Stability: Reduced coupling by compartmentalizing standard library registration separately from the interpreter and handler internals. This makes the codebase significantly easier to navigate and maintain without breaking downstream crates.

🔬 Verification: Ran `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test`. Code compiles with strict warnings and all 900+ tests pass.

---
*PR created automatically by Jules for task [16077250816174335899](https://jules.google.com/task/16077250816174335899) started by @madmax983*