### PR TITLE
⚒️ Forge: Simplify branch matching in `build_basic_blocks`

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -34,3 +34,7 @@
 **Extract Enum Variant Matchers**
 **Learning:** `crates/duke-bytecode/src/cfg.rs` contained multiple massive `match` blocks repeatedly enumerating the 15+ conditional branch instructions, unconditional jumps, and return instructions to generate CFGs and compute cyclomatic complexity. This duplicated logic and inflated file size.
 **Action:** Always extract boolean categorization logic (e.g., `is_conditional_branch()`, `is_return()`) and data extraction logic (`conditional_branch_target()`) into public helper methods directly on the enum (`Instruction`) to DRY up matching code and dramatically flatten calling modules.
+
+**Extract branch matchers**
+**Learning:** `build_basic_blocks` in `crates/duke-bytecode/src/basic_block.rs` contained a massive, 60-line inline `match` statement to identify conditional branches, unconditional jumps, and return instructions. This created deep nesting and duplicated logic.
+**Action:** Always extract boolean categorization logic and data extraction logic into public helper methods directly on the enum (e.g., `Instruction`) to DRY up matching code and dramatically flatten calling modules. Use `if-else` chains with these helpers instead of massive inline `match` blocks.

--- a/crates/duke-bytecode/src/basic_block.rs
+++ b/crates/duke-bytecode/src/basic_block.rs
@@ -81,89 +81,34 @@ pub fn build_basic_blocks(instructions: &[(usize, Instruction)]) -> Vec<BasicBlo
     leaders.insert(instructions[0].0);
 
     for (i, (pc, instr)) in instructions.iter().enumerate() {
-        let is_branch_or_return = match instr {
-            Instruction::Ifeq(_)
-            | Instruction::Ifne(_)
-            | Instruction::Iflt(_)
-            | Instruction::Ifge(_)
-            | Instruction::Ifgt(_)
-            | Instruction::Ifle(_)
-            | Instruction::IfIcmpeq(_)
-            | Instruction::IfIcmpne(_)
-            | Instruction::IfIcmplt(_)
-            | Instruction::IfIcmpge(_)
-            | Instruction::IfIcmpgt(_)
-            | Instruction::IfIcmple(_)
-            | Instruction::IfAcmpeq(_)
-            | Instruction::IfAcmpne(_)
-            | Instruction::Ifnull(_)
-            | Instruction::Ifnonnull(_)
-            | Instruction::Jsr(_)
-            | Instruction::JsrW(_) => {
-                // Rule 2: The target of a branch is a leader.
-                let offset = match instr {
-                    Instruction::JsrW(off) => *off as isize,
-                    Instruction::Ifeq(off)
-                    | Instruction::Ifne(off)
-                    | Instruction::Iflt(off)
-                    | Instruction::Ifge(off)
-                    | Instruction::Ifgt(off)
-                    | Instruction::Ifle(off)
-                    | Instruction::IfIcmpeq(off)
-                    | Instruction::IfIcmpne(off)
-                    | Instruction::IfIcmplt(off)
-                    | Instruction::IfIcmpge(off)
-                    | Instruction::IfIcmpgt(off)
-                    | Instruction::IfIcmple(off)
-                    | Instruction::IfAcmpeq(off)
-                    | Instruction::IfAcmpne(off)
-                    | Instruction::Ifnull(off)
-                    | Instruction::Ifnonnull(off)
-                    | Instruction::Jsr(off) => isize::from(*off),
-                    // This unreachable is actually unreachable due to the outer match,
-                    // but let's test it just in case if we can't... wait, we can't test unreachable.
-                    _ => unreachable!(),
-                };
-                leaders.insert((*pc as isize + offset) as usize);
-                true
-            }
-            Instruction::Goto(offset) => {
-                leaders.insert((*pc as isize + isize::from(*offset)) as usize);
-                true
-            }
-            Instruction::GotoW(offset) => {
-                leaders.insert((*pc as isize + *offset as isize) as usize);
-                true
-            }
-            Instruction::Tableswitch {
-                default, offsets, ..
-            } => {
-                leaders.insert((*pc as isize + *default as isize) as usize);
-                for offset in offsets {
-                    leaders.insert((*pc as isize + *offset as isize) as usize);
+        let is_branch_or_return = if let Some(offset) = instr.conditional_branch_target() {
+            leaders.insert((*pc as isize + offset) as usize);
+            true
+        } else if let Some(offset) = instr.unconditional_jump_target() {
+            leaders.insert((*pc as isize + offset) as usize);
+            true
+        } else if instr.is_return() {
+            true
+        } else {
+            match instr {
+                Instruction::Tableswitch {
+                    default, offsets, ..
+                } => {
+                    leaders.insert((*pc as isize + *default as isize) as usize);
+                    for offset in offsets {
+                        leaders.insert((*pc as isize + *offset as isize) as usize);
+                    }
+                    true
                 }
-                true
-            }
-            Instruction::Lookupswitch { default, pairs } => {
-                leaders.insert((*pc as isize + *default as isize) as usize);
-                for (_, offset) in pairs {
-                    leaders.insert((*pc as isize + *offset as isize) as usize);
+                Instruction::Lookupswitch { default, pairs } => {
+                    leaders.insert((*pc as isize + *default as isize) as usize);
+                    for (_, offset) in pairs {
+                        leaders.insert((*pc as isize + *offset as isize) as usize);
+                    }
+                    true
                 }
-                true
+                _ => false,
             }
-            Instruction::Return
-            | Instruction::Ireturn
-            | Instruction::Lreturn
-            | Instruction::Freturn
-            | Instruction::Dreturn
-            | Instruction::Areturn
-            | Instruction::Athrow
-            | Instruction::Ret(_)
-            | Instruction::RetW(_) => {
-                // Returns and throws also terminate the current block.
-                true
-            }
-            _ => false,
         };
 
         if is_branch_or_return && i + 1 < instructions.len() {


### PR DESCRIPTION
🚬 Smell: `build_basic_blocks` in `crates/duke-bytecode/src/basic_block.rs` contained a massive, 60-line inline `match` statement to identify conditional branches, unconditional jumps, and return instructions. This created deep nesting and duplicated logic.
✨ Solution: Replaced the large `match` block with an `if-else` chain utilizing the existing typed helper methods (`conditional_branch_target`, `unconditional_jump_target`, `is_return`) on the `Instruction` enum.
🧼 Benefit: Dramatically reduces the size and complexity of the function, removing the "Pyramid of Doom" and adhering to DRY principles by reusing existing categorization logic.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [12048244815844539357](https://jules.google.com/task/12048244815844539357) started by @madmax983*