### PR TITLE
⚒️ Forge: [extract parse_constant_pool_entry]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -23,3 +23,6 @@
 ## 2026-04-11 - Simplify argument extraction in native handlers
 **Learning:** `native.rs` had dozens of repetitions of `match args.get(1) { Some(Slot::Reference(Some(r))) => *r, _ => return Err(VmError::NullPointerException) }`. This is an unidiomatic "Pyramid of Doom" disguised as inline pattern matching, creating unnecessary clutter and masking the underlying intent of extracting a reference argument.
 **Action:** Created and used `extract_ref_arg(args, 1)?` to compress 4 lines of matching boilerplate into a single line with `?` error propagation.
+**Extract Constant Pool Parsing**
+**Learning:** `parse_constant_pool` in `crates/duke-classfile/src/parser.rs` contained a massive `match` statement allocating and populating logic for every constant pool tag, taking up over 90 lines. This "God Function" approach breaks readability and cognitive boundaries.
+**Action:** Always extract the internal logic of large `match` arms into strictly-typed helper functions (e.g. `parse_constant_pool_entry`) to flatten code and keep functions short.

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -236,89 +236,10 @@ fn parse_constant_pool(c: &mut Cursor<'_>) -> ParseResult<Vec<Option<CpEntry>>> 
     while i < count {
         let tag = c.read_u8()?;
         #[allow(clippy::match_same_arms)]
-        let entry = match tag {
-            1 => {
-                let len = c.read_u16()? as usize;
-                let bytes = c.read_bytes(len)?;
-                let s = String::from_utf8(bytes.to_vec())?;
-                CpEntry::Utf8(s)
-            }
-            3 => CpEntry::Integer(c.read_i32()?),
-            4 => CpEntry::Float(c.read_f32()?),
-            5 => {
-                let v = CpEntry::Long(c.read_i64()?);
-                pool.push(Some(v));
-                pool.push(None); // phantom slot
-                i += 2;
-                continue;
-            }
-            6 => {
-                let v = CpEntry::Double(c.read_f64()?);
-                pool.push(Some(v));
-                pool.push(None); // phantom slot
-                i += 2;
-                continue;
-            }
-            7 => CpEntry::Class {
-                name_index: c.read_cp_index()?,
-            },
-            8 => CpEntry::String {
-                string_index: c.read_cp_index()?,
-            },
-            9 => CpEntry::Fieldref {
-                class_index: c.read_cp_index()?,
-                name_and_type_index: c.read_cp_index()?,
-            },
-            10 => CpEntry::Methodref {
-                class_index: c.read_cp_index()?,
-                name_and_type_index: c.read_cp_index()?,
-            },
-            11 => CpEntry::InterfaceMethodref {
-                class_index: c.read_cp_index()?,
-                name_and_type_index: c.read_cp_index()?,
-            },
-            12 => CpEntry::NameAndType {
-                name_index: c.read_cp_index()?,
-                descriptor_index: c.read_cp_index()?,
-            },
-            15 => {
-                let reference_kind = c.read_u8()?;
-                if !(1..=9).contains(&reference_kind) {
-                    return Err(ParseError::InvalidMethodHandleKind {
-                        kind: reference_kind,
-                    });
-                }
-                CpEntry::MethodHandle {
-                    reference_kind,
-                    reference_index: c.read_cp_index()?,
-                }
-            }
-            16 => CpEntry::MethodType {
-                descriptor_index: c.read_cp_index()?,
-            },
-            17 => CpEntry::Dynamic {
-                bootstrap_method_attr_index: c.read_u16()?,
-                name_and_type_index: c.read_cp_index()?,
-            },
-            18 => CpEntry::InvokeDynamic {
-                bootstrap_method_attr_index: c.read_u16()?,
-                name_and_type_index: c.read_cp_index()?,
-            },
-            19 => CpEntry::Module {
-                name_index: c.read_cp_index()?,
-            },
-            20 => CpEntry::Package {
-                name_index: c.read_cp_index()?,
-            },
-            other => {
-                return Err(ParseError::UnknownCpTag {
-                    tag: other,
-                    index: u16::try_from(i).unwrap_or(u16::MAX),
-                });
-            }
-        };
-        pool.push(Some(entry));
-        i += 1;
+        if let Some(entry) = parse_constant_pool_entry(c, tag, &mut pool, &mut i)? {
+            pool.push(Some(entry));
+            i += 1;
+        }
     }
 
     Ok(pool)
@@ -327,6 +248,96 @@ fn parse_constant_pool(c: &mut Cursor<'_>) -> ParseResult<Vec<Option<CpEntry>>> 
 // ---------------------------------------------------------------------------
 // Fields and methods
 // ---------------------------------------------------------------------------
+
+fn parse_constant_pool_entry(
+    c: &mut Cursor<'_>,
+    tag: u8,
+    pool: &mut Vec<Option<CpEntry>>,
+    i: &mut usize,
+) -> ParseResult<Option<CpEntry>> {
+    let entry = match tag {
+        1 => {
+            let len = c.read_u16()? as usize;
+            let bytes = c.read_bytes(len)?;
+            let s = String::from_utf8(bytes.to_vec())?;
+            CpEntry::Utf8(s)
+        }
+        3 => CpEntry::Integer(c.read_i32()?),
+        4 => CpEntry::Float(c.read_f32()?),
+        5 => {
+            let v = CpEntry::Long(c.read_i64()?);
+            pool.push(Some(v));
+            pool.push(None); // phantom slot
+            *i += 2;
+            return Ok(None);
+        }
+        6 => {
+            let v = CpEntry::Double(c.read_f64()?);
+            pool.push(Some(v));
+            pool.push(None); // phantom slot
+            *i += 2;
+            return Ok(None);
+        }
+        7 => CpEntry::Class {
+            name_index: c.read_cp_index()?,
+        },
+        8 => CpEntry::String {
+            string_index: c.read_cp_index()?,
+        },
+        9 => CpEntry::Fieldref {
+            class_index: c.read_cp_index()?,
+            name_and_type_index: c.read_cp_index()?,
+        },
+        10 => CpEntry::Methodref {
+            class_index: c.read_cp_index()?,
+            name_and_type_index: c.read_cp_index()?,
+        },
+        11 => CpEntry::InterfaceMethodref {
+            class_index: c.read_cp_index()?,
+            name_and_type_index: c.read_cp_index()?,
+        },
+        12 => CpEntry::NameAndType {
+            name_index: c.read_cp_index()?,
+            descriptor_index: c.read_cp_index()?,
+        },
+        15 => {
+            let reference_kind = c.read_u8()?;
+            if !(1..=9).contains(&reference_kind) {
+                return Err(ParseError::InvalidMethodHandleKind {
+                    kind: reference_kind,
+                });
+            }
+            CpEntry::MethodHandle {
+                reference_kind,
+                reference_index: c.read_cp_index()?,
+            }
+        }
+        16 => CpEntry::MethodType {
+            descriptor_index: c.read_cp_index()?,
+        },
+        17 => CpEntry::Dynamic {
+            bootstrap_method_attr_index: c.read_u16()?,
+            name_and_type_index: c.read_cp_index()?,
+        },
+        18 => CpEntry::InvokeDynamic {
+            bootstrap_method_attr_index: c.read_u16()?,
+            name_and_type_index: c.read_cp_index()?,
+        },
+        19 => CpEntry::Module {
+            name_index: c.read_cp_index()?,
+        },
+        20 => CpEntry::Package {
+            name_index: c.read_cp_index()?,
+        },
+        other => {
+            return Err(ParseError::UnknownCpTag {
+                tag: other,
+                index: u16::try_from(*i).unwrap_or(u16::MAX),
+            });
+        }
+    };
+    Ok(Some(entry))
+}
 
 fn parse_field(c: &mut Cursor<'_>, cp_len: usize) -> ParseResult<FieldInfo> {
     let access_flags = FieldAccessFlags::from_bits_truncate(c.read_u16()?);


### PR DESCRIPTION
**🚮 Smell:** The `parse_constant_pool` function in `crates/duke-classfile/src/parser.rs` contained a massive, 90-line `match` statement that handled the allocation and population logic for every constant pool tag directly inline. This "God Function" approach breaks readability and creates deep nesting.
**✨ Solution:** Extracted the internal logic of the large `match` arms into a strictly-typed helper function called `parse_constant_pool_entry`. 
**🧼 Benefit:** Flattens the code, keeps the main parsing loop short and readable, and isolates the specific tag logic.
**🛡️ Verification:** Tests passed. Code compiled cleanly. No logic changed.

---
*PR created automatically by Jules for task [11518858750933835815](https://jules.google.com/task/11518858750933835815) started by @madmax983*