### PR TITLE
⚒️ Forge: Refactor HTML JAR generation logic

### DIFF
--- a/duke/src/html_jar.rs
+++ b/duke/src/html_jar.rs
@@ -12,13 +12,9 @@ use crate::html::generate_html_report;
 /// an interconnected set of HTML reports for every class in a JAR, plus an index.
 #[cfg(feature = "nova")]
 #[allow(clippy::case_sensitive_file_extension_comparisons)]
-#[allow(clippy::collapsible_if)]
 pub fn generate_jar_html_site(jar_path: &str, output_dir: &str) -> std::io::Result<()> {
     let loader = ZipLoader::open(Path::new(jar_path)).map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("duke: failed to open JAR '{jar_path}': {e}"),
-        )
+        std::io::Error::other(format!("duke: failed to open JAR '{jar_path}': {e}"))
     })?;
 
     fs::create_dir_all(output_dir)?;
@@ -33,23 +29,37 @@ pub fn generate_jar_html_site(jar_path: &str, output_dir: &str) -> std::io::Resu
 
     for entry_name in entries {
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            if let Ok(cf) = parse(&bytes) {
-                let html = generate_html_report(&cf);
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
+        let Ok(cf) = parse(&bytes) else {
+            continue;
+        };
 
-                let safe_name = class_name_internal.replace('/', "_");
-                let file_name = format!("{safe_name}.html");
-                let out_path = Path::new(output_dir).join(&file_name);
+        let html = generate_html_report(&cf);
 
-                if fs::write(&out_path, html).is_ok() {
-                    class_names.push((class_name_internal.to_string(), file_name));
-                }
-            }
+        let safe_name = class_name_internal.replace('/', "_");
+        let file_name = format!("{safe_name}.html");
+        let out_path = Path::new(output_dir).join(&file_name);
+
+        if fs::write(&out_path, html).is_ok() {
+            class_names.push((class_name_internal.to_string(), file_name));
         }
     }
 
     class_names.sort();
 
+    let index_html = generate_index_html(jar_path, &class_names);
+
+    let index_path = Path::new(output_dir).join("index.html");
+    fs::write(&index_path, index_html)?;
+
+    println!("✅ Generated static HTML site at {output_dir}");
+    Ok(())
+}
+
+#[cfg(feature = "nova")]
+fn generate_index_html(jar_path: &str, class_names: &[(String, String)]) -> String {
     let mut index_html = String::new();
     let _ = writeln!(&mut index_html, "<!DOCTYPE html>");
     let _ = writeln!(&mut index_html, "<html>");
@@ -92,7 +102,7 @@ pub fn generate_jar_html_site(jar_path: &str, output_dir: &str) -> std::io::Resu
         class_names.len()
     );
     let _ = writeln!(&mut index_html, "  <ul>");
-    for (name, link) in &class_names {
+    for (name, link) in class_names {
         let display_name = name.replace('/', ".");
         let _ = writeln!(
             &mut index_html,
@@ -102,12 +112,7 @@ pub fn generate_jar_html_site(jar_path: &str, output_dir: &str) -> std::io::Resu
     let _ = writeln!(&mut index_html, "  </ul>");
     let _ = writeln!(&mut index_html, "</body>");
     let _ = writeln!(&mut index_html, "</html>");
-
-    let index_path = Path::new(output_dir).join("index.html");
-    fs::write(&index_path, index_html)?;
-
-    println!("✅ Generated static HTML site at {output_dir}");
-    Ok(())
+    index_html
 }
 
 #[cfg(test)]


### PR DESCRIPTION
🚮 Smell: Nested `if let` blocks ("Pyramid of Doom") in `generate_jar_html_site` and a long HTML writing block making it a God Function. Also fixed a `clippy::io_other_error` warning.
✨ Solution: Extracted HTML generation into `generate_index_html` helper function. Used `let else` guard clauses to flatten the nesting. Replaced `std::io::Error::new` with `std::io::Error::other`.
🧼 Benefit: Significantly reduces cognitive load, flattening execution and modularizing HTML creation.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [2479375331209073069](https://jules.google.com/task/2479375331209073069) started by @madmax983*