### PR TITLE
👺 Havoc: [ZipReader Panic] Integer Overflow in read_entry_info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "autocfg"
@@ -215,6 +218,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "duke"
 version = "0.1.0"
 dependencies = [
@@ -273,6 +287,7 @@ dependencies = [
 name = "duke-loader"
 version = "0.1.0"
 dependencies = [
+ "arbitrary",
  "duke-classfile",
  "flate2",
  "proptest",

--- a/crates/duke-loader/Cargo.toml
+++ b/crates/duke-loader/Cargo.toml
@@ -9,6 +9,7 @@ thiserror.workspace = true
 flate2.workspace = true
 
 [dev-dependencies]
+arbitrary = { version = "1.4.2", features = ["derive"] }
 duke-classfile = { path = "../duke-classfile" }
 proptest.workspace = true
 

--- a/crates/duke-loader/src/zip.rs
+++ b/crates/duke-loader/src/zip.rs
@@ -148,7 +148,10 @@ impl ZipReader {
         let offset = info.local_header_offset as usize;
 
         // Validate local file header signature.
-        if offset + 30 > self.data.len() {
+        let sig_offset = offset.checked_add(30).ok_or_else(|| LoadError::ZipFormat {
+            msg: format!("local header at offset {offset} overflows"),
+        })?;
+        if sig_offset > self.data.len() {
             return Err(LoadError::ZipFormat {
                 msg: format!("local header at offset {offset} is truncated"),
             });
@@ -163,10 +166,23 @@ impl ZipReader {
         // Read local header's own filename_len and extra_len to find data start.
         let filename_len = read_u16_le(&self.data, offset + 26) as usize;
         let extra_len = read_u16_le(&self.data, offset + 28) as usize;
-        let data_start = offset + 30 + filename_len + extra_len;
+        let data_start = offset
+            .checked_add(30)
+            .and_then(|x| x.checked_add(filename_len))
+            .and_then(|x| x.checked_add(extra_len))
+            .ok_or_else(|| LoadError::ZipFormat {
+                msg: format!("entry '{}' local header lengths overflow", info.name),
+            })?;
         let compressed_size = info.compressed_size as usize;
 
-        if data_start + compressed_size > self.data.len() {
+        let end_pos =
+            data_start
+                .checked_add(compressed_size)
+                .ok_or_else(|| LoadError::ZipFormat {
+                    msg: format!("entry '{}' data extends past end of archive", info.name),
+                })?;
+
+        if end_pos > self.data.len() {
             return Err(LoadError::ZipFormat {
                 msg: format!("entry '{}' data extends past end of archive", info.name),
             });
@@ -1188,5 +1204,28 @@ mod proptests {
 
             let _ = reader.read_entry_info(&info);
         }
+    }
+}
+
+#[cfg(test)]
+mod havoc_tests {
+    use super::*;
+
+    #[test]
+    fn havoc_zip_panic_read_entry_info_start_overflow() {
+        let info = ZipEntryInfo {
+            name: "dummy".to_string(),
+            local_header_offset: usize::MAX as u64 - 10,
+            compressed_size: 100,
+            uncompressed_size: 0,
+            compression_method: 0,
+            crc32: 0,
+        };
+        let data = vec![0; 46];
+        let reader = ZipReader {
+            data,
+            index: std::collections::HashMap::new(),
+        };
+        let _ = reader.read_entry_info(&info);
     }
 }


### PR DESCRIPTION
* 🧨 **The Trigger:** Loading a crafted Zip archive with a massive `local_header_offset` or `compressed_size` triggers integer overflows when computing data boundaries in `read_entry_info`.
* 📉 **The Stack Trace:** 
  ```
  thread 'zip::havoc_overflow_tests::fuzz_zip_reader_read_entry_info_start_overflow' panicked at crates/duke-loader/src/zip.rs:151:12:
  attempt to add with overflow
  ```
* 🧪 **Reproduction:** Run `cargo test havoc_zip_panic_read_entry_info_start_overflow`.
* 😈 **Comment:** You assumed sizes and offsets parsed from external bytes would fit safely in host variables. You were wrong.

---
*PR created automatically by Jules for task [10516749411605385497](https://jules.google.com/task/10516749411605385497) started by @madmax983*