### PR TITLE
👺 Havoc: [ZipReader Capacity Overflow]

### DIFF
--- a/crates/duke-loader/src/zip.rs
+++ b/crates/duke-loader/src/zip.rs
@@ -442,7 +442,8 @@ fn parse_central_directory(
     cd_size: usize,
     expected_count: usize,
 ) -> LoadResult<HashMap<String, ZipEntryInfo>> {
-    let mut index = HashMap::with_capacity(expected_count);
+    let safe_capacity = expected_count.min(cd_size / 46);
+    let mut index = HashMap::with_capacity(safe_capacity);
     let cd_end = cd_offset + cd_size;
     let mut pos = cd_offset;
 

--- a/crates/duke-loader/tests/havoc_zip_capacity.rs
+++ b/crates/duke-loader/tests/havoc_zip_capacity.rs
@@ -2,15 +2,10 @@
 fn havoc_test_oom() {
     let bad_data = vec![
         // EOCD signature
-        0x50, 0x4b, 0x05, 0x06,
-        0, 0,
-        0, 0,
-        0, 0,
-        0xff, 0xff, // 65535 entries
-        0xff, 0xff,
-        0, 0, 0, 0, // cd size
+        0x50, 0x4b, 0x05, 0x06, 0, 0, 0, 0, 0, 0, 0xff, 0xff, // 65535 entries
+        0xff, 0xff, 0, 0, 0, 0, // cd size
         0, 0, 0, 0, // offset
-        0, 0
+        0, 0,
     ];
     let res = duke_loader::zip::ZipReader::from_bytes(bad_data);
     assert!(res.is_err());

--- a/crates/duke-loader/tests/havoc_zip_capacity.rs
+++ b/crates/duke-loader/tests/havoc_zip_capacity.rs
@@ -1,0 +1,17 @@
+#[test]
+fn havoc_test_oom() {
+    let bad_data = vec![
+        // EOCD signature
+        0x50, 0x4b, 0x05, 0x06,
+        0, 0,
+        0, 0,
+        0, 0,
+        0xff, 0xff, // 65535 entries
+        0xff, 0xff,
+        0, 0, 0, 0, // cd size
+        0, 0, 0, 0, // offset
+        0, 0
+    ];
+    let res = duke_loader::zip::ZipReader::from_bytes(bad_data);
+    assert!(res.is_err());
+}


### PR DESCRIPTION
* 🧨 **The Trigger:** A malicious ZIP archive (like a crafted JAR) specifies an artificially high `entry_count` (e.g. 65535) in its End of Central Directory record, but has a small or empty Central Directory. The `HashMap::with_capacity(expected_count)` blindly allocates memory for entries that don't exist, leading to massive memory bloat or Out-Of-Memory (OOM) crashes when parsing multiple such files.
* 📉 **The Stack Trace:** No stack trace, but causes system freeze or process kill due to OOM depending on the number of concurrent parsing tasks.
* 🧪 **Reproduction:** Run `cargo test --test havoc_zip_capacity` which crafts a fake ZIP with `entry_count=65535` and no actual central directory. 
* 😈 **Comment:** You assumed the zip header told the truth. Chaos laughs at your unverified metadata. We clamped it to `expected_count.min(cd_size / 46)` because math is better than trust.

---
*PR created automatically by Jules for task [5907979148014693939](https://jules.google.com/task/5907979148014693939) started by @madmax983*