### PR TITLE
⚒️ Forge: Extract Basic Block Leader Discovery

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -45,3 +45,7 @@
 **Extract Subroutine Matchers**
 **Learning:** `crates/duke-bytecode/src/cfg.rs` contained duplicated inline `matches!(instr, Instruction::Jsr(_) | Instruction::JsrW(_))` boilerplate which cluttered logic and hid intent.
 **Action:** Extract categorization logic into cleanly named helper methods directly on the enum (e.g., `is_subroutine_call()`) to DRY up matching code and flatten the calling modules.
+
+**Extract Basic Block Leader Discovery**
+**Learning:** `build_basic_blocks` in `crates/duke-bytecode/src/basic_block.rs` mixed leader discovery logic with block chunking logic, resulting in a large, hard-to-read function that required `clippy::too_many_lines` suppression.
+**Action:** Extract the complex leader discovery loop into a strictly-typed helper function (`find_leaders`) to separate the algorithmic phases, flatten the main function, and remove the need for linter suppressions.

--- a/crates/duke-bytecode/src/basic_block.rs
+++ b/crates/duke-bytecode/src/basic_block.rs
@@ -64,46 +64,14 @@ pub struct BasicBlock {
 /// assert_eq!(blocks[1].start_pc, 4); // Contains Iconst1, Ireturn
 /// assert_eq!(blocks[2].start_pc, 6); // Contains Iconst2, Ireturn
 /// ```
-#[allow(
-    clippy::cast_possible_wrap,
-    clippy::cast_sign_loss,
-    clippy::too_many_lines
-)]
+#[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
 #[must_use]
 pub fn build_basic_blocks(instructions: &[(usize, Instruction)]) -> Vec<BasicBlock> {
     if instructions.is_empty() {
         return Vec::new();
     }
 
-    let mut leaders = BTreeSet::new();
-
-    // Rule 1: The first instruction is always a leader.
-    leaders.insert(instructions[0].0);
-
-    for (i, (pc, instr)) in instructions.iter().enumerate() {
-        let is_branch_or_return = if let Some(offset) = instr.conditional_branch_target() {
-            leaders.insert((*pc as isize + offset) as usize);
-            true
-        } else if let Some(offset) = instr.unconditional_jump_target() {
-            leaders.insert((*pc as isize + offset) as usize);
-            true
-        } else if instr.is_return() {
-            true
-        } else if let Some((default, pairs)) = instr.switch_targets() {
-            leaders.insert((*pc as isize + default as isize) as usize);
-            for (_, offset) in pairs {
-                leaders.insert((*pc as isize + offset as isize) as usize);
-            }
-            true
-        } else {
-            false
-        };
-
-        if is_branch_or_return && i + 1 < instructions.len() {
-            // Rule 3: The instruction immediately following a branch/return is a leader.
-            leaders.insert(instructions[i + 1].0);
-        }
-    }
+    let leaders = find_leaders(instructions);
 
     let mut blocks = Vec::with_capacity(leaders.len());
     let mut current_start_pc = instructions[0].0;
@@ -134,6 +102,43 @@ pub fn build_basic_blocks(instructions: &[(usize, Instruction)]) -> Vec<BasicBlo
     }
 
     blocks
+}
+
+#[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+fn find_leaders(instructions: &[(usize, Instruction)]) -> BTreeSet<usize> {
+    let mut leaders = BTreeSet::new();
+    if instructions.is_empty() {
+        return leaders;
+    }
+
+    // Rule 1: The first instruction is always a leader.
+    leaders.insert(instructions[0].0);
+
+    for (i, (pc, instr)) in instructions.iter().enumerate() {
+        let is_branch_or_return = if let Some(offset) = instr.conditional_branch_target() {
+            leaders.insert((*pc as isize + offset) as usize);
+            true
+        } else if let Some(offset) = instr.unconditional_jump_target() {
+            leaders.insert((*pc as isize + offset) as usize);
+            true
+        } else if instr.is_return() {
+            true
+        } else if let Some((default, pairs)) = instr.switch_targets() {
+            leaders.insert((*pc as isize + default as isize) as usize);
+            for (_, offset) in pairs {
+                leaders.insert((*pc as isize + offset as isize) as usize);
+            }
+            true
+        } else {
+            false
+        };
+
+        if is_branch_or_return && i + 1 < instructions.len() {
+            // Rule 3: The instruction immediately following a branch/return is a leader.
+            leaders.insert(instructions[i + 1].0);
+        }
+    }
+    leaders
 }
 
 #[cfg(test)]


### PR DESCRIPTION
* 🚮 **Smell:** `build_basic_blocks` in `crates/duke-bytecode/src/basic_block.rs` mixed two distinct algorithmic phases (finding block leaders vs generating block chunks) in one function, resulting in a "God Function" needing `clippy::too_many_lines` suppression.
* ✨ **Solution:** Extracted the leader discovery loop into a private helper function `find_leaders`. Updated `build_basic_blocks` to call this helper.
* 🧼 **Benefit:** Dramatically flattens the code, explicitly separates discovery from aggregation, improves cognitive readability, and naturally eliminated the need for linter suppressions.
* 🛡️ **Verification:** `cargo fmt`, `cargo clippy`, and `cargo test` all passed. No behavioral logic was changed.

---
*PR created automatically by Jules for task [1615487233536202896](https://jules.google.com/task/1615487233536202896) started by @madmax983*