### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -7,3 +7,8 @@
 ## 2025-02-28 - [Hardcoded paths in tests cause massive coverage gaps]
 **Learning:** A hardcoded Windows path in `jdk_modules_path()` caused several `duke-loader` integration tests to be skipped silently on Linux CI, dropping coverage for `JImageReader` by ~45%.
 **Action:** When tests skip or coverage drops on file I/O operations, check for hardcoded OS-specific paths and replace them with dynamic resolution (like `JAVA_HOME`).
+## 2024-04-15 - Uncovered Code in duke-loader and duke-bytecode
+
+**Learning:** `Instruction::Dload` and `Instruction::IincW` bounds checking in `duke-bytecode/src/verifier.rs` were missing explicit test coverage. Similarly, inner `ZipReader` read errors (like `ZipFormat` errors when extracting files inside a nested `BOOT-INF/lib` jar) bubbling up to `find_class` callers were untested in `duke-loader/src/zip.rs`.
+
+**Action:** Add direct unit tests covering the `check_locals` function with `Dload` and `IincW` to assure the branch bounds behave properly, and write a targeted `zip_loader_try_nested_read_entry_error` test that triggers a `ZipFormat` error in an inner jar during class finding, asserting that it correctly bubbles rather than being swallowed as a NotFound or panicking.

--- a/crates/duke-bytecode/src/verifier.rs
+++ b/crates/duke-bytecode/src/verifier.rs
@@ -858,5 +858,60 @@ mod tests {
                 max_locals: 4
             })
         ));
+
+        let instr = Instruction::Dload(5);
+        let result = check_locals(&instr, 0, 4);
+        assert!(matches!(
+            result,
+            Err(VerifyError::LocalOutOfBounds {
+                pc: 0,
+                index: 5,
+                max_locals: 4
+            })
+        ));
+
+        let instr = Instruction::IincW { index: 5, value: 1 };
+        let result = check_locals(&instr, 0, 4);
+        assert!(matches!(
+            result,
+            Err(VerifyError::LocalOutOfBounds {
+                pc: 0,
+                index: 5,
+                max_locals: 4
+            })
+        ));
+
+        let instr = Instruction::Dload(5);
+        let result = check_locals(&instr, 0, 4);
+        assert!(matches!(
+            result,
+            Err(VerifyError::LocalOutOfBounds {
+                pc: 0,
+                index: 5,
+                max_locals: 4
+            })
+        ));
+
+        let instr = Instruction::DloadW(5);
+        let result = check_locals(&instr, 0, 4);
+        assert!(matches!(
+            result,
+            Err(VerifyError::LocalOutOfBounds {
+                pc: 0,
+                index: 5,
+                max_locals: 4
+            })
+        ));
+
+        let instr = Instruction::IincW { index: 5, value: 1 };
+        let result = check_locals(&instr, 0, 4);
+        assert!(matches!(
+            result,
+            Err(VerifyError::LocalOutOfBounds {
+                pc: 0,
+                index: 5,
+                max_locals: 4
+            })
+        ));
     }
 }

--- a/crates/duke-loader/src/zip.rs
+++ b/crates/duke-loader/src/zip.rs
@@ -1132,6 +1132,22 @@ mod tests {
     }
 
     #[test]
+    fn zip_loader_try_nested_read_entry_error() {
+        let mut nested_jar = build_stored_zip("Bad.class", b"data");
+        nested_jar[0] ^= 0xFF; // Corrupt local header signature
+        let outer_zip = build_multi_entry_zip(&[("BOOT-INF/lib/dependency.jar", &nested_jar)]);
+        let tmp = std::env::temp_dir().join("duke_test_zip_nested_err.jar");
+        std::fs::write(&tmp, &outer_zip).unwrap();
+
+        let loader = ZipLoader::open(&tmp).expect("should open outer zip");
+        // The inner ZipReader will fail to read "Bad.class" during find_class
+        // and should bubble the error out.
+        let err = loader.find_class("Bad").unwrap_err();
+        assert!(matches!(err, super::LoadError::ZipFormat { .. }));
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[test]
     fn zip_loader_read_entry_other_error_nested() {
         let mut nested_jar = build_stored_zip("Bad.class", b"data");
         nested_jar[0] ^= 0xFF; // Corrupt local header signature


### PR DESCRIPTION
🎯 Target: `duke-bytecode::verifier` bounds checking and `duke-loader::zip` nested reading error handling.
💣 Risk: Missing bounds checking test coverage on `Dload`, `DloadW`, and `IincW` operations leaves system susceptible to `LocalOutOfBounds` panics on unexpected bytecode permutations. Silent swallows of ZipFormat errors occurring within nested `BOOT-INF/lib` zip loaders masks system integrity logic.
🧪 Strategy: Added explicit error matching `VerifyError::LocalOutOfBounds` testing logic for specific bytecode commands into `crates/duke-bytecode/src/verifier.rs`, and introduced `zip_loader_try_nested_read_entry_error` inside `crates/duke-loader/src/zip.rs` forcing an error on corrupt payload to enforce the bubble. 
🔬 Verification: Run `cargo test -p duke-bytecode && cargo test -p duke-loader`

---
*PR created automatically by Jules for task [9311654602399226899](https://jules.google.com/task/9311654602399226899) started by @madmax983*