### PR TITLE
⚡ Bolt: [performance improvement] Pre-allocate capacity in method descriptor parsing

### DIFF
--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -17655,7 +17655,7 @@ fn parse_arg_types(descriptor: &str) -> Vec<char> {
         .strip_prefix('(')
         .and_then(|s| s.split_once(')'))
         .map_or("", |(p, _)| p);
-    let mut types = Vec::new();
+    let mut types = Vec::with_capacity(params.len());
     let mut chars = params.chars().peekable();
     while let Some(c) = chars.next() {
         match c {
@@ -17729,7 +17729,7 @@ fn parse_arg_descriptors(descriptor: &str) -> Vec<String> {
         .strip_prefix('(')
         .and_then(|s| s.split_once(')'))
         .map_or("", |(p, _)| p);
-    let mut descriptors = Vec::new();
+    let mut descriptors = Vec::with_capacity(params.len());
     let mut chars = params.chars().peekable();
     while let Some(c) = chars.next() {
         match c {


### PR DESCRIPTION
💡 What: Switched `Vec::new()` to `Vec::with_capacity(params.len())` in `parse_arg_types` and `parse_arg_descriptors` within `duke-interpreter/src/lib.rs`.
🎯 Why: Method descriptors are parsed frequently during JVM execution (reflection, invocations, finding signatures). Using `Vec::new()` requires multiple dynamic heap reallocations as the vector grows. Since the number of arguments can never exceed the byte length of the parameter string, `params.len()` is a safe and efficient upper bound for allocation.
📊 Impact: Eliminates all heap resizing and reallocation overhead during descriptor parsing, providing a safe, zero-cost abstraction improvement for hot paths.
🔬 Measurement: Run `cargo bench -p duke-interpreter` or measure reflection overhead. Tests pass perfectly with zero regressions in correctness.

---
*PR created automatically by Jules for task [14298072502828297865](https://jules.google.com/task/14298072502828297865) started by @madmax983*