### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -6,3 +6,7 @@
 
 **Confusion:** Functions inside a binary crate like `duke/src/search.rs` could not easily have executable doctests because Cargo ignores doctests on binaries by default, leading to either using `ignore` or writing complicated dummy files.
 **Clarification:** I added `compile_fail` doctests to binary crate functions as a compromise to demonstrate usage without causing failures in CI since they can't actually compile without complex setups.
+## 2024-04-12 - Core execution loop documentation missing
+
+**Confusion:** The central bytecode execution loop (`run_execution` in `duke-interpreter/src/execution.rs`) had no module-level or function-level documentation, making it a "Black Box" for developers navigating the interpreter codebase.
+**Clarification:** Added module docs (`//!`) explaining the stack-based machine model and function docs (`///`) detailing the run-loop behavior, along with an ignored doctest example.

--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -1,3 +1,14 @@
+//! The Core JVM Execution Engine.
+//!
+//! This module contains the main interpretation loop for the JVM.
+//! It is responsible for taking a decoded stream of bytecodes and
+//! executing them sequentially against the current thread's frame stack
+//! and the global garbage-collected heap.
+//!
+//! The engine implements a stack-based machine model, handling everything
+//! from basic arithmetic to complex method dispatch, object allocation,
+//! and garbage collection safe points.
+
 use std::io::Write;
 
 use duke_bytecode::Instruction;
@@ -10,6 +21,33 @@ use crate::registry::ClassRegistry;
 #[allow(clippy::wildcard_imports)]
 use crate::*;
 
+/// Executes the active method's bytecode instructions to completion or exception.
+///
+/// This is the central run-loop of the interpreter. It continually fetches the
+/// next instruction pointed to by the active frame's Program Counter (PC),
+/// executes its operational semantics (modifying the local variables, operand stack,
+/// or global heap), and advances the PC.
+///
+/// If a method invokes another Java method, a new [`Frame`] is pushed onto the
+/// call stack and execution jumps to the callee. Native methods are dispatched
+/// to their Rust implementations directly.
+///
+/// # Examples
+///
+/// ```ignore
+/// use duke_interpreter::{ExecutionState, ClassRegistry, run_execution};
+/// use duke_gc::Heap;
+/// use duke_loader::BootstrapLoader;
+///
+/// let mut registry = ClassRegistry::new();
+/// let loader = BootstrapLoader::new(vec![]);
+/// let mut heap = Heap::new();
+/// let mut state = ExecutionState::new();
+/// let mut stdout = std::io::stdout();
+///
+/// // Start the execution loop (assuming state has an active frame)
+/// let result = run_execution(&mut state, &mut registry, &loader, &mut heap, &mut stdout);
+/// ```
 #[allow(
     clippy::cast_sign_loss,
     clippy::cast_possible_truncation,


### PR DESCRIPTION
📖 **Chapter:** The `Execution Engine` module (`duke-interpreter/src/execution.rs`).
🔦 **Insight:** Added module-level and function-level documentation to explain the central run-loop for the stack-based JVM, alleviating a "Black Box" gap in the interpreter crate.
🧪 **Example:** Added an `ignore` doctest to `run_execution` showing how the VM components are wired together.

---
*PR created automatically by Jules for task [14780736124082760044](https://jules.google.com/task/14780736124082760044) started by @madmax983*