### PR TITLE
🎻 Bard: stdlib documentation and bootstrapping

### DIFF
--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -1,9 +1,33 @@
+//! Synthetic Java Standard Library Bootstrapping.
+//!
+//! This module provides the essential standard library classes (e.g., `java/lang/Object`, `java/lang/System`, `java/io/PrintStream`) required for the JVM interpreter to function. It registers native methods and allocates initial class contexts into the `ClassRegistry`.
 use crate::context::{ClassContext, FieldEntry};
 use crate::registry::ClassRegistry;
 #[allow(clippy::wildcard_imports)]
 use crate::*;
 use duke_runtime::Slot;
 
+/// Bootstraps the synthetic JDK standard library.
+///
+/// This function populates the given [`ClassRegistry`] and [`duke_gc::Heap`] with essential
+/// Java classes and native method handlers required for execution.
+///
+/// # Examples
+///
+/// ```
+/// use duke_interpreter::registry::ClassRegistry;
+/// use duke_gc::Heap;
+/// use duke_interpreter::bootstrap_stdlib;
+///
+/// let mut registry = ClassRegistry::new();
+/// let mut heap = Heap::new();
+///
+/// // Bootstrap the standard library
+/// bootstrap_stdlib(&mut registry, &mut heap);
+///
+/// // The registry should now contain essential classes
+/// assert!(registry.contains("java/lang/Object"));
+/// ```
 #[allow(clippy::too_many_lines)]
 pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) {
     // Allocate PrintStream objects for System.out and System.err.


### PR DESCRIPTION
📖 Chapter: The `stdlib` module
🔦 Insight: Added module-level documentation explaining the purpose of the synthetic JDK standard library bootstrapping, and a function-level docstring for `bootstrap_stdlib` detailing its usage and behavior.
🧪 Example: Added an executable doctest demonstrating the initialization of the `ClassRegistry` and `Heap`, and verifying the registration of `java/lang/Object`.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [14231845853639586364](https://jules.google.com/task/14231845853639586364) started by @madmax983*