### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -31,3 +31,7 @@
 ## 2024-05-24 - `clippy::doc_markdown` and Documentation Formatting
 **Confusion:** Sometimes valid words in documentation are flagged by the Rust compiler (via `clippy::doc_markdown`) if they look like CamelCase or technical terms without backticks, causing CI failures.
 **Clarification:** Ensure that any code-like elements, Java class names (e.g., `ProtectionDomain`), or technical terms in documentation comments are properly enclosed in backticks to satisfy the linter when compiling with `#![warn(missing_docs)]` and `-D warnings`.
+## 2026-04-19 - Tests are crates too
+
+**Confusion:** I missed that integration tests are technically separate crates and require module level missing_docs allowed just like binaries or library crates. I was getting test failures because I didn't add it.
+**Clarification:** Add `#![allow(missing_docs)]` at the top of integration test files so they compile cleanly when `-D missing_docs` is used.

--- a/crates/duke-loader/tests/havoc_directory_loader_fuzz.rs
+++ b/crates/duke-loader/tests/havoc_directory_loader_fuzz.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 //! Fuzz testing for the `DirectoryLoader`.
 
 use duke_loader::{ClassLoader, DirectoryLoader};

--- a/crates/duke-loader/tests/havoc_jimage_oom_crash.rs
+++ b/crates/duke-loader/tests/havoc_jimage_oom_crash.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 //! Test to verify fix for out-of-memory crash when parsing malformed jimage files.
 //!
 //! Test is modified to not crash the test runner by skipping actual execution during normal `cargo test`.

--- a/crates/duke-loader/tests/havoc_zip_capacity.rs
+++ b/crates/duke-loader/tests/havoc_zip_capacity.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 //! Tests for Havoc ZIP OOM issues
 
 #[test]

--- a/crates/duke-loader/tests/havoc_zip_panic.rs
+++ b/crates/duke-loader/tests/havoc_zip_panic.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #[test]
 fn havoc_zip_reader_cd_entry_extends_past_bounds() {
     let mut data = vec![0u8; 100];

--- a/tests/test_jar_analyze_scan.rs
+++ b/tests/test_jar_analyze_scan.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::process::Command;
 use std::path::PathBuf;
 


### PR DESCRIPTION
📖 **Chapter:** Integration Tests
🔦 **Insight:** Integration tests in Rust are treated as separate crates. If `-D missing_docs` is enforced globally via `RUSTFLAGS`, it will fail on test files unless they have top-level crate documentation or an explicit `allow`. I have added `#![allow(missing_docs)]` to all test files to fix build failures and updated the journal with this critical learning.
🧪 **Example:** Added `#![allow(missing_docs)]` to `tests/test_jar_analyze_scan.rs` and other integration test files.
🖼️ **Preview:**
```rust
#![allow(missing_docs)]
use std::process::Command;
// ...
```

---
*PR created automatically by Jules for task [12478406975843718033](https://jules.google.com/task/12478406975843718033) started by @madmax983*