### PR TITLE
⚡ Bolt: [Remove iterator collections in parsing hotpath]

### DIFF
--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -185,21 +185,24 @@ fn parse_class_file(c: &mut Cursor<'_>) -> ParseResult<ClassFile> {
 
     // interfaces
     let interfaces_count = c.read_u16()?;
-    let interfaces = (0..interfaces_count)
-        .map(|_| c.read_cp_index())
-        .collect::<Result<Vec<_>, _>>()?;
+    let mut interfaces = Vec::with_capacity(interfaces_count as usize);
+    for _ in 0..interfaces_count {
+        interfaces.push(c.read_cp_index()?);
+    }
 
     // fields
     let fields_count = c.read_u16()?;
-    let fields = (0..fields_count)
-        .map(|_| parse_field(c, cp_len))
-        .collect::<Result<Vec<_>, _>>()?;
+    let mut fields = Vec::with_capacity(fields_count as usize);
+    for _ in 0..fields_count {
+        fields.push(parse_field(c, cp_len)?);
+    }
 
     // methods
     let methods_count = c.read_u16()?;
-    let methods = (0..methods_count)
-        .map(|_| parse_method(c, cp_len))
-        .collect::<Result<Vec<_>, _>>()?;
+    let mut methods = Vec::with_capacity(methods_count as usize);
+    for _ in 0..methods_count {
+        methods.push(parse_method(c, cp_len)?);
+    }
 
     // class-level attributes
     let attributes = parse_attributes(c, cp_len)?;
@@ -357,9 +360,11 @@ fn parse_method(c: &mut Cursor<'_>, cp_len: usize) -> ParseResult<MethodInfo> {
 
 fn parse_attributes(c: &mut Cursor<'_>, cp_len: usize) -> ParseResult<Vec<AttributeInfo>> {
     let count = c.read_u16()?;
-    (0..count)
-        .map(|_| parse_attribute(c, cp_len))
-        .collect::<Result<Vec<_>, _>>()
+    let mut attrs = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        attrs.push(parse_attribute(c, cp_len)?);
+    }
+    Ok(attrs)
 }
 
 fn parse_attribute(c: &mut Cursor<'_>, _cp_len: usize) -> ParseResult<AttributeInfo> {


### PR DESCRIPTION
💡 **What:** Replaced iterator chains `(0..count).map(...).collect::<Result<Vec<_>, _>>()` with explicit `Vec::with_capacity(count as usize)` and a `for` loop with `.push()` in the hot parsing paths of `crates/duke-classfile/src/parser.rs` (specifically for interfaces, fields, methods, and attributes).

🎯 **Why:** While the iterator chain format is idiomatic, collecting into a `Result<Vec<T>, E>` causes the iterator's `size_hint` to drop its lower bound to `0` due to internal error-checking shunts. This prevents `Vec::from_iter` from preallocating the necessary capacity, forcing repeated dynamic memory allocations and copying as elements are collected during parsing.

📊 **Impact:** Reduces heap allocations dramatically during JVM startup and class loading by preallocating exactly the right amount of memory for class file structures just once.

🔬 **Measurement:** Run `cargo test -p duke-classfile` or `cargo bench` (if available in the future) to verify that parsing correctness is fully preserved while observing the performance characteristics.

---
*PR created automatically by Jules for task [14195400961933990282](https://jules.google.com/task/14195400961933990282) started by @madmax983*