### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -8,6 +8,12 @@
 pub mod context;
 /// Repositories for loaded classes and registered native methods.
 pub mod registry;
+/// Bootstrapping for the standard Java library types and native methods.
+///
+/// This module prevents the VM from crashing by injecting essential classes
+/// (like `java/lang/Object`, `java/lang/String`, and `java/io/PrintStream`)
+/// and registering their required native handers (like `println`) before
+/// user code executes.
 pub mod stdlib;
 mod threading;
 

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -4,6 +4,29 @@ use crate::registry::ClassRegistry;
 use crate::*;
 use duke_runtime::Slot;
 
+/// Injects core Java types and native handlers into the VM registry.
+///
+/// This function must be called *before* attempting to execute any Java code,
+/// as it provides the definitions for foundational classes (`java/lang/Object`,
+/// `java/lang/String`, etc.) and registers the native handlers required by
+/// methods like `System.out.println`.
+///
+/// # Examples
+///
+/// ```rust
+/// use duke_interpreter::registry::ClassRegistry;
+/// use duke_gc::Heap;
+/// use duke_interpreter::bootstrap_stdlib;
+///
+/// let mut registry = ClassRegistry::new();
+/// let mut heap = Heap::new();
+///
+/// // Inject standard library classes into the registry
+/// bootstrap_stdlib(&mut registry, &mut heap);
+///
+/// // Now it is safe to load and execute user classes!
+/// assert!(registry.get("java/lang/Object").is_ok());
+/// ```
 #[allow(clippy::too_many_lines)]
 pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) {
     // Allocate a PrintStream object on the heap.


### PR DESCRIPTION
📖 Chapter: Documented the `stdlib` module and its primary entrypoint `bootstrap_stdlib`.
🔦 Insight: Explained *why* this bootstrapping is necessary—injecting foundational Java classes (like `Object` and `String`) and native implementations (like `println`) before the VM starts executing user code, which prevents fatal missing-class errors.
🧪 Example: Added an executable doc-test to `bootstrap_stdlib` demonstrating how a `ClassRegistry` and `Heap` are initialized and passed to the bootstrapper.
🖼️ Preview: Ran `cargo doc --open` to verify clean HTML formatting.

---
*PR created automatically by Jules for task [8501839854446010198](https://jules.google.com/task/8501839854446010198) started by @madmax983*