### PR TITLE
⚒️ Forge: [extract parser functions]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -23,3 +23,10 @@
 ## 2026-04-11 - Simplify argument extraction in native handlers
 **Learning:** `native.rs` had dozens of repetitions of `match args.get(1) { Some(Slot::Reference(Some(r))) => *r, _ => return Err(VmError::NullPointerException) }`. This is an unidiomatic "Pyramid of Doom" disguised as inline pattern matching, creating unnecessary clutter and masking the underlying intent of extracting a reference argument.
 **Action:** Created and used `extract_ref_arg(args, 1)?` to compress 4 lines of matching boilerplate into a single line with `?` error propagation.
+**[Extracted Constant Pool Parser]
+**Learning:** The `parse_constant_pool` function in `crates/duke-classfile/src/parser.rs` was almost 100 lines long, with a massive match statement for decoding all constant pool entry types inside a loop.
+**Action:** Extract the body of large loop matches into typed helper functions like `parse_cp_entry` to flatten the structure and keep loop functions brief and understandable.
+
+**[Extracted Class Members Parser]
+**Learning:** `parse_class_file` in `crates/duke-classfile/src/parser.rs` handled validating the header (magic, versions), parsing the constant pool, *and* looping through all class members (interfaces, fields, methods, attributes). Doing multiple levels of sequential structural parsing in one function makes it a God Function.
+**Action:** Extract logical sections of file format parsing. Parse the header and constant pool first, then delegate to a `parse_class_members` function for the rest to clearly delineate the phases of decoding.

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -160,23 +160,12 @@ pub fn parse(bytes: &[u8]) -> ParseResult<ClassFile> {
 // Class file structure
 // ---------------------------------------------------------------------------
 
-fn parse_class_file(c: &mut Cursor<'_>) -> ParseResult<ClassFile> {
-    // §4.1 — magic
-    let magic = c.read_u32()?;
-    if magic != MAGIC {
-        return Err(ParseError::BadMagic { got: magic });
-    }
-
-    let minor_version = c.read_u16()?;
-    let major_version = c.read_u16()?;
-    if major_version > MAX_MAJOR_VERSION {
-        return Err(ParseError::UnsupportedVersion {
-            major: major_version,
-            minor: minor_version,
-        });
-    }
-
-    let constant_pool = parse_constant_pool(c)?;
+fn parse_class_members(
+    c: &mut Cursor<'_>,
+    minor_version: u16,
+    major_version: u16,
+    constant_pool: Vec<Option<CpEntry>>,
+) -> ParseResult<ClassFile> {
     let cp_len = constant_pool.len(); // for bounds validation helpers
 
     let access_flags = ClassAccessFlags::from_bits_truncate(c.read_u16()?);
@@ -221,9 +210,99 @@ fn parse_class_file(c: &mut Cursor<'_>) -> ParseResult<ClassFile> {
     })
 }
 
+fn parse_class_file(c: &mut Cursor<'_>) -> ParseResult<ClassFile> {
+    // §4.1 — magic
+    let magic = c.read_u32()?;
+    if magic != MAGIC {
+        return Err(ParseError::BadMagic { got: magic });
+    }
+
+    let minor_version = c.read_u16()?;
+    let major_version = c.read_u16()?;
+    if major_version > MAX_MAJOR_VERSION {
+        return Err(ParseError::UnsupportedVersion {
+            major: major_version,
+            minor: minor_version,
+        });
+    }
+
+    let constant_pool = parse_constant_pool(c)?;
+    parse_class_members(c, minor_version, major_version, constant_pool)
+}
+
 // ---------------------------------------------------------------------------
 // Constant pool (§4.4)
 // ---------------------------------------------------------------------------
+
+fn parse_cp_entry(c: &mut Cursor<'_>, tag: u8, i: usize) -> ParseResult<CpEntry> {
+    match tag {
+        1 => {
+            let len = c.read_u16()? as usize;
+            let bytes = c.read_bytes(len)?;
+            let s = String::from_utf8(bytes.to_vec())?;
+            Ok(CpEntry::Utf8(s))
+        }
+        3 => Ok(CpEntry::Integer(c.read_i32()?)),
+        4 => Ok(CpEntry::Float(c.read_f32()?)),
+        5 => Ok(CpEntry::Long(c.read_i64()?)),
+        6 => Ok(CpEntry::Double(c.read_f64()?)),
+        7 => Ok(CpEntry::Class {
+            name_index: c.read_cp_index()?,
+        }),
+        8 => Ok(CpEntry::String {
+            string_index: c.read_cp_index()?,
+        }),
+        9 => Ok(CpEntry::Fieldref {
+            class_index: c.read_cp_index()?,
+            name_and_type_index: c.read_cp_index()?,
+        }),
+        10 => Ok(CpEntry::Methodref {
+            class_index: c.read_cp_index()?,
+            name_and_type_index: c.read_cp_index()?,
+        }),
+        11 => Ok(CpEntry::InterfaceMethodref {
+            class_index: c.read_cp_index()?,
+            name_and_type_index: c.read_cp_index()?,
+        }),
+        12 => Ok(CpEntry::NameAndType {
+            name_index: c.read_cp_index()?,
+            descriptor_index: c.read_cp_index()?,
+        }),
+        15 => {
+            let reference_kind = c.read_u8()?;
+            if !(1..=9).contains(&reference_kind) {
+                return Err(ParseError::InvalidMethodHandleKind {
+                    kind: reference_kind,
+                });
+            }
+            Ok(CpEntry::MethodHandle {
+                reference_kind,
+                reference_index: c.read_cp_index()?,
+            })
+        }
+        16 => Ok(CpEntry::MethodType {
+            descriptor_index: c.read_cp_index()?,
+        }),
+        17 => Ok(CpEntry::Dynamic {
+            bootstrap_method_attr_index: c.read_u16()?,
+            name_and_type_index: c.read_cp_index()?,
+        }),
+        18 => Ok(CpEntry::InvokeDynamic {
+            bootstrap_method_attr_index: c.read_u16()?,
+            name_and_type_index: c.read_cp_index()?,
+        }),
+        19 => Ok(CpEntry::Module {
+            name_index: c.read_cp_index()?,
+        }),
+        20 => Ok(CpEntry::Package {
+            name_index: c.read_cp_index()?,
+        }),
+        other => Err(ParseError::UnknownCpTag {
+            tag: other,
+            index: u16::try_from(i).unwrap_or(u16::MAX),
+        }),
+    }
+}
 
 fn parse_constant_pool(c: &mut Cursor<'_>) -> ParseResult<Vec<Option<CpEntry>>> {
     let count = c.read_u16()? as usize;
@@ -235,90 +314,15 @@ fn parse_constant_pool(c: &mut Cursor<'_>) -> ParseResult<Vec<Option<CpEntry>>> 
     let mut i = 1usize;
     while i < count {
         let tag = c.read_u8()?;
-        #[allow(clippy::match_same_arms)]
-        let entry = match tag {
-            1 => {
-                let len = c.read_u16()? as usize;
-                let bytes = c.read_bytes(len)?;
-                let s = String::from_utf8(bytes.to_vec())?;
-                CpEntry::Utf8(s)
-            }
-            3 => CpEntry::Integer(c.read_i32()?),
-            4 => CpEntry::Float(c.read_f32()?),
-            5 => {
-                let v = CpEntry::Long(c.read_i64()?);
-                pool.push(Some(v));
-                pool.push(None); // phantom slot
-                i += 2;
-                continue;
-            }
-            6 => {
-                let v = CpEntry::Double(c.read_f64()?);
-                pool.push(Some(v));
-                pool.push(None); // phantom slot
-                i += 2;
-                continue;
-            }
-            7 => CpEntry::Class {
-                name_index: c.read_cp_index()?,
-            },
-            8 => CpEntry::String {
-                string_index: c.read_cp_index()?,
-            },
-            9 => CpEntry::Fieldref {
-                class_index: c.read_cp_index()?,
-                name_and_type_index: c.read_cp_index()?,
-            },
-            10 => CpEntry::Methodref {
-                class_index: c.read_cp_index()?,
-                name_and_type_index: c.read_cp_index()?,
-            },
-            11 => CpEntry::InterfaceMethodref {
-                class_index: c.read_cp_index()?,
-                name_and_type_index: c.read_cp_index()?,
-            },
-            12 => CpEntry::NameAndType {
-                name_index: c.read_cp_index()?,
-                descriptor_index: c.read_cp_index()?,
-            },
-            15 => {
-                let reference_kind = c.read_u8()?;
-                if !(1..=9).contains(&reference_kind) {
-                    return Err(ParseError::InvalidMethodHandleKind {
-                        kind: reference_kind,
-                    });
-                }
-                CpEntry::MethodHandle {
-                    reference_kind,
-                    reference_index: c.read_cp_index()?,
-                }
-            }
-            16 => CpEntry::MethodType {
-                descriptor_index: c.read_cp_index()?,
-            },
-            17 => CpEntry::Dynamic {
-                bootstrap_method_attr_index: c.read_u16()?,
-                name_and_type_index: c.read_cp_index()?,
-            },
-            18 => CpEntry::InvokeDynamic {
-                bootstrap_method_attr_index: c.read_u16()?,
-                name_and_type_index: c.read_cp_index()?,
-            },
-            19 => CpEntry::Module {
-                name_index: c.read_cp_index()?,
-            },
-            20 => CpEntry::Package {
-                name_index: c.read_cp_index()?,
-            },
-            other => {
-                return Err(ParseError::UnknownCpTag {
-                    tag: other,
-                    index: u16::try_from(i).unwrap_or(u16::MAX),
-                });
-            }
-        };
+        let entry = parse_cp_entry(c, tag, i)?;
+        let is_double_slot = matches!(entry, CpEntry::Long(_) | CpEntry::Double(_));
         pool.push(Some(entry));
-        i += 1;
+        if is_double_slot {
+            pool.push(None); // phantom slot
+            i += 2;
+        } else {
+            i += 1;
+        }
     }
 
     Ok(pool)


### PR DESCRIPTION
**🚮 Smell**: `parse_class_file` and `parse_constant_pool` in `duke-classfile/src/parser.rs` were God Functions. `parse_class_file` validated the header/magic/versions, iterated and parsed the constant pool, and then continued to parse all remaining class members in a massive block. `parse_constant_pool` contained a massive match loop inside a while loop to parse every type of entry, making it deeply nested and hard to read.

**✨ Solution**: 
- Extracted the parsing of class members (interfaces, fields, methods, attributes) into `parse_class_members()`. `parse_class_file()` now solely manages the header and passes off execution cleanly.
- Extracted the inner match statement for CP entries into `parse_cp_entry()`.

**🧼 Benefit**: Radically flattened the nesting structures. The code is much easier to read top-to-bottom and naturally separates the concerns of JVM `.class` parsing.

**🛡️ Verification**: `cargo test` passes. Behavior is completely unchanged.

---
*PR created automatically by Jules for task [189333439686380837](https://jules.google.com/task/189333439686380837) started by @madmax983*