### PR TITLE
⚡ Bolt: Pre-allocate minor GC vectors

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,6 @@
 **[Optimizing Collection Construction in Loops]
 **Learning:** Iteratively pushing elements and cloning inside a loop into a `Vec` is measurably slower than taking a slice and calling `to_vec()` or `extend_from_slice()`. The slice operations can pre-allocate the exact required capacity and use more efficient batch operations instead of loop-driven reallocations and individual `.clone()` calls.
 **Action:** When gathering items from an existing slice/vector into sub-vectors (like segmenting basic blocks), keep track of slice indices instead of accumulating into a temporary `Vec` element by element. Convert the finalized slice via `to_vec()` when the boundary is reached.
+**Pre-allocate Minor GC Worklists**
+**Learning:** Found an optimization where `Vec::new()` without capacity was used for garbage collection worklists and `to_space` inside `crates/duke-gc/src/lib.rs`. By pre-allocating with `roots.len()` and `self.young.len()`, we save memory re-allocations on hot paths during minor GC collections.
+**Action:** Always pre-allocate vectors (`Vec::with_capacity()`) where the capacity is known from `len()` of root sources, especially in core routines like garbage collection.

--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -445,11 +445,13 @@ impl Heap {
     /// Panics if a young-gen reference in `roots` cannot be converted to `usize`,
     /// which cannot happen on 64-bit targets since heap indices are always small.
     pub fn minor_collect_prepare(&mut self, roots: &[Slot]) {
-        self.to_space = Vec::new();
+        // ⚡ Bolt: Pre-allocate `to_space` based on maximum possible survivors to eliminate dynamic resizing overhead.
+        self.to_space = Vec::with_capacity(self.young.len());
         self.forward_map.clear();
 
         // Seed worklist with young refs from roots and remembered-set fields.
-        let mut worklist: Vec<usize> = Vec::new();
+        // ⚡ Bolt: Pre-allocate `worklist` based on root set size to eliminate initial dynamic resizing overhead.
+        let mut worklist: Vec<usize> = Vec::with_capacity(roots.len());
 
         for slot in roots {
             if let Some(r) = slot.as_reference()


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity()` for `to_space` and `worklist` in the young generation minor GC routine.
🎯 Why: These vectors are allocated on every minor GC cycle. The `worklist` is immediately populated with elements proportional to `roots.len()`, and `to_space` will be sized according to survivor count up to `self.young.len()`. Without capacity pre-allocation, the vectors undergo unnecessary dynamic heap reallocation as they grow.
📊 Impact: Reduces heap allocation overhead during garbage collection cycles.
🔬 Measurement: Run `cargo bench -p duke-gc` and observe memory allocations.

---
*PR created automatically by Jules for task [8455751967972695998](https://jules.google.com/task/8455751967972695998) started by @madmax983*