### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/crates/duke-bytecode/src/call_graph.rs
+++ b/crates/duke-bytecode/src/call_graph.rs
@@ -361,4 +361,47 @@ mod tests {
         let cg = generate_mermaid_call_graph(&cf);
         assert!(cg.contains("\"MyClass::myMethod()V\" --> \"MyClass::targetMethod()V\""));
     }
+
+    #[test]
+    fn test_generate_mermaid_call_graph_invalid_code() {
+        let cf = ClassFile {
+            major_version: 61,
+            minor_version: 0,
+            constant_pool: vec![
+                None, // 0
+                Some(CpEntry::Class {
+                    name_index: CpIndex(2),
+                }), // 1
+                Some(CpEntry::Utf8("MyClass".to_string())), // 2
+                Some(CpEntry::Utf8("myMethod".to_string())), // 3
+                Some(CpEntry::Utf8("()V".to_string())), // 4
+            ],
+            access_flags: ClassAccessFlags::PUBLIC,
+            this_class: CpIndex(1),
+            super_class: CpIndex(0),
+            interfaces: vec![],
+            fields: vec![],
+            methods: vec![MethodInfo {
+                access_flags: MethodAccessFlags::PUBLIC,
+                name_index: CpIndex(3),
+                descriptor_index: CpIndex(4),
+                attributes: vec![AttributeInfo {
+                    name_index: CpIndex(0),
+                    data: AttributeData::Code(CodeAttribute {
+                        max_stack: 1,
+                        max_locals: 1,
+                        // invalid code: impdep1
+                        code: vec![0xfe],
+                        exception_table: vec![],
+                        attributes: vec![],
+                    }),
+                }],
+            }],
+            attributes: vec![],
+        };
+
+        let cg = generate_mermaid_call_graph(&cf);
+        assert!(cg.contains("graph TD"));
+        assert!(!cg.contains("-->")); // no edges generated because decode fails
+    }
 }

--- a/crates/duke-bytecode/src/instruction.rs
+++ b/crates/duke-bytecode/src/instruction.rs
@@ -964,4 +964,90 @@ mod tests {
             assert_eq!(instr.mnemonic(), expected);
         }
     }
+
+    #[test]
+    fn test_is_conditional_branch() {
+        assert!(Instruction::Ifeq(5).is_conditional_branch());
+        assert!(Instruction::Ifne(5).is_conditional_branch());
+        assert!(!Instruction::Iconst0.is_conditional_branch());
+    }
+
+    #[test]
+    fn test_conditional_branch_target() {
+        assert_eq!(Instruction::Ifeq(5).conditional_branch_target(), Some(5));
+        assert_eq!(Instruction::Ifne(5).conditional_branch_target(), Some(5));
+        assert_eq!(Instruction::Iconst0.conditional_branch_target(), None);
+    }
+
+    #[test]
+    fn test_is_unconditional_jump() {
+        assert!(Instruction::Goto(5).is_unconditional_jump());
+        assert!(Instruction::GotoW(5).is_unconditional_jump());
+        assert!(Instruction::Jsr(5).is_unconditional_jump());
+        assert!(Instruction::JsrW(5).is_unconditional_jump());
+        assert!(!Instruction::Iconst0.is_unconditional_jump());
+    }
+
+    #[test]
+    fn test_unconditional_jump_target() {
+        assert_eq!(Instruction::Goto(5).unconditional_jump_target(), Some(5));
+        assert_eq!(Instruction::GotoW(5).unconditional_jump_target(), Some(5));
+        assert_eq!(Instruction::Jsr(5).unconditional_jump_target(), Some(5));
+        assert_eq!(Instruction::JsrW(5).unconditional_jump_target(), Some(5));
+        assert_eq!(Instruction::Iconst0.unconditional_jump_target(), None);
+    }
+
+    #[test]
+    fn test_switch_targets() {
+        let tableswitch = Instruction::Tableswitch {
+            default: 5,
+            low: 10,
+            high: 12,
+            offsets: vec![100, 200, 300],
+        };
+        assert_eq!(
+            tableswitch.switch_targets(),
+            Some((5, vec![(10, 100), (11, 200), (12, 300)]))
+        );
+
+        let lookupswitch = Instruction::Lookupswitch {
+            default: 5,
+            pairs: vec![(10, 100), (20, 200)],
+        };
+        assert_eq!(
+            lookupswitch.switch_targets(),
+            Some((5, vec![(10, 100), (20, 200)]))
+        );
+
+        assert_eq!(Instruction::Iconst0.switch_targets(), None);
+    }
+
+    #[test]
+    fn test_is_switch() {
+        assert!(
+            Instruction::Tableswitch {
+                default: 0,
+                low: 0,
+                high: 0,
+                offsets: vec![],
+            }
+            .is_switch()
+        );
+        assert!(
+            Instruction::Lookupswitch {
+                default: 0,
+                pairs: vec![],
+            }
+            .is_switch()
+        );
+        assert!(!Instruction::Iconst0.is_switch());
+    }
+
+    #[test]
+    fn test_is_return() {
+        assert!(Instruction::Return.is_return());
+        assert!(Instruction::Ireturn.is_return());
+        assert!(Instruction::Athrow.is_return());
+        assert!(!Instruction::Iconst0.is_return());
+    }
 }

--- a/crates/duke-bytecode/src/verifier.rs
+++ b/crates/duke-bytecode/src/verifier.rs
@@ -914,4 +914,24 @@ mod tests {
             })
         ));
     }
+
+    #[test]
+    fn test_verifier_short_form_loads_oob() {
+        assert!(matches!(
+            check_locals(&Instruction::Iload0, 0, 0),
+            Err(VerifyError::LocalOutOfBounds {
+                pc: 0,
+                index: 0,
+                max_locals: 0
+            })
+        ));
+        assert!(matches!(
+            check_locals(&Instruction::Dload0, 0, 0),
+            Err(VerifyError::LocalOutOfBounds {
+                pc: 0,
+                index: 0,
+                max_locals: 0
+            })
+        ));
+    }
 }

--- a/duke/src/html.rs
+++ b/duke/src/html.rs
@@ -467,4 +467,51 @@ mod tests {
         assert!(html.contains("<h4>Control Flow Graph</h4>"));
         assert!(html.contains("<h4>Basic Block Control Flow Graph</h4>"));
     }
+
+    #[test]
+    fn test_html_resolve_class_name_not_class_ref() {
+        use duke_classfile::types::CpEntry;
+        let cf = ClassFile {
+            major_version: 61,
+            minor_version: 0,
+            constant_pool: vec![
+                None,
+                Some(CpEntry::Integer(42)), // not a class ref
+            ],
+            access_flags: duke_classfile::access_flags::ClassAccessFlags::PUBLIC,
+            this_class: CpIndex(1),
+            super_class: CpIndex(0),
+            interfaces: vec![],
+            fields: vec![],
+            methods: vec![],
+            attributes: vec![],
+        };
+        let html = generate_html_report(&cf);
+        assert!(html.contains("&lt;not a class ref&gt;"));
+    }
+
+    #[test]
+    fn test_html_cp_str_not_utf8() {
+        use duke_classfile::types::CpEntry;
+        let cf = ClassFile {
+            major_version: 61,
+            minor_version: 0,
+            constant_pool: vec![
+                None,
+                Some(CpEntry::Class {
+                    name_index: CpIndex(2),
+                }),
+                Some(CpEntry::Integer(42)), // not a utf8 string
+            ],
+            access_flags: duke_classfile::access_flags::ClassAccessFlags::PUBLIC,
+            this_class: CpIndex(1),
+            super_class: CpIndex(0),
+            interfaces: vec![],
+            fields: vec![],
+            methods: vec![],
+            attributes: vec![],
+        };
+        let html = generate_html_report(&cf);
+        assert!(html.contains("&lt;invalid utf8&gt;"));
+    }
 }


### PR DESCRIPTION
**Assumption**: The missing coverage in bytecode helpers and HTML generators represents a gap in edge-case handling validation.

🎯 Target: `duke-bytecode` (`instruction.rs`, `verifier.rs`, `call_graph.rs`) and `duke` (`html.rs`).
💣 Risk: Edge cases in conditional branch handling, unreachable bytecode decodes, and invalid constant pool entries could panic or silently fail without proper bounds checks.
🧪 Strategy: Appended dedicated unit tests to the `tests` modules covering untested `match` arms, missing invalid bytecode paths, and fallback strings.
🔬 Verification: Run `cargo test -p duke-bytecode` and `cargo test -p duke`.

---
*PR created automatically by Jules for task [16647147638933728724](https://jules.google.com/task/16647147638933728724) started by @madmax983*