### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -1,9 +1,35 @@
+//! Minimal standard library bootstrap definitions.
+//!
 use crate::context::{ClassContext, FieldEntry};
 use crate::registry::ClassRegistry;
 #[allow(clippy::wildcard_imports)]
 use crate::*;
 use duke_runtime::Slot;
 
+/// Bootstraps the minimal standard library required for native method support.
+///
+/// This function populates the `ClassRegistry` with essential classes like
+/// `java/lang/System`, `java/io/PrintStream`, `java/lang/Math`, etc.
+/// It also registers the corresponding native handlers so the interpreter
+/// can successfully execute these core standard library calls.
+///
+/// # Examples
+///
+/// ```
+/// use duke_interpreter::{ClassRegistry, bootstrap_stdlib};
+/// use duke_gc::Heap;
+///
+/// let mut registry = ClassRegistry::new();
+/// let mut heap = Heap::new();
+///
+/// // Registry is empty initially
+/// assert!(!registry.contains("java/lang/System"));
+///
+/// bootstrap_stdlib(&mut registry, &mut heap);
+///
+/// // Now essential classes are registered
+/// assert!(registry.contains("java/lang/System"));
+/// ```
 #[allow(clippy::too_many_lines)]
 pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) {
     // Allocate a PrintStream object on the heap.


### PR DESCRIPTION
📖 Chapter: The `stdlib` module
🔦 Insight: Explained the standard library registration logic and the `bootstrap_stdlib` function. Clarified why it is necessary to pre-populate the registry so the interpreter can successfully execute core standard library calls.
🧪 Example: Added an executable doctest for `bootstrap_stdlib` verifying classes like `java/lang/System` get loaded correctly.
🖼️ Preview: Generated docs successfully (`cargo doc --no-deps` now passes cleanly with `-D missing_docs`).

---
*PR created automatically by Jules for task [6358736261289268104](https://jules.google.com/task/6358736261289268104) started by @madmax983*