### PR TITLE
⚒️ Forge: Extract Enum Variant Matchers

### DIFF
--- a/crates/duke-bytecode/src/cfg.rs
+++ b/crates/duke-bytecode/src/cfg.rs
@@ -54,7 +54,7 @@ pub fn generate_mermaid_cfg(instructions: &[(usize, Instruction)]) -> String {
             // No fall-through
         } else if let Some(offset) = instr.unconditional_jump_target() {
             let target = (*pc as isize + offset) as usize;
-            if instr.is_jsr() {
+            if matches!(instr, Instruction::Jsr(_) | Instruction::JsrW(_)) {
                 let _ = writeln!(cfg, "    node{pc} -->|true| node{target}");
                 if i + 1 < instructions.len() {
                     let next_pc = instructions[i + 1].0;
@@ -295,7 +295,9 @@ pub fn cyclomatic_complexity(instructions: &[(usize, Instruction)]) -> usize {
     let mut complexity = 1;
 
     for (_, instr) in instructions {
-        if instr.is_conditional_branch() || instr.is_jsr() {
+        if instr.is_conditional_branch()
+            || matches!(instr, Instruction::Jsr(_) | Instruction::JsrW(_))
+        {
             complexity += 1;
         } else {
             match instr {

--- a/crates/duke-bytecode/src/cfg.rs
+++ b/crates/duke-bytecode/src/cfg.rs
@@ -54,7 +54,7 @@ pub fn generate_mermaid_cfg(instructions: &[(usize, Instruction)]) -> String {
             // No fall-through
         } else if let Some(offset) = instr.unconditional_jump_target() {
             let target = (*pc as isize + offset) as usize;
-            if matches!(instr, Instruction::Jsr(_) | Instruction::JsrW(_)) {
+            if instr.is_jsr() {
                 let _ = writeln!(cfg, "    node{pc} -->|true| node{target}");
                 if i + 1 < instructions.len() {
                     let next_pc = instructions[i + 1].0;
@@ -295,9 +295,7 @@ pub fn cyclomatic_complexity(instructions: &[(usize, Instruction)]) -> usize {
     let mut complexity = 1;
 
     for (_, instr) in instructions {
-        if instr.is_conditional_branch()
-            || matches!(instr, Instruction::Jsr(_) | Instruction::JsrW(_))
-        {
+        if instr.is_conditional_branch() || instr.is_jsr() {
             complexity += 1;
         } else {
             match instr {

--- a/crates/duke-bytecode/src/instruction.rs
+++ b/crates/duke-bytecode/src/instruction.rs
@@ -446,42 +446,6 @@ impl Instruction {
         )
     }
 
-    /// Returns `true` if the instruction is a `jsr` or `jsr_w`.
-    #[must_use]
-    pub const fn is_jsr(&self) -> bool {
-        matches!(self, Self::Jsr(_) | Self::JsrW(_))
-    }
-
-    /// Returns `true` if the instruction is `invokevirtual`.
-    #[must_use]
-    pub const fn is_invokevirtual(&self) -> bool {
-        matches!(self, Self::Invokevirtual(_))
-    }
-
-    /// Returns `true` if the instruction is `invokespecial`.
-    #[must_use]
-    pub const fn is_invokespecial(&self) -> bool {
-        matches!(self, Self::Invokespecial(_))
-    }
-
-    /// Returns `true` if the instruction is `fcmpg`.
-    #[must_use]
-    pub const fn is_fcmpg(&self) -> bool {
-        matches!(self, Self::Fcmpg)
-    }
-
-    /// Returns `true` if the instruction is `dcmpg`.
-    #[must_use]
-    pub const fn is_dcmpg(&self) -> bool {
-        matches!(self, Self::Dcmpg)
-    }
-
-    /// Returns `true` if the instruction is `athrow`.
-    #[must_use]
-    pub const fn is_athrow(&self) -> bool {
-        matches!(self, Self::Athrow)
-    }
-
     /// Returns the mnemonic string for display/debugging.
     #[must_use]
     #[allow(clippy::too_many_lines)]

--- a/crates/duke-bytecode/src/instruction.rs
+++ b/crates/duke-bytecode/src/instruction.rs
@@ -446,6 +446,42 @@ impl Instruction {
         )
     }
 
+    /// Returns `true` if the instruction is a `jsr` or `jsr_w`.
+    #[must_use]
+    pub const fn is_jsr(&self) -> bool {
+        matches!(self, Self::Jsr(_) | Self::JsrW(_))
+    }
+
+    /// Returns `true` if the instruction is `invokevirtual`.
+    #[must_use]
+    pub const fn is_invokevirtual(&self) -> bool {
+        matches!(self, Self::Invokevirtual(_))
+    }
+
+    /// Returns `true` if the instruction is `invokespecial`.
+    #[must_use]
+    pub const fn is_invokespecial(&self) -> bool {
+        matches!(self, Self::Invokespecial(_))
+    }
+
+    /// Returns `true` if the instruction is `fcmpg`.
+    #[must_use]
+    pub const fn is_fcmpg(&self) -> bool {
+        matches!(self, Self::Fcmpg)
+    }
+
+    /// Returns `true` if the instruction is `dcmpg`.
+    #[must_use]
+    pub const fn is_dcmpg(&self) -> bool {
+        matches!(self, Self::Dcmpg)
+    }
+
+    /// Returns `true` if the instruction is `athrow`.
+    #[must_use]
+    pub const fn is_athrow(&self) -> bool {
+        matches!(self, Self::Athrow)
+    }
+
     /// Returns the mnemonic string for display/debugging.
     #[must_use]
     #[allow(clippy::too_many_lines)]

--- a/crates/duke-bytecode/src/instruction.rs
+++ b/crates/duke-bytecode/src/instruction.rs
@@ -446,6 +446,42 @@ impl Instruction {
         )
     }
 
+    /// Returns `true` if the instruction is a `jsr` or `jsr_w`.
+    #[must_use]
+    pub const fn is_jsr(&self) -> bool {
+        matches!(self, Self::Jsr(_) | Self::JsrW(_))
+    }
+
+    /// Returns `true` if the instruction is `invokevirtual`.
+    #[must_use]
+    pub const fn is_invokevirtual(&self) -> bool {
+        matches!(self, Self::Invokevirtual(_))
+    }
+
+    /// Returns `true` if the instruction is `invokespecial`.
+    #[must_use]
+    pub const fn is_invokespecial(&self) -> bool {
+        matches!(self, Self::Invokespecial(_))
+    }
+
+    /// Returns `true` if the instruction is `fcmpg`.
+    #[must_use]
+    pub const fn is_fcmpg(&self) -> bool {
+        matches!(self, Self::Fcmpg)
+    }
+
+    /// Returns `true` if the instruction is `dcmpg`.
+    #[must_use]
+    pub const fn is_dcmpg(&self) -> bool {
+        matches!(self, Self::Dcmpg)
+    }
+
+    /// Returns `true` if the instruction is `athrow`.
+    #[must_use]
+    pub const fn is_athrow(&self) -> bool {
+        matches!(self, Self::Athrow)
+    }
+
     /// Returns the mnemonic string for display/debugging.
     #[must_use]
     #[allow(clippy::too_many_lines)]
@@ -684,6 +720,28 @@ mod tests {
         assert_eq!(ArrayType::from_u8(11), Some(ArrayType::Long));
         assert_eq!(ArrayType::from_u8(0), None);
         assert_eq!(ArrayType::from_u8(12), None);
+    }
+
+    #[test]
+    fn test_instruction_matchers() {
+        assert!(Instruction::Jsr(5).is_jsr());
+        assert!(Instruction::JsrW(5).is_jsr());
+        assert!(!Instruction::Nop.is_jsr());
+
+        assert!(Instruction::Invokevirtual(CpIndex(1)).is_invokevirtual());
+        assert!(!Instruction::Nop.is_invokevirtual());
+
+        assert!(Instruction::Invokespecial(CpIndex(1)).is_invokespecial());
+        assert!(!Instruction::Nop.is_invokespecial());
+
+        assert!(Instruction::Fcmpg.is_fcmpg());
+        assert!(!Instruction::Nop.is_fcmpg());
+
+        assert!(Instruction::Dcmpg.is_dcmpg());
+        assert!(!Instruction::Nop.is_dcmpg());
+
+        assert!(Instruction::Athrow.is_athrow());
+        assert!(!Instruction::Nop.is_athrow());
     }
 
     #[test]

--- a/crates/duke-bytecode/src/verifier.rs
+++ b/crates/duke-bytecode/src/verifier.rs
@@ -88,7 +88,7 @@ pub fn verify(
 
         // athrow consumes the exception reference; stack is conceptually cleared
         // after throw (execution does not continue linearly), so reset depth.
-        if matches!(instr, Instruction::Athrow) {
+        if instr.is_athrow() {
             depth = 0;
         }
     }

--- a/crates/duke-bytecode/src/verifier.rs
+++ b/crates/duke-bytecode/src/verifier.rs
@@ -88,7 +88,7 @@ pub fn verify(
 
         // athrow consumes the exception reference; stack is conceptually cleared
         // after throw (execution does not continue linearly), so reset depth.
-        if instr.is_athrow() {
+        if matches!(instr, Instruction::Athrow) {
             depth = 0;
         }
     }

--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -1136,7 +1136,7 @@ pub fn run_execution(
                     -1
                 } else if a == b {
                     0
-                } else if instr.is_fcmpg() {
+                } else if matches!(instr, Instruction::Fcmpg) {
                     1
                 } else {
                     -1
@@ -1181,7 +1181,7 @@ pub fn run_execution(
                     -1
                 } else if a == b {
                     0
-                } else if instr.is_dcmpg() {
+                } else if matches!(instr, Instruction::Dcmpg) {
                     1
                 } else {
                     -1
@@ -1462,7 +1462,7 @@ pub fn run_execution(
             // classes (e.g. java/lang/Object) fall back to no-op.
             Instruction::Invokespecial(cp_idx) | Instruction::Invokevirtual(cp_idx) => {
                 // Fast path: cache hit for invokespecial (static dispatch — safe to cache).
-                if instr.is_invokespecial()
+                if matches!(instr, Instruction::Invokespecial(_))
                     && let Some(cached) = dispatch_cache
                         .get(current_class.as_str())
                         .and_then(|m| m.get(&cp_idx.0))
@@ -1524,24 +1524,25 @@ pub fn run_execution(
                     Some(current_class.as_str()),
                     loader,
                 )?;
-                let virtual_start: Option<String> = if instr.is_invokevirtual() {
-                    let arg_count = parse_arg_count(&callee_desc);
-                    let stack_len = frame.stack_len();
-                    if stack_len > arg_count {
-                        let this_pos = stack_len - arg_count - 1;
-                        if let Ok(Slot::Reference(Some(r))) = frame.peek_at(this_pos) {
-                            heap.get(r).ok().map(|o| o.class_name.clone())
+                let virtual_start: Option<String> =
+                    if matches!(instr, Instruction::Invokevirtual(_)) {
+                        let arg_count = parse_arg_count(&callee_desc);
+                        let stack_len = frame.stack_len();
+                        if stack_len > arg_count {
+                            let this_pos = stack_len - arg_count - 1;
+                            if let Ok(Slot::Reference(Some(r))) = frame.peek_at(this_pos) {
+                                heap.get(r).ok().map(|o| o.class_name.clone())
+                            } else {
+                                None
+                            }
                         } else {
                             None
                         }
                     } else {
                         None
-                    }
-                } else {
-                    None
-                };
+                    };
                 // vtable fast path for invokevirtual — check PIC after receiver type is known.
-                if instr.is_invokevirtual()
+                if matches!(instr, Instruction::Invokevirtual(_))
                     && let Some(ref runtime_class) = virtual_start
                     && let Some(cached) = vtable_cache
                         .get(current_class.as_str())
@@ -1815,7 +1816,7 @@ pub fn run_execution(
                                         _native_start.elapsed().as_nanos() as u64,
                                         result.is_err(),
                                     );
-                                    if instr.is_invokevirtual() {
+                                    if matches!(instr, Instruction::Invokevirtual(_)) {
                                         // Native methods do not perform a bytecode hierarchy
                                         // walk — hierarchy_walk is always false here.
                                         registry.telemetry.dispatch_resolution.record(
@@ -1901,7 +1902,7 @@ pub fn run_execution(
                                         _native_start.elapsed().as_nanos() as u64,
                                         result.is_err(),
                                     );
-                                    if instr.is_invokevirtual() {
+                                    if matches!(instr, Instruction::Invokevirtual(_)) {
                                         registry.telemetry.dispatch_resolution.record(
                                             current_class,
                                             cp_idx.0,
@@ -1980,7 +1981,7 @@ pub fn run_execution(
                 };
                 let arg_count = parse_arg_count(&callee_desc);
                 #[cfg(feature = "telemetry")]
-                if instr.is_invokevirtual() {
+                if matches!(instr, Instruction::Invokevirtual(_)) {
                     registry.telemetry.dispatch_resolution.record(
                         current_class,
                         cp_idx.0,

--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -1136,7 +1136,7 @@ pub fn run_execution(
                     -1
                 } else if a == b {
                     0
-                } else if matches!(instr, Instruction::Fcmpg) {
+                } else if instr.is_fcmpg() {
                     1
                 } else {
                     -1
@@ -1181,7 +1181,7 @@ pub fn run_execution(
                     -1
                 } else if a == b {
                     0
-                } else if matches!(instr, Instruction::Dcmpg) {
+                } else if instr.is_dcmpg() {
                     1
                 } else {
                     -1
@@ -1462,7 +1462,7 @@ pub fn run_execution(
             // classes (e.g. java/lang/Object) fall back to no-op.
             Instruction::Invokespecial(cp_idx) | Instruction::Invokevirtual(cp_idx) => {
                 // Fast path: cache hit for invokespecial (static dispatch — safe to cache).
-                if matches!(instr, Instruction::Invokespecial(_))
+                if instr.is_invokespecial()
                     && let Some(cached) = dispatch_cache
                         .get(current_class.as_str())
                         .and_then(|m| m.get(&cp_idx.0))
@@ -1524,25 +1524,24 @@ pub fn run_execution(
                     Some(current_class.as_str()),
                     loader,
                 )?;
-                let virtual_start: Option<String> =
-                    if matches!(instr, Instruction::Invokevirtual(_)) {
-                        let arg_count = parse_arg_count(&callee_desc);
-                        let stack_len = frame.stack_len();
-                        if stack_len > arg_count {
-                            let this_pos = stack_len - arg_count - 1;
-                            if let Ok(Slot::Reference(Some(r))) = frame.peek_at(this_pos) {
-                                heap.get(r).ok().map(|o| o.class_name.clone())
-                            } else {
-                                None
-                            }
+                let virtual_start: Option<String> = if instr.is_invokevirtual() {
+                    let arg_count = parse_arg_count(&callee_desc);
+                    let stack_len = frame.stack_len();
+                    if stack_len > arg_count {
+                        let this_pos = stack_len - arg_count - 1;
+                        if let Ok(Slot::Reference(Some(r))) = frame.peek_at(this_pos) {
+                            heap.get(r).ok().map(|o| o.class_name.clone())
                         } else {
                             None
                         }
                     } else {
                         None
-                    };
+                    }
+                } else {
+                    None
+                };
                 // vtable fast path for invokevirtual — check PIC after receiver type is known.
-                if matches!(instr, Instruction::Invokevirtual(_))
+                if instr.is_invokevirtual()
                     && let Some(ref runtime_class) = virtual_start
                     && let Some(cached) = vtable_cache
                         .get(current_class.as_str())
@@ -1816,7 +1815,7 @@ pub fn run_execution(
                                         _native_start.elapsed().as_nanos() as u64,
                                         result.is_err(),
                                     );
-                                    if matches!(instr, Instruction::Invokevirtual(_)) {
+                                    if instr.is_invokevirtual() {
                                         // Native methods do not perform a bytecode hierarchy
                                         // walk — hierarchy_walk is always false here.
                                         registry.telemetry.dispatch_resolution.record(
@@ -1902,7 +1901,7 @@ pub fn run_execution(
                                         _native_start.elapsed().as_nanos() as u64,
                                         result.is_err(),
                                     );
-                                    if matches!(instr, Instruction::Invokevirtual(_)) {
+                                    if instr.is_invokevirtual() {
                                         registry.telemetry.dispatch_resolution.record(
                                             current_class,
                                             cp_idx.0,
@@ -1981,7 +1980,7 @@ pub fn run_execution(
                 };
                 let arg_count = parse_arg_count(&callee_desc);
                 #[cfg(feature = "telemetry")]
-                if matches!(instr, Instruction::Invokevirtual(_)) {
+                if instr.is_invokevirtual() {
                     registry.telemetry.dispatch_resolution.record(
                         current_class,
                         cp_idx.0,

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -1823,12 +1823,10 @@ pub(crate) fn native_hashmap_for_each(
         .map(|i| {
             let key = heap
                 .get(this_ref)
-                .map(|o| o.fields[1 + i * 2])
-                .unwrap_or(Slot::Reference(None));
+                .map_or(Slot::Reference(None), |o| o.fields[1 + i * 2]);
             let val = heap
                 .get(this_ref)
-                .map(|o| o.fields[2 + i * 2])
-                .unwrap_or(Slot::Reference(None));
+                .map_or(Slot::Reference(None), |o| o.fields[2 + i * 2]);
             (key, val)
         })
         .collect();
@@ -1867,15 +1865,13 @@ pub(crate) fn native_hashmap_replace_all(
     let keys: Vec<Slot> = (0..size)
         .map(|i| {
             heap.get(this_ref)
-                .map(|o| o.fields[1 + i * 2])
-                .unwrap_or(Slot::Reference(None))
+                .map_or(Slot::Reference(None), |o| o.fields[1 + i * 2])
         })
         .collect();
     for (i, key) in keys.iter().enumerate() {
         let old_val = heap
             .get(this_ref)
-            .map(|o| o.fields[2 + i * 2])
-            .unwrap_or(Slot::Reference(None));
+            .map_or(Slot::Reference(None), |o| o.fields[2 + i * 2]);
         let new_val = ops.invoke(
             heap,
             out,
@@ -15645,8 +15641,7 @@ fn default_slot_for_descriptor(desc: &str) -> Slot {
 fn total_instance_field_count(registry: &ClassRegistry, class_name: &str) -> usize {
     let mut count = registry
         .get(class_name)
-        .map(|c| c.instance_field_count)
-        .unwrap_or(0);
+        .map_or(0, |c| c.instance_field_count);
     let mut sc = registry
         .get(class_name)
         .ok()

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -1823,10 +1823,12 @@ pub(crate) fn native_hashmap_for_each(
         .map(|i| {
             let key = heap
                 .get(this_ref)
-                .map_or(Slot::Reference(None), |o| o.fields[1 + i * 2]);
+                .map(|o| o.fields[1 + i * 2])
+                .unwrap_or(Slot::Reference(None));
             let val = heap
                 .get(this_ref)
-                .map_or(Slot::Reference(None), |o| o.fields[2 + i * 2]);
+                .map(|o| o.fields[2 + i * 2])
+                .unwrap_or(Slot::Reference(None));
             (key, val)
         })
         .collect();
@@ -1865,13 +1867,15 @@ pub(crate) fn native_hashmap_replace_all(
     let keys: Vec<Slot> = (0..size)
         .map(|i| {
             heap.get(this_ref)
-                .map_or(Slot::Reference(None), |o| o.fields[1 + i * 2])
+                .map(|o| o.fields[1 + i * 2])
+                .unwrap_or(Slot::Reference(None))
         })
         .collect();
     for (i, key) in keys.iter().enumerate() {
         let old_val = heap
             .get(this_ref)
-            .map_or(Slot::Reference(None), |o| o.fields[2 + i * 2]);
+            .map(|o| o.fields[2 + i * 2])
+            .unwrap_or(Slot::Reference(None));
         let new_val = ops.invoke(
             heap,
             out,
@@ -11787,7 +11791,7 @@ pub fn execute(
                     -1
                 } else if a == b {
                     0
-                } else if instr.is_fcmpg() {
+                } else if matches!(instr, Instruction::Fcmpg) {
                     1 // NaN result: Fcmpg pushes 1, Fcmpl pushes -1
                 } else {
                     -1
@@ -11838,7 +11842,7 @@ pub fn execute(
                     -1
                 } else if a == b {
                     0
-                } else if instr.is_dcmpg() {
+                } else if matches!(instr, Instruction::Dcmpg) {
                     1 // NaN result: Dcmpg pushes 1, Dcmpl pushes -1
                 } else {
                     -1
@@ -15641,7 +15645,8 @@ fn default_slot_for_descriptor(desc: &str) -> Slot {
 fn total_instance_field_count(registry: &ClassRegistry, class_name: &str) -> usize {
     let mut count = registry
         .get(class_name)
-        .map_or(0, |c| c.instance_field_count);
+        .map(|c| c.instance_field_count)
+        .unwrap_or(0);
     let mut sc = registry
         .get(class_name)
         .ok()

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -1823,12 +1823,10 @@ pub(crate) fn native_hashmap_for_each(
         .map(|i| {
             let key = heap
                 .get(this_ref)
-                .map(|o| o.fields[1 + i * 2])
-                .unwrap_or(Slot::Reference(None));
+                .map_or(Slot::Reference(None), |o| o.fields[1 + i * 2]);
             let val = heap
                 .get(this_ref)
-                .map(|o| o.fields[2 + i * 2])
-                .unwrap_or(Slot::Reference(None));
+                .map_or(Slot::Reference(None), |o| o.fields[2 + i * 2]);
             (key, val)
         })
         .collect();
@@ -1867,15 +1865,13 @@ pub(crate) fn native_hashmap_replace_all(
     let keys: Vec<Slot> = (0..size)
         .map(|i| {
             heap.get(this_ref)
-                .map(|o| o.fields[1 + i * 2])
-                .unwrap_or(Slot::Reference(None))
+                .map_or(Slot::Reference(None), |o| o.fields[1 + i * 2])
         })
         .collect();
     for (i, key) in keys.iter().enumerate() {
         let old_val = heap
             .get(this_ref)
-            .map(|o| o.fields[2 + i * 2])
-            .unwrap_or(Slot::Reference(None));
+            .map_or(Slot::Reference(None), |o| o.fields[2 + i * 2]);
         let new_val = ops.invoke(
             heap,
             out,
@@ -11791,7 +11787,7 @@ pub fn execute(
                     -1
                 } else if a == b {
                     0
-                } else if matches!(instr, Instruction::Fcmpg) {
+                } else if instr.is_fcmpg() {
                     1 // NaN result: Fcmpg pushes 1, Fcmpl pushes -1
                 } else {
                     -1
@@ -11842,7 +11838,7 @@ pub fn execute(
                     -1
                 } else if a == b {
                     0
-                } else if matches!(instr, Instruction::Dcmpg) {
+                } else if instr.is_dcmpg() {
                     1 // NaN result: Dcmpg pushes 1, Dcmpl pushes -1
                 } else {
                     -1
@@ -15645,8 +15641,7 @@ fn default_slot_for_descriptor(desc: &str) -> Slot {
 fn total_instance_field_count(registry: &ClassRegistry, class_name: &str) -> usize {
     let mut count = registry
         .get(class_name)
-        .map(|c| c.instance_field_count)
-        .unwrap_or(0);
+        .map_or(0, |c| c.instance_field_count);
     let mut sc = registry
         .get(class_name)
         .ok()

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -11791,7 +11791,7 @@ pub fn execute(
                     -1
                 } else if a == b {
                     0
-                } else if matches!(instr, Instruction::Fcmpg) {
+                } else if instr.is_fcmpg() {
                     1 // NaN result: Fcmpg pushes 1, Fcmpl pushes -1
                 } else {
                     -1
@@ -11842,7 +11842,7 @@ pub fn execute(
                     -1
                 } else if a == b {
                     0
-                } else if matches!(instr, Instruction::Dcmpg) {
+                } else if instr.is_dcmpg() {
                     1 // NaN result: Dcmpg pushes 1, Dcmpl pushes -1
                 } else {
                     -1

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -129,7 +129,7 @@ impl TelemetryStore {
 
         writeln!(w, "\n-- bytecode_cost (top 10 by count) --")?;
         let mut ops: Vec<_> = self.bytecode_cost.by_opcode.iter().collect();
-        ops.sort_by_key(|b| std::cmp::Reverse(b.1.count));
+        ops.sort_by(|a, b| b.1.count.cmp(&a.1.count));
         for (name, stat) in ops.iter().take(10) {
             writeln!(w, "  {:20} count={:>10}", name, stat.count)?;
         }
@@ -139,7 +139,7 @@ impl TelemetryStore {
             "\n-- object_lineage (top 10 allocation sites by count) --"
         )?;
         let mut sites: Vec<_> = self.object_lineage.sites.iter().collect();
-        sites.sort_by_key(|b| std::cmp::Reverse(b.1.count));
+        sites.sort_by(|a, b| b.1.count.cmp(&a.1.count));
         for ((class, method, pc), site) in sites.iter().take(10) {
             writeln!(
                 w,
@@ -180,7 +180,7 @@ impl TelemetryStore {
 
         writeln!(w, "\n-- dispatch_resolution (top 10 virtual call sites) --")?;
         let mut dsites: Vec<_> = self.dispatch_resolution.by_site.iter().collect();
-        dsites.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
+        dsites.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
         for ((class, cp), stat) in dsites.iter().take(10) {
             writeln!(
                 w,
@@ -195,7 +195,7 @@ impl TelemetryStore {
 
         writeln!(w, "\n-- native_boundary (top 10 by call count) --")?;
         let mut natives: Vec<_> = self.native_boundary.by_method.iter().collect();
-        natives.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
+        natives.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
         for ((class, method), stat) in natives.iter().take(10) {
             writeln!(
                 w,
@@ -233,7 +233,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Opcode | Count | Time (ns) |").unwrap();
         writeln!(&mut out, "|--------|-------|-----------|").unwrap();
         let mut ops: Vec<_> = self.bytecode_cost.by_opcode.iter().collect();
-        ops.sort_by_key(|b| std::cmp::Reverse(b.1.count));
+        ops.sort_by(|a, b| b.1.count.cmp(&a.1.count));
         for (name, stat) in ops.iter().take(10) {
             writeln!(
                 &mut out,
@@ -254,7 +254,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Location | Class Allocated | Count |").unwrap();
         writeln!(&mut out, "|----------|-----------------|-------|").unwrap();
         let mut sites: Vec<_> = self.object_lineage.sites.iter().collect();
-        sites.sort_by_key(|b| std::cmp::Reverse(b.1.count));
+        sites.sort_by(|a, b| b.1.count.cmp(&a.1.count));
         for ((class, method, pc), site) in sites.iter().take(10) {
             writeln!(
                 &mut out,
@@ -327,7 +327,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Caller | Calls | Targets | Hierarchy Walks |").unwrap();
         writeln!(&mut out, "|--------|-------|---------|-----------------|").unwrap();
         let mut dsites: Vec<_> = self.dispatch_resolution.by_site.iter().collect();
-        dsites.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
+        dsites.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
         for ((class, cp), stat) in dsites.iter().take(10) {
             writeln!(
                 &mut out,
@@ -350,7 +350,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Native Method | Calls | Errors | Time (ns) |").unwrap();
         writeln!(&mut out, "|---------------|-------|--------|-----------|").unwrap();
         let mut natives: Vec<_> = self.native_boundary.by_method.iter().collect();
-        natives.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
+        natives.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
         for ((class, method), stat) in natives.iter().take(10) {
             writeln!(
                 &mut out,

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -129,7 +129,7 @@ impl TelemetryStore {
 
         writeln!(w, "\n-- bytecode_cost (top 10 by count) --")?;
         let mut ops: Vec<_> = self.bytecode_cost.by_opcode.iter().collect();
-        ops.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+        ops.sort_by_key(|b| std::cmp::Reverse(b.1.count));
         for (name, stat) in ops.iter().take(10) {
             writeln!(w, "  {:20} count={:>10}", name, stat.count)?;
         }
@@ -139,7 +139,7 @@ impl TelemetryStore {
             "\n-- object_lineage (top 10 allocation sites by count) --"
         )?;
         let mut sites: Vec<_> = self.object_lineage.sites.iter().collect();
-        sites.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+        sites.sort_by_key(|b| std::cmp::Reverse(b.1.count));
         for ((class, method, pc), site) in sites.iter().take(10) {
             writeln!(
                 w,
@@ -180,7 +180,7 @@ impl TelemetryStore {
 
         writeln!(w, "\n-- dispatch_resolution (top 10 virtual call sites) --")?;
         let mut dsites: Vec<_> = self.dispatch_resolution.by_site.iter().collect();
-        dsites.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
+        dsites.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
         for ((class, cp), stat) in dsites.iter().take(10) {
             writeln!(
                 w,
@@ -195,7 +195,7 @@ impl TelemetryStore {
 
         writeln!(w, "\n-- native_boundary (top 10 by call count) --")?;
         let mut natives: Vec<_> = self.native_boundary.by_method.iter().collect();
-        natives.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
+        natives.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
         for ((class, method), stat) in natives.iter().take(10) {
             writeln!(
                 w,
@@ -233,7 +233,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Opcode | Count | Time (ns) |").unwrap();
         writeln!(&mut out, "|--------|-------|-----------|").unwrap();
         let mut ops: Vec<_> = self.bytecode_cost.by_opcode.iter().collect();
-        ops.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+        ops.sort_by_key(|b| std::cmp::Reverse(b.1.count));
         for (name, stat) in ops.iter().take(10) {
             writeln!(
                 &mut out,
@@ -254,7 +254,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Location | Class Allocated | Count |").unwrap();
         writeln!(&mut out, "|----------|-----------------|-------|").unwrap();
         let mut sites: Vec<_> = self.object_lineage.sites.iter().collect();
-        sites.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+        sites.sort_by_key(|b| std::cmp::Reverse(b.1.count));
         for ((class, method, pc), site) in sites.iter().take(10) {
             writeln!(
                 &mut out,
@@ -327,7 +327,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Caller | Calls | Targets | Hierarchy Walks |").unwrap();
         writeln!(&mut out, "|--------|-------|---------|-----------------|").unwrap();
         let mut dsites: Vec<_> = self.dispatch_resolution.by_site.iter().collect();
-        dsites.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
+        dsites.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
         for ((class, cp), stat) in dsites.iter().take(10) {
             writeln!(
                 &mut out,
@@ -350,7 +350,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Native Method | Calls | Errors | Time (ns) |").unwrap();
         writeln!(&mut out, "|---------------|-------|--------|-----------|").unwrap();
         let mut natives: Vec<_> = self.native_boundary.by_method.iter().collect();
-        natives.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
+        natives.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
         for ((class, method), stat) in natives.iter().take(10) {
             writeln!(
                 &mut out,

--- a/duke/src/jar_analyze.rs
+++ b/duke/src/jar_analyze.rs
@@ -127,7 +127,7 @@ pub fn dump_jar_analyze(jar_path: &str) {
         }
     }
 
-    all_methods.sort_by(|a, b| b.complexity.cmp(&a.complexity));
+    all_methods.sort_by_key(|b| std::cmp::Reverse(b.complexity));
 
     println!("======================================");
     println!(" JAR Analysis Summary");

--- a/duke/src/jar_analyze.rs
+++ b/duke/src/jar_analyze.rs
@@ -127,7 +127,7 @@ pub fn dump_jar_analyze(jar_path: &str) {
         }
     }
 
-    all_methods.sort_by_key(|b| std::cmp::Reverse(b.complexity));
+    all_methods.sort_by_key(|m| std::cmp::Reverse(m.complexity));
 
     println!("======================================");
     println!(" JAR Analysis Summary");


### PR DESCRIPTION
**Smell:** Scattered inline `matches!(instr, ...)` for checking instruction types created boilerplate and hindered readability.
**Solution:** Added idiomatic boolean matcher methods (`is_jsr`, `is_invokevirtual`, `is_invokespecial`, `is_fcmpg`, `is_dcmpg`, `is_athrow`) directly to the `Instruction` enum and refactored call sites across the codebase to use them.
**Benefit:** Drastically improves code clarity and centralizes the categorization logic, adhering to the "Extract Enum Variant Matchers" pattern.
**Verification:** All tests passed. No logic was altered.

---
*PR created automatically by Jules for task [13770236753413993232](https://jules.google.com/task/13770236753413993232) started by @madmax983*