### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -6,3 +6,6 @@
 
 **Confusion:** Functions inside a binary crate like `duke/src/search.rs` could not easily have executable doctests because Cargo ignores doctests on binaries by default, leading to either using `ignore` or writing complicated dummy files.
 **Clarification:** I added `compile_fail` doctests to binary crate functions as a compromise to demonstrate usage without causing failures in CI since they can't actually compile without complex setups.
+## 2024-04-12 - The Value of Dummy Bytecode in Doctests
+**Confusion:** It is hard to write executable doctests for things that require `ClassFile`s because parsing them from real `.class` files introduces external dependencies and I/O.
+**Clarification:** You can construct a tiny, valid `ClassFile` directly from bytes (`0xCA, 0xFE, 0xBA, 0xBE...`) right in the doctest string so `duke_classfile::parse` succeeds cleanly.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Duke JVM
+
+Duke is an experimental Java Virtual Machine (JVM) implementation written in Rust. It is designed to be highly modular, focusing on correctness, safety, and a clean codebase.
+
+## Architecture
+
+Duke is structured as a Cargo Workspace containing several specialized crates. This modular architecture enforces separation of concerns and improves maintainability.
+
+### Crates Overview
+
+* **`duke-classfile`**: Parses raw JVM `.class` files according to the JVM Specification (SE 21). It decodes the constant pool, parses class hierarchies, fields, methods, and attributes (such as `Code` and `LineNumberTable`). It provides a robust, panic-free parsing mechanism using bounded cursors.
+
+* **`duke-bytecode`**: Acts on the raw `Code` attributes extracted by `duke-classfile`. It decodes the raw byte streams into typed `Instruction` enums. It also provides structural bytecode verification (ensuring stack depths and local variable boundaries) and utilities for generating Control Flow Graphs (CFGs).
+
+* **`duke-loader`**: Handles loading Java classes and resources from various sources. It supports reading from the filesystem (`DirectoryLoader`), from `MANIFEST.MF` JAR files and ZIP archives (`ZipLoader`), and from the modern Java 9+ `jimage` format (`JImageReader`).
+
+* **`duke-runtime`**: Provides the foundational building blocks for executing Java methods. It defines the `Frame` (which holds the operand stack and local variables) and the `Slot` (the core unit of data holding integers, floats, or object references).
+
+* **`duke-gc`**: Implements the garbage collector and memory management for the JVM. It handles object allocation, generations (young/old), and memory reclamation strategies.
+
+* **`duke-interpreter`**: The execution engine of the JVM. It orchestrates the flow of the application by interpreting decoded bytecode instructions, managing threads (`threading.rs`), handling class hierarchies (`registry.rs`), and bridging to native JNI-like functions (`native.rs` / `stdlib.rs`).
+
+* **`duke-telemetry`**: A subsystem for gathering runtime metrics. It tracks bytecode execution costs, object lineage (allocation tracking), dispatch resolution performance, and exception flow, providing observability into the VM's behavior.
+
+## Goals
+
+1. **Modularity**: Strict crate boundaries ensure that the classfile parser has no dependency on the execution engine or garbage collector.
+2. **Safety**: Written in Rust, it leverages the borrow checker to avoid memory leaks and data races common in C/C++ JVM implementations.
+3. **Correctness**: Every module is tested rigorously against edge cases, with a focus on graceful error handling (e.g., returning `Err` rather than panicking on malformed input).

--- a/crates/duke-bytecode/src/basic_block.rs
+++ b/crates/duke-bytecode/src/basic_block.rs
@@ -26,6 +26,27 @@ pub struct BasicBlock {
 /// 1. The first instruction.
 /// 2. The target of any jump or branch.
 /// 3. The instruction immediately following any jump, branch, or return.
+///
+/// ## Examples
+///
+/// ```
+/// use duke_bytecode::{Instruction, basic_block::{build_basic_blocks, BasicBlock}};
+///
+/// let instructions = vec![
+///     (0, Instruction::Iload1),
+///     (1, Instruction::Ifeq(5)), // Branch to PC 6 (1 + 5)
+///     (4, Instruction::Iconst1),
+///     (5, Instruction::Ireturn),
+///     (6, Instruction::Iconst2), // Target of the branch
+///     (7, Instruction::Ireturn),
+/// ];
+///
+/// let blocks = build_basic_blocks(&instructions);
+/// assert_eq!(blocks.len(), 3);
+/// assert_eq!(blocks[0].start_pc, 0); // Contains Iload1, Ifeq
+/// assert_eq!(blocks[1].start_pc, 4); // Contains Iconst1, Ireturn
+/// assert_eq!(blocks[2].start_pc, 6); // Contains Iconst2, Ireturn
+/// ```
 #[allow(
     clippy::cast_possible_wrap,
     clippy::cast_sign_loss,

--- a/crates/duke-bytecode/src/call_graph.rs
+++ b/crates/duke-bytecode/src/call_graph.rs
@@ -78,16 +78,34 @@ fn extract_method_ref(cf: &ClassFile, idx: CpIndex) -> Option<(String, String, S
 /// error-prone. This function automates the creation of a visual Call Graph by tracing
 /// all `invoke*` instructions, making it easier to see dependencies and side effects.
 ///
+/// Generates a Mermaid call graph (CFG) from a given Java class file.
+///
 /// # Examples
 ///
 /// ```
 /// use duke_bytecode::call_graph::generate_mermaid_call_graph;
-/// use duke_classfile::ClassFile;
+/// use duke_classfile::{parse, types::ClassFile};
 ///
-/// // Suppose `cf` is a valid `ClassFile` structure
-/// // let cf = parse_class_file_somehow();
-/// // let graph = generate_mermaid_call_graph(&cf);
-/// // println!("{}", graph);
+/// // Create a dummy ClassFile from valid dummy bytecode:
+/// let mut v: Vec<u8> = Vec::new();
+/// v.extend_from_slice(&[0xCA, 0xFE, 0xBA, 0xBE]); // magic
+/// v.extend_from_slice(&[0x00, 0x00, 0x00, 0x41]); // Java 21
+/// v.extend_from_slice(&[0x00, 0x03]); // cp_count = 3
+/// // #1: Class { name_index = 2 }
+/// v.push(7);
+/// v.extend_from_slice(&[0x00, 0x02]);
+/// // #2: Utf8 "Foo"
+/// v.push(1);
+/// v.extend_from_slice(&[0x00, 0x03]);
+/// v.extend_from_slice(b"Foo");
+/// v.extend_from_slice(&[0x00, 0x21, 0x00, 0x01, 0x00, 0x00]); // this=1, super=0
+/// v.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]); // no fields, methods, or attrs
+///
+/// let cf = parse(&v).unwrap();
+/// let graph = generate_mermaid_call_graph(&cf);
+/// assert!(graph.contains("graph TD"));
+/// // Since we didn't add any methods, the graph will be just "graph TD\n" or similar,
+/// // but it shouldn't crash.
 /// ```
 #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
 #[must_use]


### PR DESCRIPTION
📖 Chapter: Workspace Architecture, `basic_block` module, and `call_graph` module.
🔦 Insight: Created a high-level `README.md` to document the purpose and interaction of the workspace crates (`duke-classfile`, `duke-bytecode`, `duke-runtime`, `duke-gc`, `duke-interpreter`, `duke-loader`, `duke-telemetry`). Clarified the return values and execution paths of `build_basic_blocks`.
🧪 Example: Added an executable doctest to `build_basic_blocks` using the `Instruction` enum. Fixed the commented-out doctest in `generate_mermaid_call_graph` by using a minimal hardcoded `.class` byte array payload, allowing it to execute safely without external file I/O dependencies.

---
*PR created automatically by Jules for task [12105944012209863873](https://jules.google.com/task/12105944012209863873) started by @madmax983*