### PR TITLE
🌟 Nova: Jar to HTML Extractor (JavaDoc for Bytecode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ mutants.out/
 mutants.out.old/
 .claude/
 profile.json.gz
+output_html_dir/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,7 @@ dependencies = [
  "duke-interpreter",
  "duke-loader",
  "duke-runtime",
+ "tempfile",
 ]
 
 [[package]]

--- a/duke/Cargo.toml
+++ b/duke/Cargo.toml
@@ -17,7 +17,11 @@ duke-gc = { path = "../crates/duke-gc" }
 duke-interpreter = { path = "../crates/duke-interpreter", features = [] }
 
 [features]
+nova = []
 telemetry = ["duke-interpreter/telemetry"]
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tempfile = "3.8.1"

--- a/duke/src/html_jar.rs
+++ b/duke/src/html_jar.rs
@@ -14,8 +14,12 @@ use crate::html::generate_html_report;
 #[allow(clippy::case_sensitive_file_extension_comparisons)]
 #[allow(clippy::collapsible_if)]
 pub fn generate_jar_html_site(jar_path: &str, output_dir: &str) -> std::io::Result<()> {
-    let loader = ZipLoader::open(Path::new(jar_path))
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("duke: failed to open JAR '{jar_path}': {e}")))?;
+    let loader = ZipLoader::open(Path::new(jar_path)).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("duke: failed to open JAR '{jar_path}': {e}"),
+        )
+    })?;
 
     fs::create_dir_all(output_dir)?;
 

--- a/duke/src/html_jar.rs
+++ b/duke/src/html_jar.rs
@@ -1,0 +1,130 @@
+use duke_classfile::parse;
+use duke_loader::{ClassLoader, ZipLoader};
+use std::fmt::Write;
+use std::fs;
+use std::path::Path;
+
+use crate::html::generate_html_report;
+
+/// Generates a static HTML site for an entire JAR file.
+///
+/// **Why it exists:** Provides a "`JavaDoc` for Bytecode" experience, generating
+/// an interconnected set of HTML reports for every class in a JAR, plus an index.
+#[cfg(feature = "nova")]
+#[allow(clippy::case_sensitive_file_extension_comparisons)]
+#[allow(clippy::collapsible_if)]
+pub fn generate_jar_html_site(jar_path: &str, output_dir: &str) -> std::io::Result<()> {
+    let loader = ZipLoader::open(Path::new(jar_path))
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("duke: failed to open JAR '{jar_path}': {e}")))?;
+
+    fs::create_dir_all(output_dir)?;
+
+    let mut class_names = Vec::new();
+    let reader = loader.reader();
+    let entries: Vec<String> = reader
+        .entry_names()
+        .filter(|name| name.ends_with(".class"))
+        .map(std::string::ToString::to_string)
+        .collect();
+
+    for entry_name in entries {
+        let class_name_internal = entry_name.strip_suffix(".class").unwrap();
+        if let Ok(bytes) = loader.find_class(class_name_internal) {
+            if let Ok(cf) = parse(&bytes) {
+                let html = generate_html_report(&cf);
+
+                let safe_name = class_name_internal.replace('/', "_");
+                let file_name = format!("{safe_name}.html");
+                let out_path = Path::new(output_dir).join(&file_name);
+
+                if fs::write(&out_path, html).is_ok() {
+                    class_names.push((class_name_internal.to_string(), file_name));
+                }
+            }
+        }
+    }
+
+    class_names.sort();
+
+    let mut index_html = String::new();
+    let _ = writeln!(&mut index_html, "<!DOCTYPE html>");
+    let _ = writeln!(&mut index_html, "<html>");
+    let _ = writeln!(&mut index_html, "<head>");
+    let _ = writeln!(&mut index_html, "  <meta charset=\"utf-8\">");
+    let _ = writeln!(&mut index_html, "  <title>JAR Report: {jar_path}</title>");
+    let _ = writeln!(&mut index_html, "  <style>");
+    let _ = writeln!(
+        &mut index_html,
+        "    body {{ font-family: sans-serif; margin: 2rem; background: #f9fafb; color: #111827; }}"
+    );
+    let _ = writeln!(
+        &mut index_html,
+        "    h1 {{ color: #1f2937; border-bottom: 2px solid #e5e7eb; padding-bottom: 0.5rem; }}"
+    );
+    let _ = writeln!(
+        &mut index_html,
+        "    ul {{ list-style-type: none; padding: 0; }}"
+    );
+    let _ = writeln!(&mut index_html, "    li {{ margin-bottom: 0.5rem; }}");
+    let _ = writeln!(
+        &mut index_html,
+        "    a {{ color: #2563eb; text-decoration: none; font-family: monospace; font-size: 1.1em; }}"
+    );
+    let _ = writeln!(
+        &mut index_html,
+        "    a:hover {{ text-decoration: underline; }}"
+    );
+    let _ = writeln!(&mut index_html, "  </style>");
+    let _ = writeln!(&mut index_html, "</head>");
+    let _ = writeln!(&mut index_html, "<body>");
+    let _ = writeln!(&mut index_html, "  <h1>JAR Analysis Report</h1>");
+    let _ = writeln!(
+        &mut index_html,
+        "  <p><strong>Source:</strong> <code>{jar_path}</code></p>"
+    );
+    let _ = writeln!(
+        &mut index_html,
+        "  <p><strong>Classes:</strong> {}</p>",
+        class_names.len()
+    );
+    let _ = writeln!(&mut index_html, "  <ul>");
+    for (name, link) in &class_names {
+        let display_name = name.replace('/', ".");
+        let _ = writeln!(
+            &mut index_html,
+            "    <li><a href=\"{link}\">{display_name}</a></li>"
+        );
+    }
+    let _ = writeln!(&mut index_html, "  </ul>");
+    let _ = writeln!(&mut index_html, "</body>");
+    let _ = writeln!(&mut index_html, "</html>");
+
+    let index_path = Path::new(output_dir).join("index.html");
+    fs::write(&index_path, index_html)?;
+
+    println!("✅ Generated static HTML site at {output_dir}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    #[cfg(feature = "nova")]
+    fn test_generate_jar_html_site() {
+        let dir = tempdir().unwrap();
+        let out_dir = dir.path().to_str().unwrap();
+
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../tests/fixtures/hello.jar");
+        let path_str = path.to_str().unwrap();
+
+        generate_jar_html_site(path_str, out_dir).unwrap();
+
+        let index = std::fs::read_to_string(dir.path().join("index.html")).unwrap();
+        assert!(index.contains("JAR Analysis Report"));
+        assert!(index.contains("HelloWorld.html"));
+    }
+}

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -9,6 +9,8 @@ mod analyze;
 mod deps_graph;
 mod histogram;
 mod html;
+#[cfg(feature = "nova")]
+mod html_jar;
 mod jar_analyze;
 mod scan;
 mod search;
@@ -222,6 +224,9 @@ fn main() {
         eprintln!("Usage: duke <classfile.class>");
         eprintln!("       duke dump <classfile.class>");
         eprintln!("       duke html <classfile.class> [output.html]");
+
+        #[cfg(feature = "nova")]
+        eprintln!("       duke html-jar <file.jar> <output_dir>");
         eprintln!("       duke deps-graph <classfile.class>");
         eprintln!("       duke load <ClassName>");
         eprintln!("       duke cfg <classfile.class> <method>");
@@ -265,6 +270,15 @@ fn main() {
     }
 
     // Dispatch `html`: output HTML report for class.
+
+    #[cfg(feature = "nova")]
+    if args.len() >= 4 && args[1] == "html-jar" {
+        if let Err(e) = html_jar::generate_jar_html_site(&args[2], &args[3]) {
+            eprintln!("{e}");
+            process::exit(1);
+        }
+        return;
+    }
     if args.len() >= 3 && args[1] == "html" {
         let output_path = if args.len() >= 4 {
             Some(args[3].as_str())


### PR DESCRIPTION
💡 **The Spark:** "I noticed we have a beautiful HTML report generator for individual classes and a solid ZIP loader for entire JARs, but no way to export a full project at once."
🚀 **The Feature:** "Implemented the `html-jar` command to iterate over every class in a JAR, generating interconnected HTML reports (with CFGs) and an `index.html` navigation page."
🔮 **The Potential:** "Provides a 'JavaDoc for Bytecode' experience, enabling static analysis and architecture review of entire third-party libraries visually in a browser."
⚠️ **Risk:** "Low. Isolated in `duke/src/html_jar.rs` and gated entirely behind the `nova` feature flag."

---
*PR created automatically by Jules for task [4119636462441868912](https://jules.google.com/task/4119636462441868912) started by @madmax983*