### PR TITLE
⚡ Bolt: Replace map+collect with pre-allocated vector in parse_attributes

### DIFF
--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -357,9 +357,11 @@ fn parse_method(c: &mut Cursor<'_>, cp_len: usize) -> ParseResult<MethodInfo> {
 
 fn parse_attributes(c: &mut Cursor<'_>, cp_len: usize) -> ParseResult<Vec<AttributeInfo>> {
     let count = c.read_u16()?;
-    (0..count)
-        .map(|_| parse_attribute(c, cp_len))
-        .collect::<Result<Vec<_>, _>>()
+    let mut attrs = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        attrs.push(parse_attribute(c, cp_len)?);
+    }
+    Ok(attrs)
 }
 
 fn parse_attribute(c: &mut Cursor<'_>, _cp_len: usize) -> ParseResult<AttributeInfo> {


### PR DESCRIPTION
💡 **What**: Replaced the `.collect::<Result<Vec<_>, _>>()` iterator chain in `parse_attributes` with a manual `Vec::with_capacity` initialization and a `for` loop that uses `.push()`.

🎯 **Why**: When using `.collect::<Result<Vec<_>, _>>()` in Rust, the `size_hint` of the iterator drops to `0` because the underlying `ResultShunt` iterator adapter short-circuits on errors. As a result, the `Vec` cannot pre-allocate its capacity, leading to `O(log N)` repeated heap reallocations as the vector grows. Since `parse_attributes` is in a hot path during classfile parsing and the exact number of attributes (`count`) is known in advance, manual pre-allocation avoids this overhead.

📊 **Impact**: Eliminates `O(log N)` intermediate vector reallocations per `parse_attributes` invocation.

🔬 **Measurement**: Ran `cargo test`, `cargo clippy`, and `cargo fmt`. Verify performance impact via standard class loading benchmarks.

---
*PR created automatically by Jules for task [12425985383296559988](https://jules.google.com/task/12425985383296559988) started by @madmax983*