### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/crates/duke-bytecode/src/verifier.rs
+++ b/crates/duke-bytecode/src/verifier.rs
@@ -845,4 +845,18 @@ mod tests {
         let res_valid = verify(&instructions_wide_valid, 1, 11);
         assert!(res_valid.is_ok());
     }
+
+    #[test]
+    fn should_return_error_when_local_index_is_out_of_bounds() {
+        let instr = Instruction::Iload(5);
+        let result = check_locals(&instr, 0, 4);
+        assert!(matches!(
+            result,
+            Err(VerifyError::LocalOutOfBounds {
+                pc: 0,
+                index: 5,
+                max_locals: 4
+            })
+        ));
+    }
 }


### PR DESCRIPTION
🎯 Target: `check_locals` in `crates/duke-bytecode/src/verifier.rs`.
💣 Risk: Ensures the verifier correctly rejects bytecode that attempts to access out-of-bounds local variables, preventing potential out-of-bounds panics during interpreter execution.
🧪 Strategy: Added a new unit test `should_return_error_when_local_index_is_out_of_bounds` that mocks an `Instruction::Iload` accessing index 5 when `max_locals` is 4, and asserts the exact `Err(VerifyError::LocalOutOfBounds)` response.
🔭 Verification: `cargo test -p duke-bytecode --lib verifier::tests::should_return_error_when_local_index_is_out_of_bounds`

---
*PR created automatically by Jules for task [8811465370766656613](https://jules.google.com/task/8811465370766656613) started by @madmax983*