### PR TITLE
👺 Havoc: Thread ID Integer Overflow leading to duplicate JVM threads

### DIFF
--- a/crates/duke-interpreter/src/threading.rs
+++ b/crates/duke-interpreter/src/threading.rs
@@ -171,7 +171,10 @@ impl ThreadRuntime {
     #[must_use]
     pub const fn allocate_thread_id(&mut self) -> i32 {
         let id = self.next_thread_id;
-        self.next_thread_id = self.next_thread_id.wrapping_add(1);
+        self.next_thread_id = self
+            .next_thread_id
+            .checked_add(1)
+            .expect("thread ID overflow");
         id
     }
 
@@ -296,10 +299,12 @@ mod havoc_proptest {
 
     proptest! {
         #[test]
+        #[should_panic(expected = "thread ID overflow")]
         fn test_allocate_thread_id_overflow(start in i32::MAX - 10..=i32::MAX) {
             let mut runtime = ThreadRuntime { next_thread_id: start, records: vec![] };
-            let _ = runtime.allocate_thread_id();
-            let _ = runtime.allocate_thread_id();
+            for _ in 0..20 {
+                let _ = runtime.allocate_thread_id();
+            }
         }
     }
 }

--- a/crates/duke-interpreter/src/threading.rs
+++ b/crates/duke-interpreter/src/threading.rs
@@ -168,6 +168,11 @@ impl ThreadRuntime {
         &self.records
     }
 
+    /// Allocates a unique thread ID.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the thread ID counter exceeds `i32::MAX`.
     #[must_use]
     pub const fn allocate_thread_id(&mut self) -> i32 {
         let id = self.next_thread_id;


### PR DESCRIPTION
* 🧨 **The Trigger:** Calling `allocate_thread_id()` 2 billion times (e.g. from `i32::MAX`) silently wraps to a negative ID (`-2147483648`). The JVM checks `thread_id >= 0` to see if a thread is started. This allows starting the *same* Java thread multiple times concurrently!
* 📉 **The Stack Trace:** 
```
thread 'threading::havoc_proptest::test_allocate_thread_id_overflow' panicked at crates/duke-interpreter/src/threading.rs:174:66:
thread ID overflow
```
* 🧪 **Reproduction:** `cargo test test_allocate_thread_id_overflow -p duke-interpreter`
* 😈 **Comment:** You assumed `wrapping_add(1)` on IDs was safe. You were wrong. It broke the `already_started` check, causing thread duplications, leaks, and heap corruption. I panicked it instead. Fail fast, fail hard.

---
*PR created automatically by Jules for task [17015138861056957759](https://jules.google.com/task/17015138861056957759) started by @madmax983*