### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -2487,6 +2487,39 @@ fn process_wait_and_destroy_cycle() {
 }
 
 #[test]
+fn process_destroy_running() {
+    let mut heap = Heap::new();
+    let cmd = if cfg!(windows) {
+        vec!["cmd".to_string(), "/C".to_string(), "pause".to_string()]
+    } else {
+        vec!["cat".to_string()]
+    };
+    let p_ids = heap.spawn_host_process(&cmd, None).unwrap();
+    heap.destroy_host_process(p_ids.process_id).unwrap();
+}
+
+#[test]
+fn should_return_error_when_waiting_invalid_process() {
+    let mut gc = Heap::new();
+    let err = gc.wait_host_process(999).unwrap_err();
+    assert!(matches!(err, duke_runtime::VmError::JavaException { .. }));
+}
+
+#[test]
+fn should_return_error_when_trying_exit_value_invalid_process() {
+    let mut gc = Heap::new();
+    let err = gc.try_host_process_exit_value(999).unwrap_err();
+    assert!(matches!(err, duke_runtime::VmError::JavaException { .. }));
+}
+
+#[test]
+fn should_return_error_when_destroying_invalid_process() {
+    let mut gc = Heap::new();
+    let err = gc.destroy_host_process(999).unwrap_err();
+    assert!(matches!(err, duke_runtime::VmError::JavaException { .. }));
+}
+
+#[test]
 fn socket_operations() {
     let mut heap = Heap::new();
     // connect to an invalid host should fail

--- a/crates/duke-loader/src/directory.rs
+++ b/crates/duke-loader/src/directory.rs
@@ -118,4 +118,11 @@ mod tests {
             "Vulnerability triggered! Got {result:?}"
         );
     }
+
+    #[test]
+    fn directory_loader_returns_not_found_on_empty_component() {
+        let loader = DirectoryLoader::new(std::path::PathBuf::from("/tmp"));
+        let err = loader.find_class("java//lang/Object").unwrap_err();
+        assert!(matches!(err, LoadError::NotFound { .. }));
+    }
 }

--- a/crates/duke-loader/src/jimage.rs
+++ b/crates/duke-loader/src/jimage.rs
@@ -862,6 +862,12 @@ mod tests {
             "should safely fail decompression, not panic with capacity overflow"
         );
     }
+
+    #[test]
+    fn test_jimage_parse_header_too_small() {
+        let err = super::parse_header(&[0; 10]).unwrap_err();
+        assert!(matches!(err, super::LoadError::JImageFormat { .. }));
+    }
 }
 
 #[cfg(test)]

--- a/crates/duke-loader/src/zip.rs
+++ b/crates/duke-loader/src/zip.rs
@@ -1174,6 +1174,19 @@ mod tests {
             matches!(err, LoadError::ZipFormat { ref msg } if msg == "central directory extends past end of file")
         );
     }
+
+    #[test]
+    fn test_zip_loader_try_nested_read_entry_error() {
+        let mut nested_jar = build_stored_zip("Bad.class", b"data");
+        nested_jar[0] ^= 0xFF;
+        let outer_zip = build_multi_entry_zip(&[("BOOT-INF/lib/dependency.jar", &nested_jar)]);
+        let tmp = std::env::temp_dir().join("duke_test_zip_nested_err.jar");
+        std::fs::write(&tmp, &outer_zip).unwrap();
+        let loader = ZipLoader::open(&tmp).expect("should open outer zip");
+        let err = loader.find_class("Bad").unwrap_err();
+        assert!(matches!(err, super::LoadError::ZipFormat { .. }));
+        std::fs::remove_file(&tmp).ok();
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
🎯 **Target:** `duke-loader` module (`directory.rs`, `jimage.rs`, `zip.rs`) and `duke-gc` module (host process APIs in `lib.rs`).
💣 **Risk:** Invalid or truncated archives could potentially cause panics/out-of-bounds indexing or silent swallowing of failure states. Missing process descriptors could crash runtime VMs if invalid accesses aren't fully bubbled back as Java Exceptions.
🧪 **Strategy:** Used `cargo llvm-cov` to identify missing logic branches in error handling paths and then added simple, focused `#[test]`s to trigger those exact conditions.
🔬 **Verification:** Run `cargo test --package duke-loader --lib` and `cargo test --package duke-gc --lib`.

---
*PR created automatically by Jules for task [11920995045861416629](https://jules.google.com/task/11920995045861416629) started by @madmax983*