### PR TITLE
🎻 Bard: Add narrative documentation and doctests to classfile module

### DIFF
--- a/crates/duke-classfile/src/attributes.rs
+++ b/crates/duke-classfile/src/attributes.rs
@@ -1,10 +1,16 @@
 //! JVM Attributes parsing and representations.
 //!
-//! This module defines the structures for attributes found in a `.class` file.
-//! Attributes are used in the `ClassFile`, `field_info`, `method_info`, and `Code_attribute` structures.
+//! In the JVM, attributes are the flexible extensibility mechanism of a `.class` file.
+//! They contain the *actual* bytecode of a method, the source file name, debugging symbols,
+//! or bootstrap methods for `invokedynamic`. If a class file were a book, attributes would
+//! be the footnotes, the appendices, and occasionally the entire plot!
 //!
-//! While there are many attributes defined in the JVM specification, this module
-//! currently parses the following well-known attributes into typed variants:
+//! This module parses known attributes into typed variants (like [`AttributeData::Code`]),
+//! ensuring you can inspect the method's behavior. Unknown attributes are preserved
+//! as [`AttributeData::Raw`] so the runtime won't crash on newer compiler features it
+//! doesn't fully understand yet.
+//!
+//! We support:
 //! - `Code` (§4.7.3)
 //! - `ConstantValue` (§4.7.2)
 //! - `SourceFile` (§4.7.10)
@@ -12,14 +18,30 @@
 //! - `LocalVariableTable` (§4.7.13)
 //! - `Exceptions` (§4.7.5)
 //! - `BootstrapMethods` (§4.7.23)
-//!
-//! Unknown attributes are captured as raw bytes in `AttributeData::Raw` for forward compatibility.
 
 use crate::constant_pool::CpIndex;
 
 /// Generic attribute container (§4.7).
-/// Well-known attributes are parsed into their typed variants; unknown
-/// attributes are captured as raw bytes for forward compatibility.
+///
+/// Every attribute starts with a name (a UTF-8 string in the constant pool) and a length.
+/// We parse this wrapper, and then decode the inner payload into an [`AttributeData`] enum.
+/// If we don't recognize the attribute, it lives on safely as a raw byte vector, allowing
+/// the interpreter to ignore unknown metadata rather than failing to load the class.
+///
+/// # Examples
+///
+/// ```
+/// use duke_classfile::types::{AttributeInfo, AttributeData, CpIndex};
+///
+/// let attr = AttributeInfo {
+///     name_index: CpIndex(1),
+///     data: AttributeData::Raw(vec![0x01, 0x02]),
+/// };
+///
+/// if let AttributeData::Raw(bytes) = attr.data {
+///     assert_eq!(bytes.len(), 2);
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub struct AttributeInfo {
     /// Constant pool index of the name of the attribute.

--- a/crates/duke-classfile/src/class.rs
+++ b/crates/duke-classfile/src/class.rs
@@ -58,7 +58,27 @@ pub struct ClassFile {
     pub attributes: Vec<AttributeInfo>,
 }
 
-/// Field descriptor (§4.5).
+/// Represents a field declared within a Java class or interface (§4.5).
+///
+/// Why do we need this? A class without state is just a namespace of functions.
+/// `FieldInfo` defines the layout, type descriptors, and access modifiers of every instance
+/// and static field. Crucially, it also carries attributes—such as `ConstantValue` for
+/// primitive constants—which tell the JVM how to initialize static variables before any code runs.
+///
+/// # Examples
+///
+/// ```
+/// use duke_classfile::types::{FieldInfo, CpIndex};
+/// use duke_classfile::access_flags::FieldAccessFlags;
+///
+/// let field = FieldInfo {
+///     access_flags: FieldAccessFlags::PUBLIC,
+///     name_index: CpIndex(1),
+///     descriptor_index: CpIndex(2),
+///     attributes: vec![],
+/// };
+/// assert!(field.access_flags.contains(FieldAccessFlags::PUBLIC));
+/// ```
 #[derive(Debug, Clone)]
 pub struct FieldInfo {
     /// Access flags for the field.
@@ -71,7 +91,28 @@ pub struct FieldInfo {
     pub attributes: Vec<AttributeInfo>,
 }
 
-/// Method descriptor (§4.6).
+/// Represents a method or initialization routine within a class (§4.6).
+///
+/// Methods are the verbs of the JVM. This structure tells you the method's name, its descriptor
+/// (what arguments it takes and returns), and its access flags (is it `public`, `static`, or `native`?).
+///
+/// More importantly, if the method is not `native` or `abstract`, its `attributes` array will contain
+/// a [`crate::attributes::AttributeData::Code`] attribute—the raw bytecode instructions the interpreter must execute.
+///
+/// # Examples
+///
+/// ```
+/// use duke_classfile::types::{MethodInfo, CpIndex};
+/// use duke_classfile::access_flags::MethodAccessFlags;
+///
+/// let method = MethodInfo {
+///     access_flags: MethodAccessFlags::PUBLIC,
+///     name_index: CpIndex(3),
+///     descriptor_index: CpIndex(4),
+///     attributes: vec![],
+/// };
+/// assert!(method.access_flags.contains(MethodAccessFlags::PUBLIC));
+/// ```
 #[derive(Debug, Clone)]
 pub struct MethodInfo {
     /// Access flags for the method.

--- a/crates/duke-classfile/src/error.rs
+++ b/crates/duke-classfile/src/error.rs
@@ -1,8 +1,39 @@
 //! `duke-classfile::error` — [`ParseError`] and related types
+//!
+//! Why does parsing a class file fail? Because the Java Virtual Machine is a strict taskmaster.
+//! When reading binary bytes, any malformed magic number, truncated byte stream, or invalid
+//! constant pool index means the file is fundamentally corrupt. This module provides a detailed
+//! [`enum@Error`] enumeration so that when a failure occurs, a tired developer at 3 AM knows exactly
+//! *where* and *why* it happened—whether it was a missing byte or an invalid UTF-8 string.
+//!
+//! # Examples
+//!
+//! ```
+//! use duke_classfile::error::Error;
+//!
+//! let err = Error::CpIndexZero;
+//! assert_eq!(err.to_string(), "constant pool index 0 is reserved and must not be used");
+//! ```
 
 use thiserror::Error;
 
-/// Errors that can occur while parsing a JVM `.class` file.
+/// The grand catalog of everything that can go wrong when reading a JVM `.class` file.
+///
+/// We don't just return a generic "parse failed" message. We want you to know the exact
+/// offset of the truncation, the specific invalid magic number, or the out-of-bounds
+/// [`crate::constant_pool::CpIndex`]. Use these variants to log precise, helpful diagnostics.
+///
+/// # Examples
+///
+/// ```
+/// use duke_classfile::error::Error;
+///
+/// let err = Error::UnexpectedEof { offset: 42 };
+/// match err {
+///     Error::UnexpectedEof { offset } => assert_eq!(offset, 42),
+///     _ => panic!("Expected UnexpectedEof"),
+/// }
+/// ```
 #[derive(Debug, Error)]
 pub enum Error {
     /// Expected more bytes to parse but reached the end of the file.


### PR DESCRIPTION
📖 Chapter: The `duke-classfile` module (`error`, `attributes`, and `class` submodules).
🔦 Insight: Developers need not just examples but an explanation of *why* things are structured the way they are. Clarified error handling scenarios, attribute parsing context, and the structure of class members (`FieldInfo` and `MethodInfo`) with rich narratives and intra-doc links.
🧪 Example: Added and improved executable doctests demonstrating struct initialization and error matching.
🖼️ Preview: N/A.

---
*PR created automatically by Jules for task [5425342574313262313](https://jules.google.com/task/5425342574313262313) started by @madmax983*