### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -1,3 +1,6 @@
 ## 2026-04-16 - Increased code coverage for duke-telemetry
 **Learning:** Using tools like `cargo tarpaulin` allowed finding untested behavior in `duke-telemetry`. Many `assert!` clauses were checking for string content that relied upon default settings. I added several targeted tests for `duke-bytecode` and `duke-telemetry`.
 **Action:** Adding new tests to handle explicit empty states and different JSON outputs helps prevent regressions in formatting logic.
+## 2024-04-18 - Tested Default Implementations of CallbackOps
+**Learning:** Default implementations for traits (like `CallbackOps`) are easy to overlook when searching for missing test coverage, but they still contain logic (such as returning specific `VmError` variants) that should be validated.
+**Action:** Always check the trait definitions themselves for default methods, and write a mock struct to execute and verify those defaults.

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -997,3 +997,88 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod callback_ops_tests {
+    use super::*;
+    use duke_gc::Heap;
+
+    struct MockOps;
+    impl CallbackOps for MockOps {
+        fn invoke(
+            &mut self,
+            _heap: &mut Heap,
+            _output: &mut dyn std::io::Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            _args: Vec<crate::Slot>,
+        ) -> VmResult<Option<crate::Slot>> {
+            Ok(None)
+        }
+        fn ensure_loaded(&mut self, _class: &str) -> VmResult<()> {
+            Ok(())
+        }
+        fn inspect_class(&mut self, _class: &str) -> VmResult<ReflectedClassInfo> {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn test_callback_ops_defaults() {
+        let mut ops = MockOps;
+        let mut heap = Heap::new();
+        let mut output = Vec::new();
+
+        assert!(
+            ops.ensure_class_initialized(&mut heap, &mut output, "TestClass")
+                .is_ok()
+        );
+        assert!(ops.code_source_for_class("TestClass").unwrap().is_none());
+        assert!(
+            ops.ensure_loaded_with_runtime_loader(&heap, 0, "TestClass")
+                .is_ok()
+        );
+
+        let err = ops.instance_field_slot("TestClass", "field").unwrap_err();
+        assert!(matches!(err, VmError::InvalidFieldref { index: 0 }));
+
+        let err = ops
+            .read_instance_field(&heap, 0, "TestClass", "field")
+            .unwrap_err();
+        assert!(matches!(err, VmError::InvalidFieldref { index: 0 }));
+
+        let err = ops
+            .write_instance_field(&mut heap, 0, "TestClass", "field", crate::Slot::Int(0))
+            .unwrap_err();
+        assert!(matches!(err, VmError::InvalidFieldref { index: 0 }));
+
+        let err = ops.read_static_field("TestClass", "field").unwrap_err();
+        assert!(matches!(err, VmError::InvalidFieldref { index: 0 }));
+
+        let err = ops
+            .write_static_field("TestClass", "field", crate::Slot::Int(0))
+            .unwrap_err();
+        assert!(matches!(err, VmError::InvalidFieldref { index: 0 }));
+
+        assert!(ops.runtime_loader_for_class("TestClass").unwrap().is_none());
+        assert_eq!(
+            ops.class_key_for_loaded_class("TestClass").unwrap(),
+            "TestClass"
+        );
+        assert_eq!(
+            ops.class_key_for_runtime_loader(&heap, 0, "TestClass")
+                .unwrap(),
+            "TestClass"
+        );
+        assert_eq!(
+            ops.class_key_from_source("TestClass", None).unwrap(),
+            "TestClass"
+        );
+
+        let err = ops
+            .allocate_instance(&mut heap, &mut output, "TestClass")
+            .unwrap_err();
+        assert!(matches!(err, VmError::Unimplemented { .. }));
+    }
+}

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -1020,7 +1020,9 @@ mod callback_ops_tests {
             Ok(())
         }
         fn inspect_class(&mut self, _class: &str) -> VmResult<ReflectedClassInfo> {
-            unimplemented!()
+            Err(VmError::Unimplemented {
+                mnemonic: "inspect_class",
+            })
         }
     }
 

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -129,7 +129,7 @@ impl TelemetryStore {
 
         writeln!(w, "\n-- bytecode_cost (top 10 by count) --")?;
         let mut ops: Vec<_> = self.bytecode_cost.by_opcode.iter().collect();
-        ops.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+        ops.sort_by_key(|b| std::cmp::Reverse(b.1.count));
         for (name, stat) in ops.iter().take(10) {
             writeln!(w, "  {:20} count={:>10}", name, stat.count)?;
         }
@@ -139,7 +139,7 @@ impl TelemetryStore {
             "\n-- object_lineage (top 10 allocation sites by count) --"
         )?;
         let mut sites: Vec<_> = self.object_lineage.sites.iter().collect();
-        sites.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+        sites.sort_by_key(|b| std::cmp::Reverse(b.1.count));
         for ((class, method, pc), site) in sites.iter().take(10) {
             writeln!(
                 w,
@@ -180,7 +180,7 @@ impl TelemetryStore {
 
         writeln!(w, "\n-- dispatch_resolution (top 10 virtual call sites) --")?;
         let mut dsites: Vec<_> = self.dispatch_resolution.by_site.iter().collect();
-        dsites.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
+        dsites.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
         for ((class, cp), stat) in dsites.iter().take(10) {
             writeln!(
                 w,
@@ -195,7 +195,7 @@ impl TelemetryStore {
 
         writeln!(w, "\n-- native_boundary (top 10 by call count) --")?;
         let mut natives: Vec<_> = self.native_boundary.by_method.iter().collect();
-        natives.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
+        natives.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
         for ((class, method), stat) in natives.iter().take(10) {
             writeln!(
                 w,
@@ -233,7 +233,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Opcode | Count | Time (ns) |").unwrap();
         writeln!(&mut out, "|--------|-------|-----------|").unwrap();
         let mut ops: Vec<_> = self.bytecode_cost.by_opcode.iter().collect();
-        ops.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+        ops.sort_by_key(|b| std::cmp::Reverse(b.1.count));
         for (name, stat) in ops.iter().take(10) {
             writeln!(
                 &mut out,
@@ -254,7 +254,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Location | Class Allocated | Count |").unwrap();
         writeln!(&mut out, "|----------|-----------------|-------|").unwrap();
         let mut sites: Vec<_> = self.object_lineage.sites.iter().collect();
-        sites.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+        sites.sort_by_key(|b| std::cmp::Reverse(b.1.count));
         for ((class, method, pc), site) in sites.iter().take(10) {
             writeln!(
                 &mut out,
@@ -327,7 +327,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Caller | Calls | Targets | Hierarchy Walks |").unwrap();
         writeln!(&mut out, "|--------|-------|---------|-----------------|").unwrap();
         let mut dsites: Vec<_> = self.dispatch_resolution.by_site.iter().collect();
-        dsites.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
+        dsites.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
         for ((class, cp), stat) in dsites.iter().take(10) {
             writeln!(
                 &mut out,
@@ -350,7 +350,7 @@ impl TelemetryStore {
         writeln!(&mut out, "| Native Method | Calls | Errors | Time (ns) |").unwrap();
         writeln!(&mut out, "|---------------|-------|--------|-----------|").unwrap();
         let mut natives: Vec<_> = self.native_boundary.by_method.iter().collect();
-        natives.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
+        natives.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
         for ((class, method), stat) in natives.iter().take(10) {
             writeln!(
                 &mut out,


### PR DESCRIPTION
* 🎯 Target: Default implementations of the `CallbackOps` trait in `duke-interpreter/src/registry.rs`.
* 💣 Risk: Prevents regressions if default trait methods are accidentally modified or panics are introduced.
* 🧪 Strategy: Added a mock struct implementing the trait and unit tests that call the default implementations to verify their error handling and return values.
* 🔬 Verification: `cargo test -p duke-interpreter test_callback_ops_defaults`

---
*PR created automatically by Jules for task [10944892237220940792](https://jules.google.com/task/10944892237220940792) started by @madmax983*