### PR TITLE
🛡️ Sentry: [test coverage improvement] for primitive boxing

### DIFF
--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -29593,3 +29593,50 @@ fn test_p117_array_of_arrays() {
         45
     );
 }
+
+#[test]
+fn test_box_primitive_slot() {
+    let mut heap = duke_gc::Heap::new();
+
+    let cases = vec![
+        (
+            duke_runtime::Slot::Int(42),
+            "java/lang/Integer",
+            duke_runtime::Slot::Int(42),
+        ),
+        (
+            duke_runtime::Slot::Long(999),
+            "java/lang/Long",
+            duke_runtime::Slot::Long(999),
+        ),
+        (
+            duke_runtime::Slot::Float(1.23),
+            "java/lang/Float",
+            duke_runtime::Slot::Float(1.23),
+        ),
+        (
+            duke_runtime::Slot::Double(4.56),
+            "java/lang/Double",
+            duke_runtime::Slot::Double(4.56),
+        ),
+    ];
+
+    for (input, expected_class, expected_field) in cases {
+        let result = crate::box_primitive_slot(input, &mut heap);
+
+        let duke_runtime::Slot::Reference(Some(obj_ref)) = result else {
+            panic!("Expected boxed primitive to be a Reference(Some(r))")
+        };
+
+        let obj = heap.get(obj_ref).expect("Object must exist in heap");
+        assert_eq!(obj.class_name, expected_class);
+        assert_eq!(obj.fields[0], expected_field);
+    }
+
+    let none_ref = duke_runtime::Slot::Reference(None);
+    let result = crate::box_primitive_slot(none_ref, &mut heap);
+    assert_eq!(
+        result, none_ref,
+        "Expected pass-through for other slot types"
+    );
+}


### PR DESCRIPTION
🎯 Target: `box_primitive_slot` in `crates/duke-interpreter/src/native.rs`
💣 Risk: Untested auto-boxing could fail mapping primitives to classes silently, or panic in array indexing/allocation, breaking JVM functionality that relies on primitives.
🧪 Strategy: Added a robust table-driven test to ensure all primitives correctly box to their respective objects with accurate class and field assertions, along with pass-through validation.
🔬 Verification: Run `cargo test -p duke-interpreter test_box_primitive_slot`

---
*PR created automatically by Jules for task [7947790229216969306](https://jules.google.com/task/7947790229216969306) started by @madmax983*