### PR TITLE
⚒️ Forge: Fix clippy::io_other_error in html_jar.rs

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -38,3 +38,6 @@
 **Extract branch matchers**
 **Learning:** `build_basic_blocks` in `crates/duke-bytecode/src/basic_block.rs` contained a massive, 60-line inline `match` statement to identify conditional branches, unconditional jumps, and return instructions. This created deep nesting and duplicated logic.
 **Action:** Always extract boolean categorization logic and data extraction logic into public helper methods directly on the enum (e.g., `Instruction`) to DRY up matching code and dramatically flatten calling modules. Use `if-else` chains with these helpers instead of massive inline `match` blocks.
+**[Fixed clippy::io_other_error]
+**Learning:** `std::io::Error::new(std::io::ErrorKind::Other, ...)` is clunky and triggers the `clippy::io_other_error` lint.
+**Action:** Replace it with the more concise `std::io::Error::other(...)` to improve readability and conform to idiomatic Rust.

--- a/duke/src/html_jar.rs
+++ b/duke/src/html_jar.rs
@@ -15,10 +15,7 @@ use crate::html::generate_html_report;
 #[allow(clippy::collapsible_if)]
 pub fn generate_jar_html_site(jar_path: &str, output_dir: &str) -> std::io::Result<()> {
     let loader = ZipLoader::open(Path::new(jar_path)).map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("duke: failed to open JAR '{jar_path}': {e}"),
-        )
+        std::io::Error::other(format!("duke: failed to open JAR '{jar_path}': {e}"))
     })?;
 
     fs::create_dir_all(output_dir)?;


### PR DESCRIPTION
🚮 Smell: `std::io::Error::new(std::io::ErrorKind::Other, ...)` is clunky and triggers `clippy::io_other_error`.
✨ Solution: Replaced it with the more concise `std::io::Error::other(...)`.
🧼 Benefit: Improves readability and conforms to idiomatic Rust.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [14390923438024874103](https://jules.google.com/task/14390923438024874103) started by @madmax983*