### PR TITLE
⚡ Bolt: Eliminate intermediate string allocations in Arrays.toString

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,6 @@
 **Pre-allocating Vec capacity for zip builders**
 **Learning:** `Vec::with_capacity(n)` is a highly effective way to prevent multiple heap re-allocations when using `extend_from_slice` in loops or sequentially. When dynamically generating byte buffers, calculating the exact size upfront reduces memory pressure and execution time.
 **Action:** Look for instances of `Vec::new()` immediately followed by loops that push elements or sequential `extend_from_slice` calls. If the total size can be derived mathematically, replace `Vec::new()` with `Vec::with_capacity(cap)`.
+**Arrays.toString Optimization**
+**Learning:** Avoid `format!` macros and intermediate `Vec<String>` allocations for simple formatting inside hot paths like `Arrays.toString`. You can safely write straight to a `String` buffer.
+**Action:** Use a pre-allocated `String` with `write!` directly for formatting, replacing maps with `.join()` which cause extra allocations.

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -19974,16 +19974,25 @@ pub(crate) fn native_arrays_to_string_int(
     _out: &mut dyn Write,
     _control: &mut NativeControl,
 ) -> VmResult<Option<Slot>> {
+    use std::fmt::Write as FmtWrite;
     let arr_ref = extract_ref_arg(args, 0)?;
     let fields = heap.get(arr_ref)?.fields.clone();
-    let parts: Vec<String> = fields
-        .iter()
-        .map(|s| match s {
-            Slot::Int(n) => n.to_string(),
-            _ => "0".to_string(),
-        })
-        .collect();
-    let result = format!("[{}]", parts.join(", "));
+
+    // ⚡ Bolt: Eliminate intermediate Vec<String> allocation, format! macro overhead,
+    // and .join() by appending directly to a single String buffer.
+    let mut result = String::with_capacity(fields.len() * 4 + 2);
+    result.push('[');
+    for (i, s) in fields.iter().enumerate() {
+        if i > 0 {
+            result.push_str(", ");
+        }
+        match s {
+            Slot::Int(n) => { let _ = write!(result, "{n}"); },
+            _ => result.push('0'),
+        }
+    }
+    result.push(']');
+
     let r = heap.allocate_string(result);
     Ok(Some(Slot::Reference(Some(r))))
 }
@@ -19995,23 +20004,36 @@ pub(crate) fn native_arrays_to_string_object(
     _out: &mut dyn Write,
     _control: &mut NativeControl,
 ) -> VmResult<Option<Slot>> {
+    use std::fmt::Write as FmtWrite;
     let arr_ref = extract_ref_arg(args, 0)?;
     let fields = heap.get(arr_ref)?.fields.clone();
-    let mut parts: Vec<String> = Vec::with_capacity(fields.len());
-    for s in &fields {
-        let part = match s {
-            Slot::Reference(Some(r)) => heap
-                .get(*r)
-                .ok()
-                .and_then(|o| o.string_value.clone())
-                .unwrap_or_else(|| "null".to_string()),
-            Slot::Reference(None) => "null".to_string(),
-            Slot::Int(n) => n.to_string(),
-            _ => "?".to_string(),
-        };
-        parts.push(part);
+
+    // ⚡ Bolt: Eliminate intermediate Vec<String> allocation, format! macro overhead,
+    // and .join() by appending directly to a single String buffer.
+    let mut result = String::with_capacity(fields.len() * 8 + 2);
+    result.push('[');
+    for (i, s) in fields.iter().enumerate() {
+        if i > 0 {
+            result.push_str(", ");
+        }
+        match s {
+            Slot::Reference(Some(r)) => {
+                let part = heap
+                    .get(*r)
+                    .ok()
+                    .and_then(|o| o.string_value.clone())
+                    .unwrap_or_else(|| "null".to_string());
+                result.push_str(&part);
+            }
+            Slot::Reference(None) => result.push_str("null"),
+            Slot::Int(n) => {
+                let _ = write!(result, "{n}");
+            }
+            _ => result.push('?'),
+        }
     }
-    let result = format!("[{}]", parts.join(", "));
+    result.push(']');
+
     let r = heap.allocate_string(result);
     Ok(Some(Slot::Reference(Some(r))))
 }


### PR DESCRIPTION
💡 What: Replaced intermediate `.map(...).collect::<Vec<String>>()` and `.join()` overhead in `Arrays.toString(int[])` and `Arrays.toString(Object[])` with direct string appending using a pre-allocated `String` and `std::fmt::Write`.
🎯 Why: Creating intermediate vectors and strings for simple array-to-string formatting creates unnecessary heap allocations and overhead on a hot execution path.
📊 Impact: Reduces heap allocations and formatter macro overhead significantly when printing arrays, speeding up string conversions.
🔬 Measurement: Run `cargo bench` to verify performance improvements across string and iteration benchmarks.

---
*PR created automatically by Jules for task [9290729281470871026](https://jules.google.com/task/9290729281470871026) started by @madmax983*