### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -16,3 +16,7 @@
 ## 2024-04-11 - Doc tests should be complete compiling examples
 **Confusion:** I used `compile_fail` blocks to show pseudo code and avoid compiler errors when missing setup code. Code reviewer correctly noted that we must use full working code in Examples, not broken code.
 **Clarification:** Rewrote doc-test code snippets in `execution.rs` and `native.rs` to mock necessary elements (e.g., `ExecutionState::default()`) rather than rely on `compile_fail` with pseudo-code.
+## 2024-04-14 - Test and Fuzz files missing docs
+
+**Confusion:** Running `cargo check` with `RUSTFLAGS="-D missing_docs"` fails on integration tests (`tests/*.rs`) and fuzzing targets because they don't have crate-level documentation.
+**Clarification:** Added `#![allow(missing_docs)]` to the top of test files and fuzzing binaries to ignore these lints while maintaining strict documentation standards for the actual library codebase.

--- a/crates/duke-bytecode/tests/havoc_bytecode_oom.rs
+++ b/crates/duke-bytecode/tests/havoc_bytecode_oom.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use duke_bytecode::decode;
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/duke-classfile/tests/coverage_bump.rs
+++ b/crates/duke-classfile/tests/coverage_bump.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use duke_classfile::*;
 
 #[test]

--- a/crates/duke-classfile/tests/havoc_classfile_oom.rs
+++ b/crates/duke-classfile/tests/havoc_classfile_oom.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use duke_classfile::parse;
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/duke-loader/tests/havoc_zip_oom.rs
+++ b/crates/duke-loader/tests/havoc_zip_oom.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_lossless)]
 use duke_loader::zip::ZipReader;

--- a/crates/duke-runtime/src/lib.rs
+++ b/crates/duke-runtime/src/lib.rs
@@ -7,6 +7,29 @@
 //!
 //! These types are entirely decoupled from the actual bytecode instruction set, ensuring that
 //! memory and execution state semantics are strictly isolated from the decoding and interpretation logic.
+//!
+//! # Examples
+//!
+//! Setting up a basic execution frame and manipulating the operand stack:
+//!
+//! ```
+//! use duke_runtime::{Frame, Slot, VmError};
+//!
+//! // Create a new frame with max_stack = 4, max_locals = 2, and 0 arguments
+//! let mut frame = Frame::new(4, 2, vec![]).unwrap();
+//!
+//! // Push values onto the operand stack
+//! frame.push(Slot::Int(10)).unwrap();
+//! frame.push(Slot::Int(20)).unwrap();
+//!
+//! // Pop values and perform operations
+//! let b = frame.pop_int().unwrap();
+//! let a = frame.pop_int().unwrap();
+//!
+//! // Push the result back
+//! frame.push(Slot::Int(a + b)).unwrap();
+//! assert_eq!(frame.pop_int().unwrap(), 30);
+//! ```
 
 pub mod error;
 pub mod frame;


### PR DESCRIPTION
📖 Chapter: `duke-runtime` base crate module documentation
🔦 Insight: The root crate `duke-runtime` was missing an overarching explanation of how to use its central struct `Frame` in conjunction with `Slot`. Tests were also failing documentation lints due to strict checking rules across the repo. Added `#![allow(missing_docs)]` to test binaries.
🧪 Example: Added 1 executable doctest showing how to instantiate a `Frame` and simulate basic stack arithmetic (`push`/`pop_int`).

---
*PR created automatically by Jules for task [12549599302456671085](https://jules.google.com/task/12549599302456671085) started by @madmax983*