### PR TITLE
⚡ Bolt: [Remove SwitchTargets allocations]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@
 **Pre-allocating Vec capacity for zip builders**
 **Learning:** `Vec::with_capacity(n)` is a highly effective way to prevent multiple heap re-allocations when using `extend_from_slice` in loops or sequentially. When dynamically generating byte buffers, calculating the exact size upfront reduces memory pressure and execution time.
 **Action:** Look for instances of `Vec::new()` immediately followed by loops that push elements or sequential `extend_from_slice` calls. If the total size can be derived mathematically, replace `Vec::new()` with `Vec::with_capacity(cap)`.
+
+**Eliminate Heterogeneous Iterator Allocations**
+**Learning:** Returning a `Vec` from a function just to unify different iterator types (e.g. iterating over a `Vec` directly vs. generating items on the fly) incurs unnecessary heap allocations. Using `Box<dyn Iterator>` or `Vec` hides the complexity at a performance cost.
+**Action:** Define a custom `enum` that wraps the different iterator variants and implement `Iterator` and `ExactSizeIterator` manually to achieve zero-cost abstraction without allocations. When managing internal counters in such iterators, always use `.wrapping_add(1)` to prevent debug-mode panics from integer overflows (e.g., when reaching `i32::MAX`).

--- a/crates/duke-bytecode/src/instruction.rs
+++ b/crates/duke-bytecode/src/instruction.rs
@@ -361,6 +361,50 @@ pub enum Instruction {
     },
 }
 
+/// An iterator over the match values and offsets of a switch statement.
+pub enum SwitchTargets<'a> {
+    /// Iterator for `tableswitch` instruction.
+    Tableswitch {
+        /// The lowest match value.
+        low: i32,
+        /// Iterator over the offsets.
+        offsets: std::slice::Iter<'a, i32>,
+        /// The current match value.
+        current: i32,
+    },
+    /// Iterator for `lookupswitch` instruction.
+    Lookupswitch(std::slice::Iter<'a, (i32, i32)>),
+}
+
+impl Iterator for SwitchTargets<'_> {
+    type Item = (i32, i32);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Tableswitch {
+                low: _,
+                offsets,
+                current,
+            } => {
+                let offset = offsets.next()?;
+                let val = *current;
+                *current = current.wrapping_add(1);
+                Some((val, *offset))
+            }
+            Self::Lookupswitch(pairs) => pairs.next().copied(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::Tableswitch { offsets, .. } => offsets.size_hint(),
+            Self::Lookupswitch(pairs) => pairs.size_hint(),
+        }
+    }
+}
+
+impl ExactSizeIterator for SwitchTargets<'_> {}
+
 impl Instruction {
     /// Returns `true` if the instruction is a conditional branch.
     #[must_use]
@@ -430,24 +474,30 @@ impl Instruction {
     }
 
     /// Returns the switch targets if the instruction is a switch statement.
-    /// It returns `Some((default_offset, Vec<(match_value, branch_offset)>))`.
+    /// It returns `Some((default_offset, targets_iterator))`.
+    ///
+    /// ⚡ Bolt: By returning an iterator instead of allocating and collecting into
+    /// a new `Vec`, we eliminate heap allocations during CFG generation and
+    /// complexity calculation.
     #[must_use]
-    pub fn switch_targets(&self) -> Option<(i32, Vec<(i32, i32)>)> {
+    pub fn switch_targets(&self) -> Option<(i32, SwitchTargets<'_>)> {
         match self {
             Self::Tableswitch {
                 default,
                 low,
                 offsets,
                 ..
-            } => {
-                let targets = offsets
-                    .iter()
-                    .enumerate()
-                    .map(|(i, &offset)| (i32::try_from(i).unwrap_or(0) + *low, offset))
-                    .collect();
-                Some((*default, targets))
+            } => Some((
+                *default,
+                SwitchTargets::Tableswitch {
+                    low: *low,
+                    offsets: offsets.iter(),
+                    current: *low,
+                },
+            )),
+            Self::Lookupswitch { default, pairs } => {
+                Some((*default, SwitchTargets::Lookupswitch(pairs.iter())))
             }
-            Self::Lookupswitch { default, pairs } => Some((*default, pairs.clone())),
             _ => None,
         }
     }

--- a/get_diff.py
+++ b/get_diff.py
@@ -1,0 +1,9 @@
+import re
+
+with open("crates/duke-bytecode/src/instruction.rs", "r") as f:
+    data = f.read()
+
+data = data.replace("*current += 1;", "*current = current.wrapping_add(1);")
+
+with open("crates/duke-bytecode/src/instruction.rs", "w") as f:
+    f.write(data)

--- a/get_diff2.py
+++ b/get_diff2.py
@@ -1,0 +1,20 @@
+import re
+
+with open("crates/duke-bytecode/src/instruction.rs", "r") as f:
+    data = f.read()
+
+# Add why the optimization matters.
+replacement = """    /// Returns the switch targets if the instruction is a switch statement.
+    /// It returns `Some((default_offset, targets_iterator))`.
+    ///
+    /// ⚡ Bolt: By returning an iterator instead of allocating and collecting into
+    /// a new `Vec`, we eliminate heap allocations during CFG generation and
+    /// complexity calculation.
+    #[must_use]"""
+
+data = data.replace("""    /// Returns the switch targets if the instruction is a switch statement.
+    /// It returns `Some((default_offset, targets_iterator))`.
+    #[must_use]""", replacement)
+
+with open("crates/duke-bytecode/src/instruction.rs", "w") as f:
+    f.write(data)


### PR DESCRIPTION
💡 What: Replaced the `Vec` return type of `switch_targets` with a custom iterator `SwitchTargets`.
🎯 Why: `switch_targets` was cloning vectors (for `Lookupswitch`) and collecting into vectors (for `Tableswitch`), adding heap allocation overhead during basic block construction and cyclomatic complexity checks.
📊 Impact: Eliminates heap allocations during CFG generation and complexity checks.
🔭 Measurement: Verify memory footprint reductions running the tests and the benchmarks.

---
*PR created automatically by Jules for task [7531496030188246774](https://jules.google.com/task/7531496030188246774) started by @madmax983*