### PR TITLE
⚡ Bolt: [performance improvement] Avoid costly byte array clone in FileOutputStream.writeBytes

### DIFF
--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -230,6 +230,23 @@ impl Heap {
         idx
     }
 
+    /// Clones an existing object in the heap. Returns the reference of the new object.
+    ///
+    /// # Errors
+    /// Returns `VmError::NullPointerException` if the source reference is invalid.
+    pub fn clone_object(&mut self, src_ref: u64) -> VmResult<u64> {
+        let src = self.get(src_ref)?;
+        let class_name = src.class_name.clone();
+        let fields = src.fields.clone();
+        let string_value = src.string_value.clone();
+
+        let new_ref = self.allocate(class_name, 0);
+        let dest = self.get_mut(new_ref)?;
+        dest.fields = fields;
+        dest.string_value = string_value;
+        Ok(new_ref)
+    }
+
     /// Promote a young-gen object to old gen. Returns `raw_old_idx | OLD_BIT`.
     fn promote_to_old(&mut self, mut obj: HeapObject) -> u64 {
         obj.age = 0; // reset age in old gen (not used there)

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -448,6 +448,10 @@ pub(crate) fn native_file_output_stream_write(
     Ok(None)
 }
 
+/// Native: `FileOutputStream.writeBytes([BIIZ)V` — writes an array of bytes.
+///
+/// Performance: avoids a large heap allocation (cloning the entire `fields` vector) by using
+/// index-based iteration over the byte array, improving I/O throughput for large files.
 pub(crate) fn native_file_output_stream_write_bytes(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
@@ -456,8 +460,10 @@ pub(crate) fn native_file_output_stream_write_bytes(
 ) -> VmResult<Option<Slot>> {
     let file_id = file_stream_id_from_this(args, heap)?;
     let array_ref = extract_ref_arg(args, 1)?;
-    let bytes = heap.get(array_ref)?.fields.clone();
-    for byte in bytes {
+
+    let len = heap.get(array_ref)?.fields.len();
+    for i in 0..len {
+        let byte = heap.get(array_ref)?.fields[i];
         let Slot::Int(value) = byte else {
             return Err(VmError::TypeMismatch {
                 expected: "Int",
@@ -1133,14 +1139,7 @@ pub(crate) fn native_object_clone(
     _control: &mut NativeControl,
 ) -> VmResult<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let obj = heap.get(this_ref)?;
-    let cloned_class = obj.class_name.clone();
-    let cloned_fields = obj.fields.clone();
-    let cloned_string = obj.string_value.clone();
-    let new_ref = heap.allocate(cloned_class, 0);
-    let dest = heap.get_mut(new_ref)?;
-    dest.fields = cloned_fields;
-    dest.string_value = cloned_string;
+    let new_ref = heap.clone_object(this_ref)?;
     Ok(Some(Slot::Reference(Some(new_ref))))
 }
 


### PR DESCRIPTION
💡 **What:**
1. Modified `native_file_output_stream_write_bytes` to iterate over the byte array structure in the heap directly by index (`heap.get(array_ref)?.fields[i]`), instead of eagerly cloning the entire `fields` vector into a local variable.
2. Refactored `native_object_clone` into a new `clone_object` method on `Heap` to encapsulate object cloning logic.

🎯 **Why:**
When the JVM writes to a `FileOutputStream`, it passes an array reference to the native implementation. The original code cloned the entire `Vec<Slot>` associated with that array (which could be very large for big buffer writes) before iterating to emit bytes. This unnecessary full memory copy created high GC pressure and overhead during simple I/O. Using indexed reads bypasses the borrow checker without moving data.

📊 **Impact:**
Removes an `O(N)` heap allocation and deep copy of the `fields` vector on every chunk written via `FileOutputStream.writeBytes`.

🔬 **Measurement:**
Run `cargo test` to ensure basic I/O semantics hold true. Verified using `cargo clippy`.

---
*PR created automatically by Jules for task [4385984647482319125](https://jules.google.com/task/4385984647482319125) started by @madmax983*