### PR TITLE
⚡ Bolt: Eliminate Slot Vec clones in native array iteration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,6 @@
 ## 2026-04-13 - [Avoid Chained Iterators with Collect]
 **Learning:** Replaced `.drain().map().collect::<Vec<_>>().` pattern on a `HashMap` with an explicit `Vec::with_capacity()` and a for-loop. The chained iterators drop the size hint, causing unnecessary heap reallocations. Also, explicit `drop()` on lock guards avoids clippy warnings `clippy::significant_drop_tightening` when used immediately before long-running operations.
 **Action:** Use pre-allocated vectors and loops instead of chained iterator `collect`s when the size is known, especially around lock-managed states.
+**[Eliminate Slot Vec clones in Native Array/HashMap Iteration]
+**Learning:** [Many Java native methods like `native_arraylist_index_of` or `native_arrays_equals_int` were cloning the entire `fields` vector from `heap.get(this_ref)` simply to iterate and search. Since `Slot` is `Copy`, cloning the entire vector is wildly inefficient. A previous learning suggested borrowing with `&heap.get(...)?.fields`, but this causes borrow checker conflicts if the inner loop needs `heap` for operations like `slots_equal`.]
+**Action:** [Use an index-based loop (`for i in 0..len`) by getting `len` first, then retrieving `heap.get(this_ref)?.fields[i]` inside the loop. This avoids both full `Vec` cloning and holding overlapping `Heap` borrows across function calls.]

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -16903,13 +16903,14 @@ pub(crate) fn native_arraylist_index_of(
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
     let target = extract_slot_arg(args, 1);
-    let fields = heap.get(this_ref)?.fields.clone();
-    let idx = fields
-        .iter()
-        .skip(1)
-        .position(|slot| slots_equal(slot, &target, heap))
-        .map_or(-1, |i| i32::try_from(i).unwrap_or(i32::MAX));
-    Ok(Some(Slot::Int(idx)))
+    let len = heap.get(this_ref)?.fields.len();
+    for i in 1..len {
+        let slot = heap.get(this_ref)?.fields[i];
+        if slots_equal(&slot, &target, heap) {
+            return Ok(Some(Slot::Int(i32::try_from(i - 1).unwrap_or(i32::MAX))));
+        }
+    }
+    Ok(Some(Slot::Int(-1)))
 }
 
 /// Native: `ArrayList.lastIndexOf(Object)I` — last occurrence, or -1.
@@ -16921,13 +16922,16 @@ pub(crate) fn native_arraylist_last_index_of(
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
     let target = extract_slot_arg(args, 1);
-    let fields = heap.get(this_ref)?.fields.clone();
-    let idx = fields
-        .iter()
-        .skip(1)
-        .rposition(|slot| slots_equal(slot, &target, heap))
-        .map_or(-1, |i| i32::try_from(i).unwrap_or(i32::MAX));
-    Ok(Some(Slot::Int(idx)))
+    let len = heap.get(this_ref)?.fields.len();
+    if len > 1 {
+        for i in (1..len).rev() {
+            let slot = heap.get(this_ref)?.fields[i];
+            if slots_equal(&slot, &target, heap) {
+                return Ok(Some(Slot::Int(i32::try_from(i - 1).unwrap_or(i32::MAX))));
+            }
+        }
+    }
+    Ok(Some(Slot::Int(-1)))
 }
 
 /// Native: `ArrayList.add(I,Object)V` — inserts element at index, shifting others right.
@@ -17011,11 +17015,15 @@ pub(crate) fn native_hashmap_contains_value(
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
     let target = extract_slot_arg(args, 1);
-    let fields = heap.get(this_ref)?.fields.clone();
-    // Values are at even indices: 2, 4, 6, ...
     let mut i = 2usize;
-    while i < fields.len() {
-        if slots_equal(&fields[i], &target, heap) {
+    loop {
+        // Evaluate len inside the loop since heap access can't be held across slots_equal
+        let len = heap.get(this_ref)?.fields.len();
+        if i >= len {
+            break;
+        }
+        let slot = heap.get(this_ref)?.fields[i];
+        if slots_equal(&slot, &target, heap) {
             return Ok(Some(Slot::Int(1)));
         }
         i += 2;
@@ -17170,14 +17178,20 @@ pub(crate) fn native_arrays_equals_int(
 ) -> VmResult<Option<Slot>> {
     let a_ref = extract_ref_arg(args, 0)?;
     let b_ref = extract_ref_arg(args, 1)?;
-    let a_fields = heap.get(a_ref)?.fields.clone();
-    let b_fields = heap.get(b_ref)?.fields.clone();
-    let equal = a_fields.len() == b_fields.len()
-        && a_fields.iter().zip(&b_fields).all(|(x, y)| match (x, y) {
-            (Slot::Int(a), Slot::Int(b)) => a == b,
-            _ => false,
-        });
-    Ok(Some(Slot::Int(i32::from(equal))))
+    let a_len = heap.get(a_ref)?.fields.len();
+    let b_len = heap.get(b_ref)?.fields.len();
+    if a_len != b_len {
+        return Ok(Some(Slot::Int(0)));
+    }
+    for i in 0..a_len {
+        let x = heap.get(a_ref)?.fields[i];
+        let y = heap.get(b_ref)?.fields[i];
+        match (x, y) {
+            (Slot::Int(a), Slot::Int(b)) if a == b => {}
+            _ => return Ok(Some(Slot::Int(0))),
+        }
+    }
+    Ok(Some(Slot::Int(1)))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
💡 **What**: Refactored `native_arraylist_index_of`, `native_arraylist_last_index_of`, `native_hashmap_contains_value`, and `native_arrays_equals_int` in `crates/duke-interpreter/src/native.rs` to replace entire `.fields.clone()` calls with index-based loops.

🎯 **Why**: Previously, these methods cloned the entire underlying `Vec<Slot>` associated with `ArrayList`s and `HashMap`s just to iterate or search through them. Because `Slot`s are `Copy`, this cloning was completely unnecessary and incurred O(N) heap memory allocations per method call. Fetching length via `heap.get(this_ref)?.fields.len()` outside or directly inside the loops and retrieving individual elements by index avoids allocating intermediate vectors while sidestepping overlapping mutable borrow checker conflicts with `slots_equal`.

📊 **Impact**: Massively reduces heap allocations and copying overhead on hot native execution paths involving collection searching or array comparisons. Memory allocation goes from O(N) to O(1) for these operations.

🔬 **Measurement**: Verified with `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test` across the workspace with all tests passing successfully. No performance regressions reported.

---
*PR created automatically by Jules for task [11985594804181074930](https://jules.google.com/task/11985594804181074930) started by @madmax983*