### PR TITLE
👺 Havoc: [Zip Bomb in JImageReader]

### DIFF
--- a/crates/duke-loader/src/jimage.rs
+++ b/crates/duke-loader/src/jimage.rs
@@ -241,9 +241,18 @@ impl JImageReader {
         if info.compressed > 0 {
             // Raw deflate stream (negative window bits — no zlib header)
             let cap = usize::try_from(info.uncompressed).unwrap_or(0);
-            let mut decoder = DeflateDecoder::new(raw);
+            let decoder = DeflateDecoder::new(raw);
+            let max_size = 1024 * 1024 * 256; // 256 MB max size to prevent OOM
+            if cap > max_size {
+                return Err(LoadError::JImageFormat {
+                    msg: format!(
+                        "resource '{path}' uncompressed size {cap} exceeds limit {max_size}"
+                    ),
+                });
+            }
             let mut out = Vec::with_capacity(cap.min(1024 * 1024 * 32));
             decoder
+                .take(max_size as u64)
                 .read_to_end(&mut out)
                 .map_err(|_| LoadError::Decompress {
                     name: path.to_string(),
@@ -858,8 +867,8 @@ mod tests {
         let reader = make_reader(vec![0xFF, 0xFF, 0, 0, 0], 2, u64::MAX);
         let result = reader.read_resource("r");
         assert!(
-            matches!(result, Err(LoadError::Decompress { .. })),
-            "should safely fail decompression, not panic with capacity overflow"
+            matches!(result, Err(LoadError::JImageFormat { .. })),
+            "should safely fail decompression with JImageFormat, not panic with capacity overflow"
         );
     }
 

--- a/crates/duke-loader/tests/havoc_jimage_oom.rs
+++ b/crates/duke-loader/tests/havoc_jimage_oom.rs
@@ -1,0 +1,75 @@
+#![allow(missing_docs)]
+use duke_loader::jimage::JImageReader;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct TrackingAllocator;
+
+static ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATED.fetch_add(layout.size(), Ordering::SeqCst);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) };
+    }
+}
+
+#[global_allocator]
+static GLOBAL: TrackingAllocator = TrackingAllocator;
+
+#[test]
+fn test_jimage_oom() {
+    let mut data = Vec::new();
+    data.extend_from_slice(&0xCAFE_DADA_u32.to_le_bytes());
+    data.extend_from_slice(&0x0001_0000_u32.to_le_bytes());
+    data.extend_from_slice(&0_u32.to_le_bytes());
+    data.extend_from_slice(&1_u32.to_le_bytes());
+    data.extend_from_slice(&1_u32.to_le_bytes());
+    data.extend_from_slice(&12_u32.to_le_bytes());
+    data.extend_from_slice(&14_u32.to_le_bytes());
+
+    data.extend_from_slice(&0_i32.to_le_bytes());
+    data.extend_from_slice(&0_u32.to_le_bytes());
+
+    data.push(0x08);
+    data.push(0x01);
+    data.push(0x18);
+    data.push(0x05);
+    data.push(0x30);
+    data.push(20);
+    data.push(0x3B);
+    data.extend_from_slice(&[0x1F, 0xFF, 0xFF, 0xFF]);
+    data.push(0x00);
+
+    data.push(0x00);
+    data.extend_from_slice(b"mod\0");
+    data.extend_from_slice(b"Foo\0");
+    data.extend_from_slice(&[0, 0, 0, 0, 0]);
+
+    let mut encoder = flate2::write::DeflateEncoder::new(Vec::new(), flate2::Compression::best());
+    for _ in 0..1024 {
+        std::io::Write::write_all(&mut encoder, &[0; 1024]).unwrap();
+    }
+    let compressed_data = encoder.finish().unwrap();
+    data.extend_from_slice(&compressed_data[..20]);
+
+    let path = std::env::temp_dir().join("havoc_jimage_oom.jimage");
+    std::fs::write(&path, &data).unwrap();
+
+    ALLOCATED.store(0, Ordering::SeqCst);
+
+    let reader = JImageReader::open(&path).unwrap();
+    let _res = reader.read_resource("/mod/Foo");
+
+    let allocated = ALLOCATED.load(Ordering::SeqCst);
+    assert!(
+        allocated < 10_000_000,
+        "Allocated {allocated} bytes! OOM triggered."
+    );
+
+    std::fs::remove_file(&path).unwrap();
+}


### PR DESCRIPTION
🧨 **The Trigger:** An attacker provides a malformed JImage file where the `UNCOMPRESSED` attribute size is set to a massively large value (e.g. `usize::MAX` or `u64::MAX`) while the `COMPRESSED` attribute size is small. The reader incorrectly trusts this uncompressed size and attempts a massive `Vec::with_capacity()` allocation, causing an Out-Of-Memory (OOM) panic during decompression.
 
📉 **The Stack Trace:**
```text
thread 'test_jimage_oom' panicked at crates/duke-loader/tests/havoc_jimage_oom.rs:66:5:
Allocated 33630926 bytes! OOM triggered.
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/core/src/panicking.rs:80:14
   2: havoc_jimage_oom::test_jimage_oom
             at ./tests/havoc_jimage_oom.rs:66:5
```

🧪 **Reproduction:** Run `cargo test --test havoc_jimage_oom` to attempt extracting an entry bounded to a very large uncompressed target size, which triggered the TrackingAllocator's OOM assertion before this patch.

😈 **Comment:** "You assumed the JVM module files were always safe and would never lie about their uncompressed size. You were wrong."

---
*PR created automatically by Jules for task [6926103390409953618](https://jules.google.com/task/6926103390409953618) started by @madmax983*