### PR TITLE
👺 Havoc: String.indent integer overflow panic

### DIFF
--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -24965,7 +24965,7 @@ pub(crate) fn native_string_indent(
             })
             .collect()
     } else {
-        let remove = (-n) as usize;
+        let remove = n.unsigned_abs() as usize;
         s.lines()
             .map(|line| {
                 let stripped = line.trim_start_matches(' ');
@@ -25159,5 +25159,25 @@ mod havoc_thread_join_itself {
         // It should NOT panic, but rather return Ok(())
         let res = rx_panic.recv_timeout(std::time::Duration::from_millis(50));
         assert!(res.is_err(), "Expected no panic, but received one!");
+    }
+}
+
+#[cfg(test)]
+mod havoc_string_indent_overflow {
+    use super::*;
+    use std::io::sink;
+    use duke_gc::Heap;
+    use duke_runtime::Slot;
+
+    #[test]
+
+    fn test_string_indent_overflow() {
+        let mut heap = Heap::new();
+        let r = heap.allocate_string("hello\nworld".to_string());
+
+        let args = vec![Slot::Reference(Some(r)), Slot::Int(i32::MIN)];
+        let mut control = NativeControl::default();
+
+        let _ = native_string_indent(&args, &mut heap, &mut sink(), &mut control);
     }
 }


### PR DESCRIPTION
* 🧨 **The Trigger:** Calling `String.indent(int)` with `i32::MIN` causes an arithmetic overflow when negating the number.
* 📉 **The Stack Trace:**
```
thread 'havoc_string_indent_overflow::test_string_indent_overflow' (16429) panicked at crates/duke-interpreter/src/native.rs:24968:22:
attempt to negate with overflow
```
* 🧪 **Reproduction:** Run `cargo test havoc_string_indent_overflow`. 
* 😈 **Comment:** You assumed every integer can be negated. Math is hard. I win.

---
*PR created automatically by Jules for task [5125341636462959446](https://jules.google.com/task/5125341636462959446) started by @madmax983*