### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/crates/duke-loader/src/zip.rs
+++ b/crates/duke-loader/src/zip.rs
@@ -508,6 +508,15 @@ fn parse_central_directory(
 mod tests {
     use super::*;
 
+    #[test]
+    fn test_zip_loader_reader() {
+        let zip_bytes = build_stored_zip("test.txt", b"hello world");
+        let reader = ZipReader::from_bytes(zip_bytes).expect("valid zip");
+        let loader = ZipLoader::from_reader(reader).expect("valid zip");
+        let r = loader.reader();
+        assert_eq!(r.data.len(), 125);
+    }
+
     // ── Helpers: build minimal valid ZIPs in memory ──────────────────────
 
     /// Build a minimal ZIP archive containing one STORED entry.


### PR DESCRIPTION
🎯 Target: `crates/duke-loader/src/zip.rs` - `ZipLoader::reader` function.
💣 Risk: Missing test coverage for `ZipLoader::reader` which provides access to the underlying `ZipReader` instance. Without it, regressions in this accessor might go unnoticed.
🧪 Strategy: Added `test_zip_loader_reader` unit test that uses the existing `build_stored_zip` helper to create an in-memory mock zip, instantiates a `ZipReader` via `from_bytes`, wraps it in a `ZipLoader`, retrieves the reader using the target method, and verifies the size of the internal `data` byte array.
🔭 Verification: Execute `cargo test test_zip_loader_reader` to specifically run this test.

---
*PR created automatically by Jules for task [14345063026140534729](https://jules.google.com/task/14345063026140534729) started by @madmax983*