### PR TITLE
🌟 Nova: Basic Block Control Flow Graph Support

### DIFF
--- a/crates/duke-bytecode/src/cfg.rs
+++ b/crates/duke-bytecode/src/cfg.rs
@@ -548,4 +548,77 @@ mod basic_block_cfg_tests {
         assert!(cfg.contains("block0 -->|true| block6"));
         assert!(cfg.contains("block0 -->|false| block4"));
     }
+
+    #[test]
+    fn test_generate_basic_block_cfg_empty() {
+        let blocks = build_basic_blocks(&[]);
+        let cfg = generate_basic_block_cfg(&blocks);
+        assert!(cfg.contains("graph TD"));
+        assert!(!cfg.contains("block0"));
+    }
+
+    #[test]
+    fn test_generate_basic_block_cfg_switch() {
+        let instructions = vec![
+            (0, Instruction::Tableswitch {
+                default: 10,
+                low: 1,
+                high: 2,
+                offsets: vec![4, 6],
+            }),
+        ];
+        let blocks = build_basic_blocks(&instructions);
+        let cfg = generate_basic_block_cfg(&blocks);
+        assert!(cfg.contains("graph TD"));
+        assert!(cfg.contains("block0 -->|default| block10"));
+        assert!(cfg.contains("block0 -->|1| block4"));
+        assert!(cfg.contains("block0 -->|2| block6"));
+    }
+
+    #[test]
+    fn test_generate_basic_block_cfg_lookupswitch() {
+        let instructions = vec![
+            (0, Instruction::Lookupswitch {
+                default: 10,
+                pairs: vec![(5, 4), (10, 6)],
+            }),
+        ];
+        let blocks = build_basic_blocks(&instructions);
+        let cfg = generate_basic_block_cfg(&blocks);
+        assert!(cfg.contains("graph TD"));
+        assert!(cfg.contains("block0 -->|default| block10"));
+        assert!(cfg.contains("block0 -->|5| block4"));
+        assert!(cfg.contains("block0 -->|10| block6"));
+    }
+
+    #[test]
+    fn test_generate_basic_block_cfg_goto() {
+        let instructions = vec![
+            (0, Instruction::Goto(4)),
+            (3, Instruction::Iconst1), // Unreachable, but just to have next block
+            (4, Instruction::Iconst2),
+        ];
+        let blocks = build_basic_blocks(&instructions);
+        let cfg = generate_basic_block_cfg(&blocks);
+        assert!(cfg.contains("graph TD"));
+        assert!(cfg.contains("block0 --> block4"));
+    }
+
+    #[test]
+    fn test_generate_basic_block_cfg_fallthrough() {
+        let instructions = vec![
+            (0, Instruction::Iconst0),
+            (1, Instruction::Nop),
+            (2, Instruction::Ireturn),
+        ];
+        let blocks = build_basic_blocks(&instructions);
+        let cfg = generate_basic_block_cfg(&blocks);
+        assert!(cfg.contains("graph TD"));
+        // One big block
+        assert!(cfg.contains("block0[\"Block 0"));
+        assert!(cfg.contains("0: iconst_0"));
+        assert!(cfg.contains("1: nop"));
+        assert!(cfg.contains("2: ireturn"));
+        assert!(!cfg.contains("-->"));
+    }
 }

--- a/crates/duke-bytecode/src/cfg.rs
+++ b/crates/duke-bytecode/src/cfg.rs
@@ -559,14 +559,15 @@ mod basic_block_cfg_tests {
 
     #[test]
     fn test_generate_basic_block_cfg_switch() {
-        let instructions = vec![
-            (0, Instruction::Tableswitch {
+        let instructions = vec![(
+            0,
+            Instruction::Tableswitch {
                 default: 10,
                 low: 1,
                 high: 2,
                 offsets: vec![4, 6],
-            }),
-        ];
+            },
+        )];
         let blocks = build_basic_blocks(&instructions);
         let cfg = generate_basic_block_cfg(&blocks);
         assert!(cfg.contains("graph TD"));
@@ -576,13 +577,33 @@ mod basic_block_cfg_tests {
     }
 
     #[test]
+    fn test_generate_basic_block_cfg_switch_negative() {
+        let instructions = vec![(
+            0,
+            Instruction::Tableswitch {
+                default: 10,
+                low: -1,
+                high: 0,
+                offsets: vec![4, 6],
+            },
+        )];
+        let blocks = build_basic_blocks(&instructions);
+        let cfg = generate_basic_block_cfg(&blocks);
+        assert!(cfg.contains("graph TD"));
+        assert!(cfg.contains("block0 -->|default| block10"));
+        assert!(cfg.contains("block0 -->|-1| block4"));
+        assert!(cfg.contains("block0 -->|0| block6"));
+    }
+
+    #[test]
     fn test_generate_basic_block_cfg_lookupswitch() {
-        let instructions = vec![
-            (0, Instruction::Lookupswitch {
+        let instructions = vec![(
+            0,
+            Instruction::Lookupswitch {
                 default: 10,
                 pairs: vec![(5, 4), (10, 6)],
-            }),
-        ];
+            },
+        )];
         let blocks = build_basic_blocks(&instructions);
         let cfg = generate_basic_block_cfg(&blocks);
         assert!(cfg.contains("graph TD"));

--- a/crates/duke-bytecode/src/lib.rs
+++ b/crates/duke-bytecode/src/lib.rs
@@ -20,6 +20,8 @@ pub mod verifier;
 
 #[cfg(feature = "nova")]
 pub use basic_block::{BasicBlock, build_basic_blocks};
+#[cfg(feature = "nova")]
+pub use cfg::generate_basic_block_cfg;
 pub use call_graph::generate_mermaid_call_graph;
 pub use cfg::{cyclomatic_complexity, generate_mermaid_cfg};
 pub use decoder::decode;

--- a/crates/duke-bytecode/src/lib.rs
+++ b/crates/duke-bytecode/src/lib.rs
@@ -20,9 +20,9 @@ pub mod verifier;
 
 #[cfg(feature = "nova")]
 pub use basic_block::{BasicBlock, build_basic_blocks};
+pub use call_graph::generate_mermaid_call_graph;
 #[cfg(feature = "nova")]
 pub use cfg::generate_basic_block_cfg;
-pub use call_graph::generate_mermaid_call_graph;
 pub use cfg::{cyclomatic_complexity, generate_mermaid_cfg};
 pub use decoder::decode;
 pub use error::{DecodeError, DecodeResult, Error, Result, VerifyError, VerifyResult};

--- a/duke/Cargo.toml
+++ b/duke/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 duke-classfile = { path = "../crates/duke-classfile" }
-duke-bytecode = { path = "../crates/duke-bytecode" }
+duke-bytecode = { path = "../crates/duke-bytecode", features = ["nova"] }
 duke-loader = { path = "../crates/duke-loader" }
 duke-runtime = { path = "../crates/duke-runtime" }
 duke-gc = { path = "../crates/duke-gc" }

--- a/duke/src/html.rs
+++ b/duke/src/html.rs
@@ -1,4 +1,6 @@
-use duke_bytecode::{decode, generate_mermaid_cfg};
+use duke_bytecode::{
+    build_basic_blocks, decode, generate_basic_block_cfg, generate_mermaid_cfg,
+};
 use duke_classfile::{
     ClassFile,
     types::{AttributeData, CpEntry, CpIndex},
@@ -211,6 +213,14 @@ fn write_methods(out: &mut String, cf: &ClassFile) {
                         let _ = writeln!(out, "{cfg}");
                         let _ = writeln!(out, "      </div>");
 
+                        // Generate Basic Block CFG
+                        let blocks = build_basic_blocks(&instructions);
+                        let bbcfg = generate_basic_block_cfg(&blocks);
+                        let _ = writeln!(out, "      <h4>Basic Block Control Flow Graph</h4>");
+                        let _ = writeln!(out, "      <div class=\"mermaid\">");
+                        let _ = writeln!(out, "{bbcfg}");
+                        let _ = writeln!(out, "      </div>");
+
                         // Also show raw bytecode for reference
                         let _ = writeln!(out, "      <details>");
                         let _ = writeln!(
@@ -411,5 +421,7 @@ mod tests {
         // Assertions for decode success/error
         assert!(html.contains("return")); // The mnemonic for 0xb1
         assert!(html.contains("Decode Error:")); // For the invalid opcode
+        assert!(html.contains("<h4>Control Flow Graph</h4>"));
+        assert!(html.contains("<h4>Basic Block Control Flow Graph</h4>"));
     }
 }

--- a/duke/src/html.rs
+++ b/duke/src/html.rs
@@ -1,6 +1,4 @@
-use duke_bytecode::{
-    build_basic_blocks, decode, generate_basic_block_cfg, generate_mermaid_cfg,
-};
+use duke_bytecode::{build_basic_blocks, decode, generate_basic_block_cfg, generate_mermaid_cfg};
 use duke_classfile::{
     ClassFile,
     types::{AttributeData, CpEntry, CpIndex},

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -907,6 +907,13 @@ mod cfg_tests {
     }
 
     #[test]
+    fn test_dump_bbcfg_valid() {
+        let mut p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        p.push("../tests/fixtures/HelloWorld.class");
+        dump_bbcfg(p.to_str().unwrap(), "main");
+    }
+
+    #[test]
     fn test_extract_bbcfg() {
         // Find HelloWorld.class in tests/fixtures
         let mut p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -14,7 +14,10 @@ mod scan;
 mod search;
 mod uml;
 
-use duke_bytecode::{decode, generate_mermaid_call_graph, generate_mermaid_cfg};
+use duke_bytecode::{
+    build_basic_blocks, decode, generate_basic_block_cfg, generate_mermaid_call_graph,
+    generate_mermaid_cfg,
+};
 use duke_classfile::{
     ClassFile,
     access_flags::MethodAccessFlags,
@@ -222,6 +225,7 @@ fn main() {
         eprintln!("       duke deps-graph <classfile.class>");
         eprintln!("       duke load <ClassName>");
         eprintln!("       duke cfg <classfile.class> <method>");
+        eprintln!("       duke bbcfg <classfile.class> <method>");
         eprintln!("       duke cg <classfile.class>");
         eprintln!("       duke analyze <classfile.class>");
         eprintln!("       duke jar-analyze <file.jar>");
@@ -274,6 +278,12 @@ fn main() {
     // Dispatch `cfg`: dump control flow graph for a method.
     if args.len() >= 4 && args[1] == "cfg" {
         dump_cfg(&args[2], &args[3]);
+        return;
+    }
+
+    // Dispatch `bbcfg`: dump basic block control flow graph for a method.
+    if args.len() >= 4 && args[1] == "bbcfg" {
+        dump_bbcfg(&args[2], &args[3]);
         return;
     }
 
@@ -805,6 +815,45 @@ fn dump_cfg(path: &str, method_name: &str) {
     process::exit(1);
 }
 
+fn dump_bbcfg(path: &str, method_name: &str) {
+    let bytes = std::fs::read(path).unwrap_or_else(|e| {
+        eprintln!("duke: cannot read '{path}': {e}");
+        process::exit(1);
+    });
+    let cf = parse(&bytes).unwrap_or_else(|e| {
+        eprintln!("duke: parse error: {e}");
+        process::exit(1);
+    });
+
+    let target = cf
+        .methods
+        .iter()
+        .find(|m| {
+            let Some(Some(CpEntry::Utf8(s))) = cf.constant_pool.get(m.name_index.0 as usize) else {
+                return false;
+            };
+            s.as_str() == method_name
+        })
+        .unwrap_or_else(|| {
+            eprintln!("duke: method '{method_name}' not found");
+            process::exit(1);
+        });
+
+    for attr in &target.attributes {
+        if let AttributeData::Code(code) = &attr.data {
+            let instructions = decode(&code.code).unwrap_or_else(|e| {
+                eprintln!("duke: decode error: {e}");
+                process::exit(1);
+            });
+            let blocks = build_basic_blocks(&instructions);
+            println!("{}", generate_basic_block_cfg(&blocks));
+            return;
+        }
+    }
+    eprintln!("duke: method '{method_name}' has no code attribute");
+    process::exit(1);
+}
+
 fn dump_cg(path: &str) {
     let bytes = std::fs::read(path).unwrap_or_else(|e| {
         eprintln!("duke: cannot read '{path}': {e}");
@@ -850,6 +899,42 @@ mod cfg_tests {
                 found_code = true;
                 let instructions = decode(&code.code).expect("decode instructions");
                 let cfg_str = generate_mermaid_cfg(&instructions);
+                assert!(cfg_str.contains("graph TD"));
+                assert!(cfg_str.contains("getstatic"));
+            }
+        }
+        assert!(found_code, "should have found code attribute for main");
+    }
+
+    #[test]
+    fn test_extract_bbcfg() {
+        // Find HelloWorld.class in tests/fixtures
+        let mut p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        p.push("../tests/fixtures/HelloWorld.class");
+
+        let bytes = std::fs::read(&p).expect("read class");
+        let cf = parse(&bytes).expect("parse class");
+
+        // Use core logic inside dump_bbcfg to extract main
+        let target = cf
+            .methods
+            .iter()
+            .find(|m| {
+                let Some(Some(CpEntry::Utf8(s))) = cf.constant_pool.get(m.name_index.0 as usize)
+                else {
+                    return false;
+                };
+                s.as_str() == "main"
+            })
+            .expect("find main");
+
+        let mut found_code = false;
+        for attr in &target.attributes {
+            if let AttributeData::Code(code) = &attr.data {
+                found_code = true;
+                let instructions = decode(&code.code).expect("decode instructions");
+                let blocks = build_basic_blocks(&instructions);
+                let cfg_str = generate_basic_block_cfg(&blocks);
                 assert!(cfg_str.contains("graph TD"));
                 assert!(cfg_str.contains("getstatic"));
             }

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -913,7 +913,6 @@ mod cfg_tests {
         dump_bbcfg(p.to_str().unwrap(), "main");
     }
 
-
     #[test]
     fn test_extract_bbcfg() {
         // Find HelloWorld.class in tests/fixtures
@@ -989,6 +988,9 @@ mod cfg_tests {
         let html_content = std::fs::read_to_string(&out_path).unwrap();
         assert!(html_content.contains("<!DOCTYPE html>"));
         assert!(html_content.contains("Duke Class Report: HelloWorld"));
+
+        // Basic Block CFG Coverage
+        assert!(html_content.contains("<h4>Basic Block Control Flow Graph</h4>"));
 
         // Clean up
         std::fs::remove_file(out_path).unwrap();

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -913,6 +913,7 @@ mod cfg_tests {
         dump_bbcfg(p.to_str().unwrap(), "main");
     }
 
+
     #[test]
     fn test_extract_bbcfg() {
         // Find HelloWorld.class in tests/fixtures

--- a/get_diff.py
+++ b/get_diff.py
@@ -1,0 +1,7 @@
+import sys
+
+def main():
+    print("Testing get_diff")
+
+if __name__ == "__main__":
+    main()

--- a/plan_test.sh
+++ b/plan_test.sh
@@ -1,0 +1,2 @@
+sed -i 's/fn test_extract_bbcfg() {/fn test_dump_bbcfg_valid() {\n        let mut p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));\n        p.push("..\/tests\/fixtures\/HelloWorld.class");\n        dump_bbcfg(p.to_str().unwrap(), "main");\n    }\n\n    #[test]\n    fn test_extract_bbcfg_old() {/g' duke/src/main.rs
+cargo test -p duke

--- a/plan_test2.sh
+++ b/plan_test2.sh
@@ -1,0 +1,5 @@
+cat << 'INNER_EOF' > src_main_patch.sh
+sed -i 's/fn test_extract_bbcfg_old/fn test_extract_bbcfg/g' duke/src/main.rs
+INNER_EOF
+bash src_main_patch.sh
+cargo fmt --all

--- a/src_main_patch.sh
+++ b/src_main_patch.sh
@@ -1,0 +1,1 @@
+sed -i 's/fn test_extract_bbcfg_old/fn test_extract_bbcfg/g' duke/src/main.rs


### PR DESCRIPTION
💡 **The Spark:**
While the existing instruction-by-instruction Mermaid CFG graphs are great for granular debugging, they quickly become unwieldy "spaghetti" monsters for any method with moderate cyclomatic complexity. The `duke-bytecode` crate secretly had `nova` feature-flagged logic to partition instructions into Basic Blocks and generate high-level graphs, but it was never hooked up to the user.

🚀 **The Feature:**
Implemented **Basic Block Control Flow Graph (bbcfg)** generation for developers.
1. Added a new `duke bbcfg <classfile.class> <method>` subcommand for quick terminal debugging.
2. Updated the `duke html` static analysis report generator to automatically render the Basic Block graph alongside the raw instruction graph, drastically improving the readability of complex Java methods.

🔮 **The Potential:**
Basic blocks are the foundational requirement for advanced compiler analysis, dominance frontiers, and JIT compilation. By surfacing them to the developer tooling, we pave the way for building a full-fledged optimizer or simply providing better visual profiling of "hot" code paths in the future.

⚠️ **Risk:**
Low. The implementation is strictly additive. The only change to existing code was toggling a feature flag and injecting a secondary graph into the HTML output. Existing core interpreters and parsers are completely unaffected.

---
*PR created automatically by Jules for task [3419152783257742596](https://jules.google.com/task/3419152783257742596) started by @madmax983*