### PR TITLE
⚒️ Forge: [refactor instruction matching]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -30,3 +30,7 @@
 **[Extracted Class Members Parser]
 **Learning:** `parse_class_file` in `crates/duke-classfile/src/parser.rs` handled validating the header (magic, versions), parsing the constant pool, *and* looping through all class members (interfaces, fields, methods, attributes). Doing multiple levels of sequential structural parsing in one function makes it a God Function.
 **Action:** Extract logical sections of file format parsing. Parse the header and constant pool first, then delegate to a `parse_class_members` function for the rest to clearly delineate the phases of decoding.
+
+**Extract Enum Variant Matchers**
+**Learning:** `crates/duke-bytecode/src/cfg.rs` contained multiple massive `match` blocks repeatedly enumerating the 15+ conditional branch instructions, unconditional jumps, and return instructions to generate CFGs and compute cyclomatic complexity. This duplicated logic and inflated file size.
+**Action:** Always extract boolean categorization logic (e.g., `is_conditional_branch()`, `is_return()`) and data extraction logic (`conditional_branch_target()`) into public helper methods directly on the enum (`Instruction`) to DRY up matching code and dramatically flatten calling modules.

--- a/crates/duke-bytecode/src/cfg.rs
+++ b/crates/duke-bytecode/src/cfg.rs
@@ -50,83 +50,52 @@ pub fn generate_mermaid_cfg(instructions: &[(usize, Instruction)]) -> String {
         let _ = writeln!(cfg, "    node{pc}[\"{pc}: {mnemonic}\"]");
 
         // Add edges
-        match instr {
-            // Absolute fall-through stops
-            Instruction::Return
-            | Instruction::Ireturn
-            | Instruction::Lreturn
-            | Instruction::Freturn
-            | Instruction::Dreturn
-            | Instruction::Areturn
-            | Instruction::Athrow
-            | Instruction::Ret(_)
-            | Instruction::RetW(_) => {
-                // No fall-through
-            }
-            Instruction::Goto(offset) => {
-                let target = (*pc as isize + isize::from(*offset)) as usize;
-                let _ = writeln!(cfg, "    node{pc} --> node{target}");
-            }
-            Instruction::GotoW(offset) => {
-                let target = (*pc as isize + *offset as isize) as usize;
-                let _ = writeln!(cfg, "    node{pc} --> node{target}");
-            }
-            Instruction::Tableswitch {
-                default, offsets, ..
-            } => {
-                let default_target = (*pc as isize + *default as isize) as usize;
-                let _ = writeln!(cfg, "    node{pc} -->|default| node{default_target}");
-                for (idx, offset) in offsets.iter().enumerate() {
-                    let target = (*pc as isize + *offset as isize) as usize;
-                    let _ = writeln!(cfg, "    node{pc} -->|{idx}| node{target}");
-                }
-            }
-            Instruction::Lookupswitch { default, pairs } => {
-                let default_target = (*pc as isize + *default as isize) as usize;
-                let _ = writeln!(cfg, "    node{pc} -->|default| node{default_target}");
-                for (match_val, offset) in pairs {
-                    let target = (*pc as isize + *offset as isize) as usize;
-                    let _ = writeln!(cfg, "    node{pc} -->|{match_val}| node{target}");
-                }
-            }
-            // Conditional branches
-            Instruction::Ifeq(offset)
-            | Instruction::Ifne(offset)
-            | Instruction::Iflt(offset)
-            | Instruction::Ifge(offset)
-            | Instruction::Ifgt(offset)
-            | Instruction::Ifle(offset)
-            | Instruction::IfIcmpeq(offset)
-            | Instruction::IfIcmpne(offset)
-            | Instruction::IfIcmplt(offset)
-            | Instruction::IfIcmpge(offset)
-            | Instruction::IfIcmpgt(offset)
-            | Instruction::IfIcmple(offset)
-            | Instruction::IfAcmpeq(offset)
-            | Instruction::IfAcmpne(offset)
-            | Instruction::Ifnull(offset)
-            | Instruction::Ifnonnull(offset)
-            | Instruction::Jsr(offset) => {
-                let target = (*pc as isize + isize::from(*offset)) as usize;
+        if instr.is_return() {
+            // No fall-through
+        } else if let Some(offset) = instr.unconditional_jump_target() {
+            let target = (*pc as isize + offset) as usize;
+            if matches!(instr, Instruction::Jsr(_) | Instruction::JsrW(_)) {
                 let _ = writeln!(cfg, "    node{pc} -->|true| node{target}");
                 if i + 1 < instructions.len() {
                     let next_pc = instructions[i + 1].0;
                     let _ = writeln!(cfg, "    node{pc} -->|false| node{next_pc}");
                 }
+            } else {
+                let _ = writeln!(cfg, "    node{pc} --> node{target}");
             }
-            Instruction::JsrW(offset) => {
-                let target = (*pc as isize + *offset as isize) as usize;
-                let _ = writeln!(cfg, "    node{pc} -->|true| node{target}");
-                if i + 1 < instructions.len() {
-                    let next_pc = instructions[i + 1].0;
-                    let _ = writeln!(cfg, "    node{pc} -->|false| node{next_pc}");
+        } else if let Some(offset) = instr.conditional_branch_target() {
+            let target = (*pc as isize + offset) as usize;
+            let _ = writeln!(cfg, "    node{pc} -->|true| node{target}");
+            if i + 1 < instructions.len() {
+                let next_pc = instructions[i + 1].0;
+                let _ = writeln!(cfg, "    node{pc} -->|false| node{next_pc}");
+            }
+        } else {
+            match instr {
+                Instruction::Tableswitch {
+                    default, offsets, ..
+                } => {
+                    let default_target = (*pc as isize + *default as isize) as usize;
+                    let _ = writeln!(cfg, "    node{pc} -->|default| node{default_target}");
+                    for (idx, offset) in offsets.iter().enumerate() {
+                        let target = (*pc as isize + *offset as isize) as usize;
+                        let _ = writeln!(cfg, "    node{pc} -->|{idx}| node{target}");
+                    }
                 }
-            }
-            // Everything else falls through
-            _ => {
-                if i + 1 < instructions.len() {
-                    let next_pc = instructions[i + 1].0;
-                    let _ = writeln!(cfg, "    node{pc} --> node{next_pc}");
+                Instruction::Lookupswitch { default, pairs } => {
+                    let default_target = (*pc as isize + *default as isize) as usize;
+                    let _ = writeln!(cfg, "    node{pc} -->|default| node{default_target}");
+                    for (match_val, offset) in pairs {
+                        let target = (*pc as isize + *offset as isize) as usize;
+                        let _ = writeln!(cfg, "    node{pc} -->|{match_val}| node{target}");
+                    }
+                }
+                _ => {
+                    // Everything else falls through
+                    if i + 1 < instructions.len() {
+                        let next_pc = instructions[i + 1].0;
+                        let _ = writeln!(cfg, "    node{pc} --> node{next_pc}");
+                    }
                 }
             }
         }
@@ -326,39 +295,24 @@ pub fn cyclomatic_complexity(instructions: &[(usize, Instruction)]) -> usize {
     let mut complexity = 1;
 
     for (_, instr) in instructions {
-        match instr {
-            // Conditional branches
-            Instruction::Ifeq(_)
-            | Instruction::Ifne(_)
-            | Instruction::Iflt(_)
-            | Instruction::Ifge(_)
-            | Instruction::Ifgt(_)
-            | Instruction::Ifle(_)
-            | Instruction::IfIcmpeq(_)
-            | Instruction::IfIcmpne(_)
-            | Instruction::IfIcmplt(_)
-            | Instruction::IfIcmpge(_)
-            | Instruction::IfIcmpgt(_)
-            | Instruction::IfIcmple(_)
-            | Instruction::IfAcmpeq(_)
-            | Instruction::IfAcmpne(_)
-            | Instruction::Ifnull(_)
-            | Instruction::Ifnonnull(_)
-            | Instruction::Jsr(_)
-            | Instruction::JsrW(_) => {
-                complexity += 1;
+        if instr.is_conditional_branch()
+            || matches!(instr, Instruction::Jsr(_) | Instruction::JsrW(_))
+        {
+            complexity += 1;
+        } else {
+            match instr {
+                // Switch statements
+                Instruction::Tableswitch { offsets, .. } => {
+                    // Number of possible paths = offsets.len() + 1 (for default).
+                    // Subtract 1 because we start at 1 complexity inherently.
+                    complexity += offsets.len();
+                }
+                Instruction::Lookupswitch { pairs, .. } => {
+                    // Number of possible paths = pairs.len() + 1 (for default).
+                    complexity += pairs.len();
+                }
+                _ => {}
             }
-            // Switch statements
-            Instruction::Tableswitch { offsets, .. } => {
-                // Number of possible paths = offsets.len() + 1 (for default).
-                // Subtract 1 because we start at 1 complexity inherently.
-                complexity += offsets.len();
-            }
-            Instruction::Lookupswitch { pairs, .. } => {
-                // Number of possible paths = pairs.len() + 1 (for default).
-                complexity += pairs.len();
-            }
-            _ => {}
         }
     }
 
@@ -484,75 +438,47 @@ pub fn generate_basic_block_cfg(blocks: &[crate::basic_block::BasicBlock]) -> St
         // Edge definition based on the last instruction
         if let Some((last_pc, last_instr)) = block.instructions.last() {
             let next_block_id = block.end_pc;
-            match last_instr {
-                crate::Instruction::Goto(offset) | crate::Instruction::Jsr(offset) => {
-                    let target = (*last_pc as isize + isize::from(*offset)) as usize;
-                    let _ = writeln!(cfg, "    block{block_id} --> block{target}");
-                }
-                crate::Instruction::GotoW(offset) | crate::Instruction::JsrW(offset) => {
-                    let target = (*last_pc as isize + *offset as isize) as usize;
-                    let _ = writeln!(cfg, "    block{block_id} --> block{target}");
-                }
-                crate::Instruction::Ifeq(offset)
-                | crate::Instruction::Ifne(offset)
-                | crate::Instruction::Iflt(offset)
-                | crate::Instruction::Ifge(offset)
-                | crate::Instruction::Ifgt(offset)
-                | crate::Instruction::Ifle(offset)
-                | crate::Instruction::IfIcmpeq(offset)
-                | crate::Instruction::IfIcmpne(offset)
-                | crate::Instruction::IfIcmplt(offset)
-                | crate::Instruction::IfIcmpge(offset)
-                | crate::Instruction::IfIcmpgt(offset)
-                | crate::Instruction::IfIcmple(offset)
-                | crate::Instruction::IfAcmpeq(offset)
-                | crate::Instruction::IfAcmpne(offset)
-                | crate::Instruction::Ifnull(offset)
-                | crate::Instruction::Ifnonnull(offset) => {
-                    let target = (*last_pc as isize + isize::from(*offset)) as usize;
-                    let _ = writeln!(cfg, "    block{block_id} -->|true| block{target}");
-                    let _ = writeln!(cfg, "    block{block_id} -->|false| block{next_block_id}");
-                }
-                crate::Instruction::Tableswitch {
-                    default,
-                    low,
-                    high: _,
-                    offsets,
-                } => {
-                    let target = (*last_pc as isize + *default as isize) as usize;
-                    let _ = writeln!(cfg, "    block{block_id} -->|default| block{target}");
-                    for (i, offset) in offsets.iter().enumerate() {
-                        let target = (*last_pc as isize + *offset as isize) as usize;
-                        let _ = writeln!(
-                            cfg,
-                            "    block{block_id} -->|{}| block{target}",
-                            (i as i32) + *low
-                        );
+            if last_instr.is_return() {
+                // No fall-through, no explicit branches to other blocks
+            } else if let Some(offset) = last_instr.unconditional_jump_target() {
+                let target = (*last_pc as isize + offset) as usize;
+                let _ = writeln!(cfg, "    block{block_id} --> block{target}");
+            } else if let Some(offset) = last_instr.conditional_branch_target() {
+                let target = (*last_pc as isize + offset) as usize;
+                let _ = writeln!(cfg, "    block{block_id} -->|true| block{target}");
+                let _ = writeln!(cfg, "    block{block_id} -->|false| block{next_block_id}");
+            } else {
+                match last_instr {
+                    crate::Instruction::Tableswitch {
+                        default,
+                        low,
+                        high: _,
+                        offsets,
+                    } => {
+                        let target = (*last_pc as isize + *default as isize) as usize;
+                        let _ = writeln!(cfg, "    block{block_id} -->|default| block{target}");
+                        for (i, offset) in offsets.iter().enumerate() {
+                            let target = (*last_pc as isize + *offset as isize) as usize;
+                            let _ = writeln!(
+                                cfg,
+                                "    block{block_id} -->|{}| block{target}",
+                                (i as i32) + *low
+                            );
+                        }
                     }
-                }
-                crate::Instruction::Lookupswitch { default, pairs } => {
-                    let target = (*last_pc as isize + *default as isize) as usize;
-                    let _ = writeln!(cfg, "    block{block_id} -->|default| block{target}");
-                    for (key, offset) in pairs {
-                        let target = (*last_pc as isize + *offset as isize) as usize;
-                        let _ = writeln!(cfg, "    block{block_id} -->|{key}| block{target}");
+                    crate::Instruction::Lookupswitch { default, pairs } => {
+                        let target = (*last_pc as isize + *default as isize) as usize;
+                        let _ = writeln!(cfg, "    block{block_id} -->|default| block{target}");
+                        for (key, offset) in pairs {
+                            let target = (*last_pc as isize + *offset as isize) as usize;
+                            let _ = writeln!(cfg, "    block{block_id} -->|{key}| block{target}");
+                        }
                     }
-                }
-                crate::Instruction::Return
-                | crate::Instruction::Ireturn
-                | crate::Instruction::Lreturn
-                | crate::Instruction::Freturn
-                | crate::Instruction::Dreturn
-                | crate::Instruction::Areturn
-                | crate::Instruction::Athrow
-                | crate::Instruction::Ret(_)
-                | crate::Instruction::RetW(_) => {
-                    // No fall-through, no explicit branches to other blocks
-                }
-                _ => {
-                    // Fall-through
-                    if pc_to_block.contains_key(&next_block_id) {
-                        let _ = writeln!(cfg, "    block{block_id} --> block{next_block_id}");
+                    _ => {
+                        // Fall-through
+                        if pc_to_block.contains_key(&next_block_id) {
+                            let _ = writeln!(cfg, "    block{block_id} --> block{next_block_id}");
+                        }
                     }
                 }
             }

--- a/crates/duke-bytecode/src/instruction.rs
+++ b/crates/duke-bytecode/src/instruction.rs
@@ -362,6 +362,90 @@ pub enum Instruction {
 }
 
 impl Instruction {
+    /// Returns `true` if the instruction is a conditional branch.
+    #[must_use]
+    pub const fn is_conditional_branch(&self) -> bool {
+        matches!(
+            self,
+            Self::Ifeq(_)
+                | Self::Ifne(_)
+                | Self::Iflt(_)
+                | Self::Ifge(_)
+                | Self::Ifgt(_)
+                | Self::Ifle(_)
+                | Self::IfIcmpeq(_)
+                | Self::IfIcmpne(_)
+                | Self::IfIcmplt(_)
+                | Self::IfIcmpge(_)
+                | Self::IfIcmpgt(_)
+                | Self::IfIcmple(_)
+                | Self::IfAcmpeq(_)
+                | Self::IfAcmpne(_)
+                | Self::Ifnull(_)
+                | Self::Ifnonnull(_)
+        )
+    }
+
+    /// Returns the branch target offset for a conditional branch.
+    #[must_use]
+    pub const fn conditional_branch_target(&self) -> Option<isize> {
+        match self {
+            Self::Ifeq(offset)
+            | Self::Ifne(offset)
+            | Self::Iflt(offset)
+            | Self::Ifge(offset)
+            | Self::Ifgt(offset)
+            | Self::Ifle(offset)
+            | Self::IfIcmpeq(offset)
+            | Self::IfIcmpne(offset)
+            | Self::IfIcmplt(offset)
+            | Self::IfIcmpge(offset)
+            | Self::IfIcmpgt(offset)
+            | Self::IfIcmple(offset)
+            | Self::IfAcmpeq(offset)
+            | Self::IfAcmpne(offset)
+            | Self::Ifnull(offset)
+            | Self::Ifnonnull(offset) => Some(*offset as isize),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if the instruction is an unconditional jump.
+    #[must_use]
+    pub const fn is_unconditional_jump(&self) -> bool {
+        matches!(
+            self,
+            Self::Goto(_) | Self::GotoW(_) | Self::Jsr(_) | Self::JsrW(_)
+        )
+    }
+
+    /// Returns the target offset for an unconditional jump.
+    #[must_use]
+    pub const fn unconditional_jump_target(&self) -> Option<isize> {
+        match self {
+            Self::Goto(offset) | Self::Jsr(offset) => Some(*offset as isize),
+            Self::GotoW(offset) | Self::JsrW(offset) => Some(*offset as isize),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if the instruction halts execution in the current frame.
+    #[must_use]
+    pub const fn is_return(&self) -> bool {
+        matches!(
+            self,
+            Self::Return
+                | Self::Ireturn
+                | Self::Lreturn
+                | Self::Freturn
+                | Self::Dreturn
+                | Self::Areturn
+                | Self::Athrow
+                | Self::Ret(_)
+                | Self::RetW(_)
+        )
+    }
+
     /// Returns the mnemonic string for display/debugging.
     #[must_use]
     #[allow(clippy::too_many_lines)]


### PR DESCRIPTION
🚮 **Smell:** Multiple massive `match` statements across `generate_mermaid_cfg`, `cyclomatic_complexity`, and `generate_basic_block_cfg` repeatedly exhausted 16+ conditional branch variants, returns, and jumps, resulting in extremely bloated and hard-to-read code.

✨ **Solution:** Added public boolean and `Option`-returning helper methods directly to the `Instruction` enum (`is_conditional_branch`, `conditional_branch_target`, `is_unconditional_jump`, `unconditional_jump_target`, and `is_return`). The CFG generation logic was updated to use these helpers via `if-let` chains.

🧼 **Benefit:** Dramatically flattens and DRYs up `cfg.rs`, reducing cognitive load. Future branches or returns added to the bytecode instruction set will now only need to be categorized in one place (`instruction.rs`) rather than hunting down every CFG analyzer.

🛡️ **Verification:** Tests passed. `cargo check` and `cargo clippy` pass with zero warnings. No logic changed.

---
*PR created automatically by Jules for task [8969659804260853427](https://jules.google.com/task/8969659804260853427) started by @madmax983*