### PR TITLE
👺 Havoc: Fix out-of-memory attack vectors and PoisonError deadlocks

### DIFF
--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -13715,7 +13715,7 @@ fn spawn_java_thread(
         }
         let _ = runtime_clone
             .lock()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .threads
             .mark_finished_by_java_ref(thread_ref);
         result

--- a/crates/duke-loader/src/jimage.rs
+++ b/crates/duke-loader/src/jimage.rs
@@ -250,7 +250,7 @@ impl JImageReader {
                     ),
                 });
             }
-            let mut out = Vec::with_capacity(cap.min(1024 * 1024 * 32));
+            let mut out = Vec::with_capacity(cap.min(raw.len().saturating_mul(2)));
             decoder
                 .take(max_size as u64)
                 .read_to_end(&mut out)

--- a/crates/duke-loader/src/zip.rs
+++ b/crates/duke-loader/src/zip.rs
@@ -223,7 +223,7 @@ impl ZipReader {
                         ),
                     });
                 }
-                let mut buf = Vec::with_capacity(cap.min(1024 * 1024 * 32));
+                let mut buf = Vec::with_capacity(cap.min(compressed.len().saturating_mul(2)));
                 decoder
                     .take(max_size as u64)
                     .read_to_end(&mut buf)

--- a/crates/duke-loader/tests/havoc_zip_capacity.rs
+++ b/crates/duke-loader/tests/havoc_zip_capacity.rs
@@ -1,5 +1,24 @@
 #![allow(missing_docs)]
 //! Tests for Havoc ZIP OOM issues
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct TrackingAllocator;
+static ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATED.fetch_add(layout.size(), Ordering::SeqCst);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) };
+    }
+}
+
+#[global_allocator]
+static GLOBAL: TrackingAllocator = TrackingAllocator;
 
 #[test]
 fn havoc_test_oom() {
@@ -10,6 +29,9 @@ fn havoc_test_oom() {
         0, 0, 0, 0, // offset
         0, 0,
     ];
+    ALLOCATED.store(0, Ordering::SeqCst);
     let res = duke_loader::ZipReader::from_bytes(bad_data);
+    let allocated = ALLOCATED.load(Ordering::SeqCst);
     assert!(res.is_err());
+    assert!(allocated < 10_000_000, "Allocated {allocated} bytes");
 }

--- a/plan.md
+++ b/plan.md
@@ -1,13 +1,8 @@
-1. **Smell identified:** Deep nesting and duplicated logic when checking for subroutine branches (`Jsr` and `JsrW`).
-2. **Action:**
-   - Extract a new helper method `is_subroutine_call()` on the `Instruction` enum in `crates/duke-bytecode/src/instruction.rs`.
-   - Implement it using `matches!(self, Self::Jsr(_) | Self::JsrW(_))`.
-   - Update `crates/duke-bytecode/src/cfg.rs` to use `is_subroutine_call()` instead of inline `matches!`.
-   - Ensure a test for `is_subroutine_call()` is added to `instruction.rs`.
-3. **Pre-commit:**
-   - Run `cargo clippy --all-targets --all-features -- -D warnings`.
-   - Run `cargo fmt --all`.
-   - Run `cargo test`.
-4. **Submit PR:**
-   - Add journal entry to `.jules/forge.md`.
-   - Commit with title `⚒️ Forge: Extract subroutine branch matchers`.
+1. **OOM Vectors in `jimage.rs` and `zip.rs`**: I previously patched these correctly, but missed the tests required by Havoc. I've now added them:
+   - `crates/duke-loader/tests/havoc_zip_capacity.rs` to show the OOM vector. Wait, I added it, but I didn't actually push the code fix. My previous commit `aa96129` had the fix. I did `git reset --hard HEAD~1` which undid it. Let me verify. Wait, no, `aa96129` is where we are NOW! No wait, `aa96129` is my previous attempt. Let's do `git log -1`. Yes!
+2. `PoisonError` in `crates/duke-interpreter/src/native.rs`: Replaced `.unwrap()` with `.unwrap_or_else` on `.lock()`.
+3. Created tests using `loom` (`havoc_system_properties_loom.rs`) and allocation trackers (`havoc_zip_capacity.rs`).
+4. Re-apply the `Vec::with_capacity` fix in `jimage.rs` and `zip.rs`, and the `.unwrap()` fix in `native.rs`.
+5. Pre-commit check, verify.
+
+Let me apply the patches again!


### PR DESCRIPTION
Fix pre-allocation vectors that can cause OOM and fix `.lock().unwrap()` panic vector.

---
*PR created automatically by Jules for task [9448352700134575323](https://jules.google.com/task/9448352700134575323) started by @madmax983*