### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,11 @@
 **Eliminate intermediate Vec allocation in StringJoiner**
 **Learning:** We identified a hot path string concatenation in `native_stringjoiner_tostring` where it was unnecessarily accumulating string representations into an intermediate `Vec<String>` before joining them.
 **Action:** Replaced `.collect::<Vec<_>>()` and `.join()` with a pre-allocated single String buffer and `.push_str()` direct appending. This eliminates overhead for allocating vector buffers and extra formatting strings.
+
+**Reduced String.clone() in Registry**
+**Learning:** `clone()` operations on large string keys or options inside tight loops (like class registry checks and super_class/interface iterations) unnecessarily allocate memory even when immutable references `&str` or simple value drops are perfectly valid.
+**Action:** Replace `clone()` with `.as_deref()` or borrow references (`&ctx.super_class`, `&ctx.interfaces`) when calling external methods, and limit string copies strictly to hash map insertion via moving or single string duplication.
+
+**Basic Block Vec Reallocation**
+**Learning:** `Vec::new()` inside looping parser instructions causes multi-level heap reallocations. For small arrays where capacity is known from slice bounds (like basic blocks bounds / leader offsets), `Vec::with_capacity` drastically minimizes heap allocation traffic.
+**Action:** When constructing `Vec` from parsed instruction iterators, pre-compute rough capacity based on slice metrics or known leaders array length.

--- a/crates/duke-bytecode/src/basic_block.rs
+++ b/crates/duke-bytecode/src/basic_block.rs
@@ -132,8 +132,8 @@ pub fn build_basic_blocks(instructions: &[(usize, Instruction)]) -> Vec<BasicBlo
         }
     }
 
-    let mut blocks = Vec::new();
-    let mut current_block = Vec::new();
+    let mut blocks = Vec::with_capacity(leaders.len());
+    let mut current_block = Vec::with_capacity(instructions.len() / leaders.len().max(1));
     let mut current_start = instructions[0].0;
 
     for (pc, instr) in instructions {
@@ -143,7 +143,7 @@ pub fn build_basic_blocks(instructions: &[(usize, Instruction)]) -> Vec<BasicBlo
                 end_pc: *pc,
                 instructions: current_block,
             });
-            current_block = Vec::new();
+            current_block = Vec::with_capacity(instructions.len() / leaders.len().max(1));
             current_start = *pc;
         }
         current_block.push((*pc, instr.clone()));

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -545,17 +545,17 @@ impl ClassRegistry {
             return Ok(false);
         };
         let mut ctx = crate::build_class_context(&cf);
-        let resolved_super_class = if let Some(super_class) = ctx.super_class.clone() {
-            let _ = self.ensure_loaded_inner(&super_class, loader, code_source, runtime_loader)?;
-            Some(self.class_key_from_provenance(&super_class, code_source, runtime_loader))
+        let resolved_super_class = if let Some(super_class) = &ctx.super_class {
+            let _ = self.ensure_loaded_inner(super_class, loader, code_source, runtime_loader)?;
+            Some(self.class_key_from_provenance(super_class, code_source, runtime_loader))
         } else {
             None
         };
         let mut resolved_interfaces = Vec::with_capacity(ctx.interfaces.len());
-        for interface in ctx.interfaces.clone() {
-            let _ = self.ensure_loaded_inner(&interface, loader, code_source, runtime_loader)?;
+        for interface in &ctx.interfaces {
+            let _ = self.ensure_loaded_inner(interface, loader, code_source, runtime_loader)?;
             resolved_interfaces.push(self.class_key_from_provenance(
-                &interface,
+                interface,
                 code_source,
                 runtime_loader,
             ));


### PR DESCRIPTION
1. What: Switched `Vec::new()` to `Vec::with_capacity(...)` in `crates/duke-bytecode/src/basic_block.rs` based on `leaders.len()`. Replaced `.clone()` on `super_class` and `interfaces` during `registry` insertion with references.
2. Why: The vector reallocations generated unnecessary heap allocations. The `registry.rs` clones of class names/interfaces produced transient allocations during deep hierarchy resolution or recursive interface traversal. 
3. Impact: Measured via `cargo bench`. `bootstrap_stdlib` metrics improved steadily with less allocations across JVM booting.
4. Measurement: `cargo bench` and code review.

---
*PR created automatically by Jules for task [5326645110963808325](https://jules.google.com/task/5326645110963808325) started by @madmax983*