### PR TITLE
⚒️ Forge: Extract constant pool entry parsing logic

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,7 @@
 **Extract God Function**
 **Learning:** `bootstrap_stdlib` was over 3600 lines long, a classic God Function anti-pattern that cluttered the `lib.rs` file. Moving it to its own file dramatically improved readability.
 **Action:** Always look for massive setup or registration functions and extract them to dedicated modules, using `pub(crate)` to share internal helpers.
+
+**Extract Pyramid of Doom**
+**Learning:** `parse_constant_pool` in `crates/duke-classfile/src/parser.rs` contained a massive, deeply nested `match` block for parsing constant pool entries. This "Pyramid of Doom" made the function difficult to read and maintain. Extracting the `match` block into a separate helper function, `parse_cp_entry`, flattened the structure and significantly improved clarity without altering the logic.
+**Action:** Always identify deeply nested logic, especially large `match` or `if/else` statements, and extract them into named helper functions to flatten the code and reduce cognitive load.

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -235,93 +235,91 @@ fn parse_constant_pool(c: &mut Cursor<'_>) -> ParseResult<Vec<Option<CpEntry>>> 
     let mut i = 1usize;
     while i < count {
         let tag = c.read_u8()?;
-        #[allow(clippy::match_same_arms)]
-        let entry = match tag {
-            1 => {
-                let len = c.read_u16()? as usize;
-                let bytes = c.read_bytes(len)?;
-                let s = String::from_utf8(bytes.to_vec())?;
-                CpEntry::Utf8(s)
-            }
-            3 => CpEntry::Integer(c.read_i32()?),
-            4 => CpEntry::Float(c.read_f32()?),
-            5 => {
-                let v = CpEntry::Long(c.read_i64()?);
-                pool.push(Some(v));
-                pool.push(None); // phantom slot
-                i += 2;
-                continue;
-            }
-            6 => {
-                let v = CpEntry::Double(c.read_f64()?);
-                pool.push(Some(v));
-                pool.push(None); // phantom slot
-                i += 2;
-                continue;
-            }
-            7 => CpEntry::Class {
-                name_index: c.read_cp_index()?,
-            },
-            8 => CpEntry::String {
-                string_index: c.read_cp_index()?,
-            },
-            9 => CpEntry::Fieldref {
-                class_index: c.read_cp_index()?,
-                name_and_type_index: c.read_cp_index()?,
-            },
-            10 => CpEntry::Methodref {
-                class_index: c.read_cp_index()?,
-                name_and_type_index: c.read_cp_index()?,
-            },
-            11 => CpEntry::InterfaceMethodref {
-                class_index: c.read_cp_index()?,
-                name_and_type_index: c.read_cp_index()?,
-            },
-            12 => CpEntry::NameAndType {
-                name_index: c.read_cp_index()?,
-                descriptor_index: c.read_cp_index()?,
-            },
-            15 => {
-                let reference_kind = c.read_u8()?;
-                if !(1..=9).contains(&reference_kind) {
-                    return Err(ParseError::InvalidMethodHandleKind {
-                        kind: reference_kind,
-                    });
-                }
-                CpEntry::MethodHandle {
-                    reference_kind,
-                    reference_index: c.read_cp_index()?,
-                }
-            }
-            16 => CpEntry::MethodType {
-                descriptor_index: c.read_cp_index()?,
-            },
-            17 => CpEntry::Dynamic {
-                bootstrap_method_attr_index: c.read_u16()?,
-                name_and_type_index: c.read_cp_index()?,
-            },
-            18 => CpEntry::InvokeDynamic {
-                bootstrap_method_attr_index: c.read_u16()?,
-                name_and_type_index: c.read_cp_index()?,
-            },
-            19 => CpEntry::Module {
-                name_index: c.read_cp_index()?,
-            },
-            20 => CpEntry::Package {
-                name_index: c.read_cp_index()?,
-            },
-            other => {
-                return Err(ParseError::UnknownCpTag {
-                    tag: other,
-                    index: u16::try_from(i).unwrap_or(u16::MAX),
-                });
-            }
-        };
+        let (entry, is_wide) = parse_cp_entry(c, tag, i)?;
         pool.push(Some(entry));
-        i += 1;
+        if is_wide {
+            pool.push(None); // phantom slot
+            i += 2;
+        } else {
+            i += 1;
+        }
     }
 
     Ok(pool)
+}
+
+#[allow(clippy::match_same_arms)]
+fn parse_cp_entry(c: &mut Cursor<'_>, tag: u8, index: usize) -> ParseResult<(CpEntry, bool)> {
+    let entry = match tag {
+        1 => {
+            let len = c.read_u16()? as usize;
+            let bytes = c.read_bytes(len)?;
+            let s = String::from_utf8(bytes.to_vec())?;
+            CpEntry::Utf8(s)
+        }
+        3 => CpEntry::Integer(c.read_i32()?),
+        4 => CpEntry::Float(c.read_f32()?),
+        5 => return Ok((CpEntry::Long(c.read_i64()?), true)),
+        6 => return Ok((CpEntry::Double(c.read_f64()?), true)),
+        7 => CpEntry::Class {
+            name_index: c.read_cp_index()?,
+        },
+        8 => CpEntry::String {
+            string_index: c.read_cp_index()?,
+        },
+        9 => CpEntry::Fieldref {
+            class_index: c.read_cp_index()?,
+            name_and_type_index: c.read_cp_index()?,
+        },
+        10 => CpEntry::Methodref {
+            class_index: c.read_cp_index()?,
+            name_and_type_index: c.read_cp_index()?,
+        },
+        11 => CpEntry::InterfaceMethodref {
+            class_index: c.read_cp_index()?,
+            name_and_type_index: c.read_cp_index()?,
+        },
+        12 => CpEntry::NameAndType {
+            name_index: c.read_cp_index()?,
+            descriptor_index: c.read_cp_index()?,
+        },
+        15 => {
+            let reference_kind = c.read_u8()?;
+            if !(1..=9).contains(&reference_kind) {
+                return Err(ParseError::InvalidMethodHandleKind {
+                    kind: reference_kind,
+                });
+            }
+            CpEntry::MethodHandle {
+                reference_kind,
+                reference_index: c.read_cp_index()?,
+            }
+        }
+        16 => CpEntry::MethodType {
+            descriptor_index: c.read_cp_index()?,
+        },
+        17 => CpEntry::Dynamic {
+            bootstrap_method_attr_index: c.read_u16()?,
+            name_and_type_index: c.read_cp_index()?,
+        },
+        18 => CpEntry::InvokeDynamic {
+            bootstrap_method_attr_index: c.read_u16()?,
+            name_and_type_index: c.read_cp_index()?,
+        },
+        19 => CpEntry::Module {
+            name_index: c.read_cp_index()?,
+        },
+        20 => CpEntry::Package {
+            name_index: c.read_cp_index()?,
+        },
+        other => {
+            return Err(ParseError::UnknownCpTag {
+                tag: other,
+                index: u16::try_from(index).unwrap_or(u16::MAX),
+            });
+        }
+    };
+    Ok((entry, false))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
🚮 Smell: `parse_constant_pool` in `crates/duke-classfile/src/parser.rs` contained a massive, deeply nested `match` block for parsing individual constant pool entries. This "Pyramid of Doom" made the function difficult to read and understand.
✨ Solution: Extracted the `match` block into a new helper function, `parse_cp_entry`. The new function returns a tuple indicating if the entry is wide to handle the phantom slot logic cleanly.
🧼 Benefit: Reduces cognitive load and flattens the structure of `parse_constant_pool`, significantly improving readability.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [6329106332037883553](https://jules.google.com/task/6329106332037883553) started by @madmax983*