### PR TITLE
👺 Havoc: Fix out-of-bounds panic in StringBuilder.delete

### DIFF
--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -1823,12 +1823,10 @@ pub(crate) fn native_hashmap_for_each(
         .map(|i| {
             let key = heap
                 .get(this_ref)
-                .map(|o| o.fields[1 + i * 2])
-                .unwrap_or(Slot::Reference(None));
+                .map_or(Slot::Reference(None), |o| o.fields[1 + i * 2]);
             let val = heap
                 .get(this_ref)
-                .map(|o| o.fields[2 + i * 2])
-                .unwrap_or(Slot::Reference(None));
+                .map_or(Slot::Reference(None), |o| o.fields[2 + i * 2]);
             (key, val)
         })
         .collect();
@@ -1873,8 +1871,7 @@ pub(crate) fn native_hashmap_replace_all(
     for (i, key) in keys.iter().enumerate() {
         let old_val = heap
             .get(this_ref)
-            .map(|o| o.fields[2 + i * 2])
-            .unwrap_or(Slot::Reference(None));
+            .map_or(Slot::Reference(None), |o| o.fields[2 + i * 2]);
         let new_val = ops.invoke(
             heap,
             out,
@@ -15644,8 +15641,7 @@ fn default_slot_for_descriptor(desc: &str) -> Slot {
 fn total_instance_field_count(registry: &ClassRegistry, class_name: &str) -> usize {
     let mut count = registry
         .get(class_name)
-        .map(|c| c.instance_field_count)
-        .unwrap_or(0);
+        .map_or(0, |c| c.instance_field_count);
     let mut sc = registry
         .get(class_name)
         .ok()
@@ -16034,15 +16030,6 @@ pub(crate) fn native_sb_delete(
         .get_mut(this_ref)?
         .string_value
         .get_or_insert_with(String::new);
-
-    let char_count = buf.chars().count();
-    if start > end || start < 0 || start.unsigned_abs() as usize > char_count {
-        return Err(VmError::ArrayIndexOutOfBounds {
-            index: start,
-            length: char_count,
-        });
-    }
-
     let start_byte = usize::try_from(start)
         .ok()
         .and_then(|i| buf.char_indices().nth(i).map(|(b, _)| b))
@@ -25126,47 +25113,9 @@ pub(crate) fn native_hashmap_remove_key_value(
 }
 
 #[cfg(test)]
-mod havoc_sb_delete {
-
-    #[test]
-    fn test_sb_delete_out_of_bounds() {
-        use super::{native_sb_delete, NativeControl};
-        use duke_gc::Heap;
-        use duke_runtime::Slot;
-
-        let mut heap = Heap::new();
-        // Since heap.allocate doesn't set string_value directly, we do it via raw access or a proper way
-        let this_ref = heap.allocate("java/lang/StringBuilder".to_string(), 0);
-        heap.get_mut(this_ref).unwrap().string_value = Some("hello".to_string());
-
-        let args = vec![
-            Slot::Reference(Some(this_ref)),
-            Slot::Int(3), // start
-            Slot::Int(2), // end
-        ];
-
-        let mut out: Vec<u8> = Vec::new();
-        let mut control = NativeControl::default();
-
-        let result = native_sb_delete(&args, &mut heap, &mut out, &mut control);
-
-        match result {
-            Err(duke_runtime::VmError::ArrayIndexOutOfBounds { index, length }) => {
-                assert_eq!(index, 3);
-                assert_eq!(length, 5);
-            }
-            other => panic!("Expected ArrayIndexOutOfBounds, got {other:?}"),
-        }
-    }
-
-}
-
 mod havoc_thread_join_itself {
-    #[cfg(test)]
     use super::*;
-    #[cfg(test)]
     use std::sync::{Arc, Mutex};
-    #[cfg(test)]
     use std::thread;
 
     #[test]

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -16035,6 +16035,15 @@ pub(crate) fn native_sb_delete(
         .get_mut(this_ref)?
         .string_value
         .get_or_insert_with(String::new);
+
+    let char_count = buf.chars().count();
+    if start > end || start < 0 || start as usize > char_count {
+        return Err(VmError::ArrayIndexOutOfBounds {
+            index: start,
+            length: char_count,
+        });
+    }
+
     let start_byte = usize::try_from(start)
         .ok()
         .and_then(|i| buf.char_indices().nth(i).map(|(b, _)| b))
@@ -25118,6 +25127,41 @@ pub(crate) fn native_hashmap_remove_key_value(
 }
 
 #[cfg(test)]
+mod havoc_sb_delete {
+
+    #[test]
+    fn test_sb_delete_out_of_bounds() {
+        use super::{native_sb_delete, NativeControl};
+        use duke_gc::Heap;
+        use duke_runtime::Slot;
+
+        let mut heap = Heap::new();
+        // Since heap.allocate doesn't set string_value directly, we do it via raw access or a proper way
+        let this_ref = heap.allocate("java/lang/StringBuilder".to_string(), 0);
+        heap.get_mut(this_ref).unwrap().string_value = Some("hello".to_string());
+
+        let args = vec![
+            Slot::Reference(Some(this_ref)),
+            Slot::Int(3), // start
+            Slot::Int(2), // end
+        ];
+
+        let mut out: Vec<u8> = Vec::new();
+        let mut control = NativeControl::default();
+
+        let result = native_sb_delete(&args, &mut heap, &mut out, &mut control);
+
+        match result {
+            Err(duke_runtime::VmError::ArrayIndexOutOfBounds { index, length }) => {
+                assert_eq!(index, 3);
+                assert_eq!(length, 5);
+            }
+            other => panic!("Expected ArrayIndexOutOfBounds, got {other:?}"),
+        }
+    }
+
+}
+
 mod havoc_thread_join_itself {
     use super::*;
     use std::sync::{Arc, Mutex};

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -1867,8 +1867,7 @@ pub(crate) fn native_hashmap_replace_all(
     let keys: Vec<Slot> = (0..size)
         .map(|i| {
             heap.get(this_ref)
-                .map(|o| o.fields[1 + i * 2])
-                .unwrap_or(Slot::Reference(None))
+                .map_or(Slot::Reference(None), |o| o.fields[1 + i * 2])
         })
         .collect();
     for (i, key) in keys.iter().enumerate() {
@@ -16037,7 +16036,7 @@ pub(crate) fn native_sb_delete(
         .get_or_insert_with(String::new);
 
     let char_count = buf.chars().count();
-    if start > end || start < 0 || start as usize > char_count {
+    if start > end || start < 0 || start.unsigned_abs() as usize > char_count {
         return Err(VmError::ArrayIndexOutOfBounds {
             index: start,
             length: char_count,
@@ -25163,8 +25162,11 @@ mod havoc_sb_delete {
 }
 
 mod havoc_thread_join_itself {
+    #[cfg(test)]
     use super::*;
+    #[cfg(test)]
     use std::sync::{Arc, Mutex};
+    #[cfg(test)]
     use std::thread;
 
     #[test]

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -129,7 +129,7 @@ impl TelemetryStore {
 
         writeln!(w, "\n-- bytecode_cost (top 10 by count) --")?;
         let mut ops: Vec<_> = self.bytecode_cost.by_opcode.iter().collect();
-        ops.sort_by_key(|b| std::cmp::Reverse(b.1.count));
+        ops.sort_by(|a, b| b.1.count.cmp(&a.1.count));
         for (name, stat) in ops.iter().take(10) {
             writeln!(w, "  {:20} count={:>10}", name, stat.count)?;
         }
@@ -139,7 +139,7 @@ impl TelemetryStore {
             "\n-- object_lineage (top 10 allocation sites by count) --"
         )?;
         let mut sites: Vec<_> = self.object_lineage.sites.iter().collect();
-        sites.sort_by_key(|b| std::cmp::Reverse(b.1.count));
+        sites.sort_by(|a, b| b.1.count.cmp(&a.1.count));
         for ((class, method, pc), site) in sites.iter().take(10) {
             writeln!(
                 w,
@@ -180,7 +180,7 @@ impl TelemetryStore {
 
         writeln!(w, "\n-- dispatch_resolution (top 10 virtual call sites) --")?;
         let mut dsites: Vec<_> = self.dispatch_resolution.by_site.iter().collect();
-        dsites.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
+        dsites.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
         for ((class, cp), stat) in dsites.iter().take(10) {
             writeln!(
                 w,
@@ -195,7 +195,7 @@ impl TelemetryStore {
 
         writeln!(w, "\n-- native_boundary (top 10 by call count) --")?;
         let mut natives: Vec<_> = self.native_boundary.by_method.iter().collect();
-        natives.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
+        natives.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
         for ((class, method), stat) in natives.iter().take(10) {
             writeln!(
                 w,
@@ -233,7 +233,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Opcode | Count | Time (ns) |").unwrap();
         writeln!(&mut out, "|--------|-------|-----------|").unwrap();
         let mut ops: Vec<_> = self.bytecode_cost.by_opcode.iter().collect();
-        ops.sort_by_key(|b| std::cmp::Reverse(b.1.count));
+        ops.sort_by(|a, b| b.1.count.cmp(&a.1.count));
         for (name, stat) in ops.iter().take(10) {
             writeln!(
                 &mut out,
@@ -254,7 +254,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Location | Class Allocated | Count |").unwrap();
         writeln!(&mut out, "|----------|-----------------|-------|").unwrap();
         let mut sites: Vec<_> = self.object_lineage.sites.iter().collect();
-        sites.sort_by_key(|b| std::cmp::Reverse(b.1.count));
+        sites.sort_by(|a, b| b.1.count.cmp(&a.1.count));
         for ((class, method, pc), site) in sites.iter().take(10) {
             writeln!(
                 &mut out,
@@ -327,7 +327,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Caller | Calls | Targets | Hierarchy Walks |").unwrap();
         writeln!(&mut out, "|--------|-------|---------|-----------------|").unwrap();
         let mut dsites: Vec<_> = self.dispatch_resolution.by_site.iter().collect();
-        dsites.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
+        dsites.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
         for ((class, cp), stat) in dsites.iter().take(10) {
             writeln!(
                 &mut out,
@@ -350,7 +350,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Native Method | Calls | Errors | Time (ns) |").unwrap();
         writeln!(&mut out, "|---------------|-------|--------|-----------|").unwrap();
         let mut natives: Vec<_> = self.native_boundary.by_method.iter().collect();
-        natives.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
+        natives.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
         for ((class, method), stat) in natives.iter().take(10) {
             writeln!(
                 &mut out,

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -129,7 +129,7 @@ impl TelemetryStore {
 
         writeln!(w, "\n-- bytecode_cost (top 10 by count) --")?;
         let mut ops: Vec<_> = self.bytecode_cost.by_opcode.iter().collect();
-        ops.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+        ops.sort_by_key(|b| std::cmp::Reverse(b.1.count));
         for (name, stat) in ops.iter().take(10) {
             writeln!(w, "  {:20} count={:>10}", name, stat.count)?;
         }
@@ -139,7 +139,7 @@ impl TelemetryStore {
             "\n-- object_lineage (top 10 allocation sites by count) --"
         )?;
         let mut sites: Vec<_> = self.object_lineage.sites.iter().collect();
-        sites.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+        sites.sort_by_key(|b| std::cmp::Reverse(b.1.count));
         for ((class, method, pc), site) in sites.iter().take(10) {
             writeln!(
                 w,
@@ -180,7 +180,7 @@ impl TelemetryStore {
 
         writeln!(w, "\n-- dispatch_resolution (top 10 virtual call sites) --")?;
         let mut dsites: Vec<_> = self.dispatch_resolution.by_site.iter().collect();
-        dsites.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
+        dsites.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
         for ((class, cp), stat) in dsites.iter().take(10) {
             writeln!(
                 w,
@@ -195,7 +195,7 @@ impl TelemetryStore {
 
         writeln!(w, "\n-- native_boundary (top 10 by call count) --")?;
         let mut natives: Vec<_> = self.native_boundary.by_method.iter().collect();
-        natives.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
+        natives.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
         for ((class, method), stat) in natives.iter().take(10) {
             writeln!(
                 w,
@@ -233,7 +233,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Opcode | Count | Time (ns) |").unwrap();
         writeln!(&mut out, "|--------|-------|-----------|").unwrap();
         let mut ops: Vec<_> = self.bytecode_cost.by_opcode.iter().collect();
-        ops.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+        ops.sort_by_key(|b| std::cmp::Reverse(b.1.count));
         for (name, stat) in ops.iter().take(10) {
             writeln!(
                 &mut out,
@@ -254,7 +254,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Location | Class Allocated | Count |").unwrap();
         writeln!(&mut out, "|----------|-----------------|-------|").unwrap();
         let mut sites: Vec<_> = self.object_lineage.sites.iter().collect();
-        sites.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+        sites.sort_by_key(|b| std::cmp::Reverse(b.1.count));
         for ((class, method, pc), site) in sites.iter().take(10) {
             writeln!(
                 &mut out,
@@ -327,7 +327,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Caller | Calls | Targets | Hierarchy Walks |").unwrap();
         writeln!(&mut out, "|--------|-------|---------|-----------------|").unwrap();
         let mut dsites: Vec<_> = self.dispatch_resolution.by_site.iter().collect();
-        dsites.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
+        dsites.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
         for ((class, cp), stat) in dsites.iter().take(10) {
             writeln!(
                 &mut out,
@@ -350,7 +350,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Native Method | Calls | Errors | Time (ns) |").unwrap();
         writeln!(&mut out, "|---------------|-------|--------|-----------|").unwrap();
         let mut natives: Vec<_> = self.native_boundary.by_method.iter().collect();
-        natives.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
+        natives.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
         for ((class, method), stat) in natives.iter().take(10) {
             writeln!(
                 &mut out,

--- a/patch_telemetry_sort.py
+++ b/patch_telemetry_sort.py
@@ -1,0 +1,15 @@
+with open('crates/duke-telemetry/src/lib.rs', 'r') as f:
+    content = f.read()
+
+replacements = [
+    ("ops.sort_by(|a, b| b.1.count.cmp(&a.1.count));", "ops.sort_by_key(|b| std::cmp::Reverse(b.1.count));"),
+    ("sites.sort_by(|a, b| b.1.count.cmp(&a.1.count));", "sites.sort_by_key(|b| std::cmp::Reverse(b.1.count));"),
+    ("dsites.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));", "dsites.sort_by_key(|b| std::cmp::Reverse(b.1.calls));"),
+    ("natives.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));", "natives.sort_by_key(|b| std::cmp::Reverse(b.1.calls));")
+]
+
+for s, r in replacements:
+    content = content.replace(s, r)
+
+with open('crates/duke-telemetry/src/lib.rs', 'w') as f:
+    f.write(content)


### PR DESCRIPTION
🧨 **The Trigger:** Calling `StringBuilder.delete(start, end)` with `start > end`, `start < 0`, or `start` greater than the string's character length bypassed bounds checking. This caused the underlying Rust `String::drain()` or `buf.char_indices().nth()` logic to panic, crashing the VM with a slice bounds error instead of failing gracefully.

📉 **The Stack Trace:**
```
thread 'main' panicked at:
slice index starts at X but ends at Y
```

🧪 **Reproduction:**
Write a mock Java test invoking `new StringBuilder("hello").delete(3, 2);` which triggers the panic.

😈 **Comment:**
You assumed Java callers would never pass negative or inverted bounds to `StringBuilder.delete`. You were wrong. Fixed by validating bounds and gracefully throwing `VmError::ArrayIndexOutOfBounds` instead. Added `test_sb_delete_out_of_bounds` unit test.

---
*PR created automatically by Jules for task [743672102393874494](https://jules.google.com/task/743672102393874494) started by @madmax983*