### PR TITLE
⚡ Bolt: Remove intermediate .collect::<Vec<_>>() chains

### DIFF
--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -7258,9 +7258,7 @@ fn run_execution(
                 // ⚡ Bolt: `ExceptionEntry` now derives `Clone`, avoiding manual field-by-field mapping.
                 let exc_table = registry.get(&current_class)?.methods[*method_idx]
                     .exception_table
-                    .iter()
-                    .cloned()
-                    .collect::<Vec<_>>();
+                    .clone();
                 let handler = find_exception_handler(
                     &exc_table,
                     $throw_pc,
@@ -7329,9 +7327,7 @@ fn run_execution(
                                 // ⚡ Bolt: `ExceptionEntry` now derives `Clone`, avoiding manual field-by-field mapping.
                                 let tbl = ctx.methods[*method_idx]
                                     .exception_table
-                                    .iter()
-                                    .cloned()
-                                    .collect::<Vec<_>>();
+                                    .clone();
                                 (tbl, cpc)
                             };
                             let handler = find_exception_handler(


### PR DESCRIPTION
💡 What: Removed inefficient `.iter().cloned().collect::<Vec<_>>()` chains when copying the exception table in `execute_class` and replaced them with direct `.clone()` calls on the vector.

🎯 Why: The previous code unnecessarily created an iterator, cloned each item individually, and then re-collected them into a new `Vec`. Calling `.clone()` directly on the `Vec` is much more idiomatic, readable, and allows the standard library to use its optimized internal cloning implementation which properly pre-allocates exact capacity.

📊 Impact: Reduces iterator overhead and improves code readability on the exception handling path.

🔬 Measurement: Run `cargo test` to verify that all existing VM semantics (especially `tests::exception_flow_records_throw_and_catch`) continue to pass perfectly.

---
*PR created automatically by Jules for task [7065793219889177024](https://jules.google.com/task/7065793219889177024) started by @madmax983*