### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -1035,6 +1035,88 @@ mod tests {
     }
     #[test]
     #[cfg(feature = "telemetry")]
+    fn test_ser_helpers_site3() {
+        use serde::Serialize;
+        use std::collections::HashMap;
+
+        #[derive(Serialize)]
+        struct Dummy {
+            #[serde(serialize_with = "crate::ser_helpers::site3")]
+            map: HashMap<(String, String, usize), i32>,
+        }
+
+        let mut map = HashMap::new();
+        map.insert(("MyClass".to_string(), "myMethod".to_string(), 42), 100);
+
+        let dummy = Dummy { map };
+        let json = serde_json::to_string(&dummy).unwrap();
+        assert_eq!(json, r#"{"map":{"MyClass::myMethod@42":100}}"#);
+    }
+
+    #[test]
+    #[cfg(feature = "telemetry")]
+    fn test_ser_helpers_site2_u16() {
+        use serde::Serialize;
+        use std::collections::HashMap;
+
+        #[derive(Serialize)]
+        struct Dummy {
+            #[serde(serialize_with = "crate::ser_helpers::site2_u16")]
+            map: HashMap<(String, u16), i32>,
+        }
+
+        let mut map = HashMap::new();
+        map.insert(("MyClass".to_string(), 15), 200);
+
+        let dummy = Dummy { map };
+        let json = serde_json::to_string(&dummy).unwrap();
+        assert_eq!(json, r#"{"map":{"MyClass@15":200}}"#);
+    }
+
+    #[test]
+    #[cfg(feature = "telemetry")]
+    fn test_ser_helpers_pair_str() {
+        use serde::Serialize;
+        use std::collections::HashMap;
+
+        #[derive(Serialize)]
+        struct Dummy {
+            #[serde(serialize_with = "crate::ser_helpers::pair_str")]
+            map: HashMap<(String, String), i32>,
+        }
+
+        let mut map = HashMap::new();
+        map.insert(("MyClass".to_string(), "myMethod".to_string()), 300);
+
+        let dummy = Dummy { map };
+        let json = serde_json::to_string(&dummy).unwrap();
+        assert_eq!(json, r#"{"map":{"MyClass::myMethod":300}}"#);
+    }
+
+    #[test]
+    #[cfg(feature = "telemetry")]
+    fn test_ser_helpers_sorted_set() {
+        use serde::Serialize;
+        use std::collections::HashSet;
+
+        #[derive(Serialize)]
+        struct Dummy {
+            #[serde(serialize_with = "crate::ser_helpers::sorted_set")]
+            set: HashSet<String>,
+        }
+
+        let mut set = HashSet::new();
+        set.insert("B".to_string());
+        set.insert("A".to_string());
+        set.insert("C".to_string());
+
+        let dummy = Dummy { set };
+        let json = serde_json::to_string(&dummy).unwrap();
+        assert_eq!(json, r#"{"set":["A","B","C"]}"#);
+    }
+
+    #[test]
+    #[cfg(feature = "telemetry")]
     fn telemetry_store_to_markdown_report() {
         let mut store = TelemetryStore::default();
         store.bytecode_cost.record("iadd", "Foo", "bar", 10, 100);


### PR DESCRIPTION
🎯 Target: `duke_telemetry::ser_helpers` serialization functions.
💣 Risk: If custom serde serialization logic changes unexpectedly, JSON output for telemetry may format incorrectly, breaking external log analyzers that rely on these stringified map keys.
🧪 Strategy: Added direct serialization tests utilizing `serde_json::to_string` on custom structs applying `#[serde(serialize_with)]` attributes corresponding to `site3`, `site2_u16`, `pair_str`, and `sorted_set`. Used maps with exactly one element to prevent iteration order instability in JSON string assertions.
🔬 Verification: Run `cargo test -p duke-telemetry --features telemetry`.

---
*PR created automatically by Jules for task [7113422208572080817](https://jules.google.com/task/7113422208572080817) started by @madmax983*