### PR TITLE
⚒️ Forge: Fix SwitchTargets test comparisons

### DIFF
--- a/crates/duke-bytecode/src/instruction.rs
+++ b/crates/duke-bytecode/src/instruction.rs
@@ -1055,21 +1055,26 @@ mod tests {
             high: 12,
             offsets: vec![100, 200, 300],
         };
+        let targets = tableswitch.switch_targets();
+        assert!(targets.is_some());
+        let (default, iter) = targets.unwrap();
+        assert_eq!(default, 5);
         assert_eq!(
-            tableswitch.switch_targets(),
-            Some((5, vec![(10, 100), (11, 200), (12, 300)]))
+            iter.collect::<Vec<_>>(),
+            vec![(10, 100), (11, 200), (12, 300)]
         );
 
         let lookupswitch = Instruction::Lookupswitch {
             default: 5,
             pairs: vec![(10, 100), (20, 200)],
         };
-        assert_eq!(
-            lookupswitch.switch_targets(),
-            Some((5, vec![(10, 100), (20, 200)]))
-        );
+        let targets = lookupswitch.switch_targets();
+        assert!(targets.is_some());
+        let (default, iter) = targets.unwrap();
+        assert_eq!(default, 5);
+        assert_eq!(iter.collect::<Vec<_>>(), vec![(10, 100), (20, 200)]);
 
-        assert_eq!(Instruction::Iconst0.switch_targets(), None);
+        assert!(Instruction::Iconst0.switch_targets().is_none());
     }
 
     #[test]


### PR DESCRIPTION
🚮 Smell: The test_switch_targets test was attempting to assert equality between Option<(i32, SwitchTargets<'_>)> and Option<(i32, Vec<(i32, i32)>)>, which fails to compile.
✨ Solution: Refactored the test to use explicit assertions on the unpacked default value and the collected iterator output.
🧼 Benefit: Resolves compiler errors while avoiding unnecessary #[derive] additions to the public enum.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [9205125008490364778](https://jules.google.com/task/9205125008490364778) started by @madmax983*