### PR TITLE
👺 Havoc: Fix Frame::new capacity DoS

### DIFF
--- a/crates/duke-runtime/src/frame.rs
+++ b/crates/duke-runtime/src/frame.rs
@@ -52,6 +52,16 @@ impl Frame {
     /// assert_eq!(frame.load_local(1).unwrap(), Slot::Int(0)); // zero-initialized
     /// ```
     pub fn new(max_stack: usize, max_locals: usize, args: Vec<Slot>) -> VmResult<Self> {
+        let max_size = 1024 * 1024;
+        if max_stack > max_size {
+            return Err(VmError::StackOverflow);
+        }
+        if max_locals > max_size {
+            return Err(VmError::LocalOutOfBounds {
+                index: 0,
+                max_locals,
+            });
+        }
         if args.len() > max_locals {
             return Err(VmError::LocalOutOfBounds {
                 index: args.len(),

--- a/crates/duke-runtime/tests/havoc_frame_oom.rs
+++ b/crates/duke-runtime/tests/havoc_frame_oom.rs
@@ -1,0 +1,41 @@
+#![allow(missing_docs)]
+use duke_runtime::Frame;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct TrackingAllocator;
+
+static ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATED.fetch_add(layout.size(), Ordering::SeqCst);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) };
+    }
+}
+
+#[global_allocator]
+static GLOBAL: TrackingAllocator = TrackingAllocator;
+
+#[test]
+fn test_frame_capacity_overflow() {
+    ALLOCATED.store(0, Ordering::SeqCst);
+
+    // Test large max_stack. We expect it to gracefully return Err rather than panic in Vec::with_capacity
+    let result1 = Frame::new(usize::MAX / 16, 5, vec![]);
+    assert!(result1.is_err());
+
+    // Test large max_locals. We expect it to gracefully return Err rather than panic in Vec::resize
+    let result2 = Frame::new(5, usize::MAX / 16, vec![]);
+    assert!(result2.is_err());
+
+    let allocated = ALLOCATED.load(Ordering::SeqCst);
+    assert!(
+        allocated < 10_000_000,
+        "Allocated {allocated} bytes! OOM triggered."
+    );
+}

--- a/duke/src/html_jar.rs
+++ b/duke/src/html_jar.rs
@@ -15,10 +15,7 @@ use crate::html::generate_html_report;
 #[allow(clippy::collapsible_if)]
 pub fn generate_jar_html_site(jar_path: &str, output_dir: &str) -> std::io::Result<()> {
     let loader = ZipLoader::open(Path::new(jar_path)).map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("duke: failed to open JAR '{jar_path}': {e}"),
-        )
+        std::io::Error::other(format!("duke: failed to open JAR '{jar_path}': {e}"))
     })?;
 
     fs::create_dir_all(output_dir)?;


### PR DESCRIPTION
👺 **Havoc: Fix Frame::new capacity DoS**

🧨 **The Trigger:** 
A bytecode file with a maliciously crafted `max_stack` or `max_locals` (e.g., `usize::MAX / 16`) could be passed to `Frame::new`. When `Vec::with_capacity(max_stack)` or `args.resize(max_locals, Slot::Int(0))` is called, the Rust standard library immediately panics with "capacity overflow", bringing down the JVM interpreter abruptly (DoS). 

📉 **The Stack Trace:**
```
thread 'test_frame_capacity_overflow' panicked at library/alloc/src/raw_vec/mod.rs:28:5:
capacity overflow
```

🧪 **Reproduction:**
Run the newly added test `havoc_frame_oom` which instantiates `Frame::new` with large dimensions and verifies the panics are replaced with safe `VmError` returns.

😈 **Comment:**
"You assumed memory was infinite and that the standard library wouldn't complain about allocating a buffer larger than the known universe. You were wrong."

---
*PR created automatically by Jules for task [8572522734157189870](https://jules.google.com/task/8572522734157189870) started by @madmax983*