### PR TITLE
👺 Havoc: `ThreadRuntime` panic on 2 billionth thread

### DIFF
--- a/crates/duke-interpreter/proptest-regressions/threading.txt
+++ b/crates/duke-interpreter/proptest-regressions/threading.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 6335597bb1109b44be5d181892e2e8a6a4763ef9138f5ab391af01d7cd62a233 # shrinks to start = 2147483646

--- a/crates/duke-interpreter/src/threading.rs
+++ b/crates/duke-interpreter/src/threading.rs
@@ -99,7 +99,7 @@ impl ThreadRuntime {
     #[must_use]
     pub const fn allocate_thread_id(&mut self) -> i32 {
         let id = self.next_thread_id;
-        self.next_thread_id += 1;
+        self.next_thread_id = self.next_thread_id.wrapping_add(1);
         id
     }
 
@@ -172,5 +172,20 @@ mod tests {
         assert_eq!(runtime.live_workers(), 0);
         assert!(!runtime.mark_finished_by_java_ref(77));
         assert!(!runtime.mark_finished_by_java_ref(999));
+    }
+}
+
+#[cfg(test)]
+mod havoc_proptest {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn test_allocate_thread_id_overflow(start in i32::MAX - 10..=i32::MAX) {
+            let mut runtime = ThreadRuntime { next_thread_id: start, records: vec![] };
+            let _ = runtime.allocate_thread_id();
+            let _ = runtime.allocate_thread_id();
+        }
     }
 }


### PR DESCRIPTION
* 🧨 **The Trigger:** Calling `allocate_thread_id` repeatedly until it hits `i32::MAX` causes a runtime panic due to integer overflow debug assertions.
* 📉 **The Stack Trace:** `thread '...' panicked at crates/duke-interpreter/src/threading.rs:102:9: attempt to add with overflow`
* 🧪 **Reproduction:** "Run `cargo test -p duke-interpreter test_allocate_thread_id_overflow`."
* 😈 **Comment:** "You assumed we'd never reach 2 billion threads. You were wrong."

---
*PR created automatically by Jules for task [5906030127870183417](https://jules.google.com/task/5906030127870183417) started by @madmax983*