### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,6 @@
 **Basic Block Vec Reallocation**
 **Learning:** `Vec::new()` inside looping parser instructions causes multi-level heap reallocations. For small arrays where capacity is known from slice bounds (like basic blocks bounds / leader offsets), `Vec::with_capacity` drastically minimizes heap allocation traffic.
 **Action:** When constructing `Vec` from parsed instruction iterators, pre-compute rough capacity based on slice metrics or known leaders array length.
+## 2026-04-13 - [Avoid Chained Iterators with Collect]
+**Learning:** Replaced `.drain().map().collect::<Vec<_>>().` pattern on a `HashMap` with an explicit `Vec::with_capacity()` and a for-loop. The chained iterators drop the size hint, causing unnecessary heap reallocations. Also, explicit `drop()` on lock guards avoids clippy warnings `clippy::significant_drop_tightening` when used immediately before long-running operations.
+**Action:** Use pre-allocated vectors and loops instead of chained iterator `collect`s when the size is known, especially around lock-managed states.

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -12971,7 +12971,7 @@ impl ExecutionState {
             pc_to_idx,
             instructions,
             frame,
-            call_stack: Vec::new(),
+            call_stack: Vec::with_capacity(32),
             frame_pool: FramePool::new(),
             dispatch_cache: HashMap::new(),
             vtable_cache: HashMap::new(),
@@ -13469,11 +13469,12 @@ fn wait_for_all_java_threads(
             if runtime.handles.is_empty() {
                 return first_error.unwrap_or(Ok(()));
             }
-            runtime
-                .handles
-                .drain()
-                .map(|(_, handle)| handle)
-                .collect::<Vec<_>>()
+            let mut handles = Vec::with_capacity(runtime.handles.len());
+            for (_, handle) in runtime.handles.drain() {
+                handles.push(handle);
+            }
+            drop(runtime);
+            handles
         };
 
         for handle in handles {


### PR DESCRIPTION
⚡ Bolt: [performance improvement]

💡 What:
1. Replaced `.drain().map().collect()` on a `HashMap` inside `wait_for_all_java_threads` with a `Vec::with_capacity` and an explicit loop.
2. Pre-allocated the VM `call_stack` using `Vec::with_capacity(32)` instead of `Vec::new()`.
3. Addressed a `clippy::significant_drop_tightening` warning by dropping the `MutexGuard` explicitly in `wait_for_all_java_threads`.

🎯 Why:
1. Chained iterators on `drain` lose their `size_hint`, causing unnecessary intermediate heap reallocations. A single, correctly sized allocation guarantees O(1) memory allocation.
2. The `call_stack` starts empty and quickly grows to a modest depth. Avoiding the initial capacity expansion reallocations on every method execution provides a micro-optimization on a very hot path.

📊 Impact: Removes `O(N)` heap reallocations when draining thread handles and removes initial heap reallocations when executing every Java method.

🔬 Measurement: Run `cargo clippy` and `cargo test` to ensure correctness and zero semantic changes.

---
*PR created automatically by Jules for task [13968746207943872562](https://jules.google.com/task/13968746207943872562) started by @madmax983*