### PR TITLE
🎻 Bard: [documentation update] Telemetry Subsystem

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -35,3 +35,7 @@
 
 **Confusion:** I missed that integration tests are technically separate crates and require module level missing_docs allowed just like binaries or library crates. I was getting test failures because I didn't add it.
 **Clarification:** Add `#![allow(missing_docs)]` at the top of integration test files so they compile cleanly when `-D missing_docs` is used.
+
+## 2024-04-22 - Missing Examples in Sub-Modules
+**Confusion:** Functions inside internal models were not covered by missing_docs and lacked `# Examples` doctests, making their usage unclear.
+**Clarification:** Executable examples were explicitly added to inner methods on stores like `BytecodeCostStore` and `ExceptionFlowStore`.

--- a/crates/duke-interpreter/tests/coverage_bump.rs
+++ b/crates/duke-interpreter/tests/coverage_bump.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #[allow(dead_code)]
 #[allow(clippy::missing_const_for_fn)]
 const fn test() {

--- a/crates/duke-interpreter/tests/havoc_system_properties_loom.rs
+++ b/crates/duke-interpreter/tests/havoc_system_properties_loom.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use loom::sync::Mutex;
 use loom::thread;
 use std::collections::HashMap;

--- a/crates/duke-telemetry/src/bytecode_cost.rs
+++ b/crates/duke-telemetry/src/bytecode_cost.rs
@@ -69,6 +69,18 @@ impl BytecodeCostStore {
     /// - `method`: The name of the method currently executing.
     /// - `pc`: The program counter (instruction index) within the method.
     /// - `elapsed_ns`: How long the instruction took to execute, in nanoseconds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use duke_telemetry::BytecodeCostStore;
+    ///
+    /// let mut store = BytecodeCostStore::default();
+    /// store.record("iadd", "Math", "add", 0, 150);
+    ///
+    /// assert_eq!(store.by_opcode["iadd"].count, 1);
+    /// assert_eq!(store.by_opcode["iadd"].total_ns, 150);
+    /// ```
     pub fn record(
         &mut self,
         name: &'static str,

--- a/crates/duke-telemetry/src/class_init_dag.rs
+++ b/crates/duke-telemetry/src/class_init_dag.rs
@@ -62,6 +62,16 @@ impl ClassInitDagStore {
     /// - `class`: The JVM name of the class that was initialized.
     /// - `triggered_by`: The name of the class whose execution triggered this initialization.
     /// - `duration_ns`: Total time spent executing the `<clinit>` method.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use duke_telemetry::ClassInitDagStore;
+    ///
+    /// let mut store = ClassInitDagStore::default();
+    /// store.record("java/lang/String", "java/lang/System", 500);
+    /// assert_eq!(store.events.len(), 1);
+    /// ```
     pub fn record(&mut self, class: &str, triggered_by: &str, duration_ns: u64) {
         self.events.push(ClinitEvent {
             class: class.to_string(),
@@ -71,6 +81,17 @@ impl ClassInitDagStore {
     }
 
     /// Export the initialization DAG to a Graphviz DOT format string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use duke_telemetry::ClassInitDagStore;
+    ///
+    /// let mut store = ClassInitDagStore::default();
+    /// store.record("java/lang/String", "java/lang/System", 500);
+    /// let dot = store.to_dot();
+    /// assert!(dot.contains("digraph ClassInitDag"));
+    /// ```
     #[must_use]
     pub fn to_dot(&self) -> String {
         use std::fmt::Write;
@@ -94,6 +115,17 @@ impl ClassInitDagStore {
     }
 
     /// Export the initialization DAG to a Mermaid flowchart string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use duke_telemetry::ClassInitDagStore;
+    ///
+    /// let mut store = ClassInitDagStore::default();
+    /// store.record("java/lang/String", "java/lang/System", 500);
+    /// let mermaid = store.to_mermaid();
+    /// assert!(mermaid.contains("graph TD;"));
+    /// ```
     #[must_use]
     pub fn to_mermaid(&self) -> String {
         use std::fmt::Write;

--- a/crates/duke-telemetry/src/dispatch_resolution.rs
+++ b/crates/duke-telemetry/src/dispatch_resolution.rs
@@ -76,6 +76,19 @@ impl DispatchResolutionStore {
     /// - `resolved_class`: The actual runtime class of the receiver object.
     /// - `hierarchy_walk`: True if the method implementation was found by walking
     ///   up the superclass chain; false if it was found directly on `resolved_class`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use duke_telemetry::DispatchResolutionStore;
+    ///
+    /// let mut store = DispatchResolutionStore::default();
+    /// store.record("Foo", 42, "SubA", true);
+    ///
+    /// let stat = &store.by_site[&("Foo".to_string(), 42)];
+    /// assert_eq!(stat.calls, 1);
+    /// assert_eq!(stat.hierarchy_walks, 1);
+    /// ```
     pub fn record(
         &mut self,
         caller_class: &str,

--- a/crates/duke-telemetry/src/exception_flow.rs
+++ b/crates/duke-telemetry/src/exception_flow.rs
@@ -66,6 +66,17 @@ impl ExceptionFlowStore {
     /// - `throw_class`: The class executing the `athrow` instruction.
     /// - `throw_method`: The method executing the `athrow` instruction.
     /// - `throw_pc`: Program counter of the `athrow` instruction.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use duke_telemetry::ExceptionFlowStore;
+    ///
+    /// let mut store = ExceptionFlowStore::default();
+    /// let idx = store.record_throw("Exception", "Main", "run", 10);
+    /// assert_eq!(idx, 0);
+    /// assert_eq!(store.events[0].exception_class, "Exception");
+    /// ```
     pub fn record_throw(
         &mut self,
         exception_class: &str,
@@ -88,6 +99,18 @@ impl ExceptionFlowStore {
     /// - `catch_class`: The class where the exception handler matched.
     /// - `catch_method`: The method where the exception handler matched.
     /// - `handler_pc`: The starting program counter of the exception handler block.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use duke_telemetry::ExceptionFlowStore;
+    ///
+    /// let mut store = ExceptionFlowStore::default();
+    /// let idx = store.record_throw("Exception", "Main", "run", 10);
+    /// store.record_catch(idx, "Main", "run", 20);
+    ///
+    /// assert_eq!(store.events[0].catch_site.as_ref().unwrap().2, 20);
+    /// ```
     pub fn record_catch(
         &mut self,
         event_idx: usize,

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -120,9 +120,13 @@ impl TelemetryStore {
     /// use duke_telemetry::TelemetryStore;
     ///
     /// let mut store = TelemetryStore::default();
+    /// store.bytecode_cost.record("iadd", "Foo", "bar", 10, 100);
     /// let mut buf = Vec::<u8>::new();
-    /// #[cfg(feature = "telemetry")]
     /// store.print_report(&mut buf).unwrap();
+    ///
+    /// let output = String::from_utf8(buf).unwrap();
+    /// assert!(output.contains("=== Duke VM Telemetry Report ==="));
+    /// assert!(output.contains("iadd"));
     /// ```
     pub fn print_report(&self, w: &mut dyn std::io::Write) -> std::io::Result<()> {
         writeln!(w, "=== Duke VM Telemetry Report ===")?;
@@ -211,6 +215,20 @@ impl TelemetryStore {
     ///
     /// This exporter provides a GitHub-flavored Markdown representation of the telemetry
     /// data, making it easy to paste into PRs or issues for performance analysis.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use duke_telemetry::TelemetryStore;
+    ///
+    /// let mut store = TelemetryStore::default();
+    /// store.bytecode_cost.record("iadd", "Foo", "bar", 10, 100);
+    /// store.class_init_dag.record("java/lang/String", "java/lang/System", 500);
+    ///
+    /// let md = store.to_markdown_report();
+    /// assert!(md.contains("# Duke VM Telemetry Report"));
+    /// assert!(md.contains("java/lang/System"));
+    /// ```
     #[must_use]
     #[allow(clippy::too_many_lines)]
     pub fn to_markdown_report(&self) -> String {

--- a/crates/duke-telemetry/src/native_boundary.rs
+++ b/crates/duke-telemetry/src/native_boundary.rs
@@ -67,6 +67,19 @@ impl NativeBoundaryStore {
     /// - `method`: The name of the native method.
     /// - `elapsed_ns`: How long the native execution took, in nanoseconds.
     /// - `is_err`: True if the method failed (e.g., returned a `VmError` or threw an exception).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use duke_telemetry::NativeBoundaryStore;
+    ///
+    /// let mut store = NativeBoundaryStore::default();
+    /// store.record_call("System", "exit", 100, false);
+    ///
+    /// let stat = &store.by_method[&("System".to_string(), "exit".to_string())];
+    /// assert_eq!(stat.calls, 1);
+    /// assert_eq!(stat.total_ns, 100);
+    /// ```
     pub fn record_call(&mut self, class: &str, method: &str, elapsed_ns: u64, is_err: bool) {
         let stat = self
             .by_method

--- a/crates/duke-telemetry/src/object_lineage.rs
+++ b/crates/duke-telemetry/src/object_lineage.rs
@@ -66,6 +66,18 @@ impl ObjectLineageStore {
     /// - `method`: The method executing the `new` instruction.
     /// - `pc`: Program counter of the allocation site.
     /// - `class_allocated`: The class name of the instantiated object.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use duke_telemetry::ObjectLineageStore;
+    ///
+    /// let mut store = ObjectLineageStore::default();
+    /// store.record("Main", "run", 5, "java/lang/String");
+    ///
+    /// let site = &store.sites[&("Main".to_string(), "run".to_string(), 5)];
+    /// assert_eq!(site.count, 1);
+    /// ```
     pub fn record(
         &mut self,
         allocating_class: &str,


### PR DESCRIPTION
📖 Chapter: The `TelemetryStore` and its sub-stores.
🔦 Insight: Inner store methods lacked executable examples, making the usage of specific telemetry features (like object lineage and exception tracking) unclear.
🧪 Example: Added 8 executable doctests across `lib.rs`, `bytecode_cost.rs`, `class_init_dag.rs`, `dispatch_resolution.rs`, `exception_flow.rs`, `native_boundary.rs`, and `object_lineage.rs`.
🖼️ Preview: Documentation examples now compile and render with `cargo doc`.

---
*PR created automatically by Jules for task [530011191888134507](https://jules.google.com/task/530011191888134507) started by @madmax983*