### PR TITLE
👺 Havoc: Prevent unbounded allocation OOM crash in duke_gc::Heap::allocate

### DIFF
--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -145,6 +145,10 @@ impl Heap {
     ///
     /// # Examples
     ///
+    /// # Panics
+    ///
+    /// Panics if `field_count` exceeds 1,048,576 to prevent `OutOfMemory` capacity overflows.
+    ///
     /// ```
     /// use duke_gc::Heap;
     /// let heap = Heap::new();
@@ -189,6 +193,10 @@ impl Heap {
     }
 
     /// Allocate a new object in the young generation. Returns a young-gen reference.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `field_count` exceeds 1,048,576 to prevent `OutOfMemory` capacity overflows.
     ///
     /// # Examples
     ///

--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -200,6 +200,14 @@ impl Heap {
     /// assert_eq!(heap.get(r).unwrap().class_name, "java/lang/Object");
     /// ```
     pub fn allocate(&mut self, class_name: String, field_count: usize) -> u64 {
+        // 👺 HAVOC: Stop OOM attacks!
+        // Prevent unbounded allocation which triggers stdlib capacity overflow and crashes the process.
+        // We explicitly assert limit. A "graceful" panic provides a backtrace and prevents
+        // uncontrolled heap exhaustions inside the VM execution layer.
+        assert!(
+            field_count <= 1024 * 1024,
+            "Allocation exceeded maximum allowed field count"
+        );
         self.alloc_since_gc += 1;
         self.live_count += 1;
         let idx = self.young_top as u64; // OLD_BIT == 0 → young ref

--- a/crates/duke-gc/tests/havoc_heap_oom.rs
+++ b/crates/duke-gc/tests/havoc_heap_oom.rs
@@ -1,0 +1,30 @@
+#![allow(missing_docs)]
+use duke_gc::Heap;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct TrackingAllocator;
+
+static ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATED.fetch_add(layout.size(), Ordering::SeqCst);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) };
+    }
+}
+
+#[global_allocator]
+static GLOBAL: TrackingAllocator = TrackingAllocator;
+
+#[test]
+#[should_panic(expected = "Allocation exceeded maximum allowed field count")]
+fn test_heap_allocate_oom() {
+    ALLOCATED.store(0, Ordering::SeqCst);
+    let mut heap = Heap::new();
+    let _ = heap.allocate("Ljava/lang/Object;".to_string(), 2_000_000_000);
+}


### PR DESCRIPTION
**👺 The Trigger:**
Calling `duke_gc::Heap::allocate` with an excessively large `field_count` (e.g., from an artificially large multianewarray or array initialization payload).

**📉 The Stack Trace:**
```
memory allocation of 16000000000 bytes failed
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
process didn't exit successfully: `/app/target/debug/deps/havoc_heap_oom-1ce6068b8d4befe6` (signal: 6, SIGABRT: process abort signal)
```
The VM process crashes immediately because `vec![Slot::Int(0); field_count]` panics on standard library capacity overflow.

**🧪 Reproduction:**
Run `cargo test -p duke-gc --test havoc_heap_oom`. A maliciously crafted classfile could instruct the VM to construct an array with 2 billion elements, shutting down the entire server node.

**😈 Comment:**
You assumed the VM could infinitely allocate elements simply because it was asked to. You were wrong. An assert bounding limits safely prevents complete unrecoverable process death.

(Note: To avoid breaking tests, we inserted a graceful max limit assertion to `field_count <= 1024 * 1024`. Future refactors should make `allocate()` return a `Result` so the VM can throw `OutOfMemoryError` safely.)

---
*PR created automatically by Jules for task [15191495732942366842](https://jules.google.com/task/15191495732942366842) started by @madmax983*