### PR TITLE
⚡ Bolt: Remove unnecessary heap allocations when parsing nested JARs

### DIFF
--- a/crates/duke-loader/src/zip.rs
+++ b/crates/duke-loader/src/zip.rs
@@ -338,16 +338,15 @@ impl ClassLoader for ZipLoader {
 }
 
 fn nested_boot_inf_lib_loaders(reader: &ZipReader) -> LoadResult<Vec<ZipLoader>> {
-    let mut nested_entry_names: Vec<String> = reader
+    let mut nested_entry_names: Vec<&str> = reader
         .entry_names()
         .filter(|name| is_nested_boot_inf_lib_archive(name))
-        .map(str::to_owned)
         .collect();
     nested_entry_names.sort_unstable();
 
     let mut nested_libs = Vec::with_capacity(nested_entry_names.len());
     for entry_name in nested_entry_names {
-        let nested_bytes = reader.read_entry(&entry_name)?;
+        let nested_bytes = reader.read_entry(entry_name)?;
         nested_libs.push(ZipLoader::from_reader(ZipReader::from_bytes(
             nested_bytes,
         )?)?);


### PR DESCRIPTION
💡 What: The optimization implemented is switching `nested_entry_names` from `Vec<String>` to `Vec<&str>` in `nested_boot_inf_lib_loaders`.
🎯 Why: Gathering paths for nested BOOT-INF/lib JARs resulted in multiple heap allocations caused by calling `.map(str::to_owned)` which is completely unnecessary since `.read_entry()` already accepts a string slice (`&str`).
📊 Impact: Removes `N` heap allocations (where `N` is the number of nested library JARs in a Spring Boot application), which noticeably reduces the memory overhead and speeds up the ClassLoader bootstrapping process during interpreter startup.
🔬 Measurement: Run `cargo bench` or profile fat JAR bootstrap.

---
*PR created automatically by Jules for task [16639359539339845211](https://jules.google.com/task/16639359539339845211) started by @madmax983*