### PR TITLE
⚒️ Forge: Extract central directory entry parser

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -45,3 +45,7 @@
 **Extract Subroutine Matchers**
 **Learning:** `crates/duke-bytecode/src/cfg.rs` contained duplicated inline `matches!(instr, Instruction::Jsr(_) | Instruction::JsrW(_))` boilerplate which cluttered logic and hid intent.
 **Action:** Extract categorization logic into cleanly named helper methods directly on the enum (e.g., `is_subroutine_call()`) to DRY up matching code and flatten the calling modules.
+
+**Extract Central Directory Parser**
+**Learning:** `parse_central_directory` inside `crates/duke-loader/src/zip.rs` contained a massive loop (70+ lines) unpacking and validating the fields of every single central directory entry. This logic caused the method to become deeply nested and bloated, violating the "God Function" smell and making it harder to read the overarching parsing loop.
+**Action:** Extracted the core loop logic into a helper function `parse_central_directory_entry`, flattening the loop into just a few lines. Always extract complex per-item decoding from parsing loops.

--- a/crates/duke-loader/src/zip.rs
+++ b/crates/duke-loader/src/zip.rs
@@ -480,6 +480,73 @@ fn parse_eocd_and_central_directory(
     parse_central_directory(data, cd_offset, cd_size, entry_count)
 }
 
+/// Parse a single central directory entry.
+fn parse_central_directory_entry(
+    data: &[u8],
+    pos: usize,
+    cd_end: usize,
+) -> LoadResult<(ZipEntryInfo, usize)> {
+    // Each central directory header is at least 46 bytes.
+    if pos.checked_add(46).is_none_or(|end| end > cd_end) {
+        return Err(LoadError::ZipFormat {
+            msg: "central directory entry truncated".to_string(),
+        });
+    }
+    let sig = read_u32_le(data, pos);
+    if sig != CD_SIGNATURE {
+        return Err(LoadError::ZipFormat {
+            msg: format!("expected central directory signature at offset {pos}, got {sig:#010x}"),
+        });
+    }
+
+    let compression_method = read_u16_le(data, pos + 10);
+    let crc32 = read_u32_le(data, pos + 16);
+    let compressed_size = u64::from(read_u32_le(data, pos + 20));
+    let uncompressed_size = u64::from(read_u32_le(data, pos + 24));
+    let filename_len = usize::from(read_u16_le(data, pos + 28));
+    let extra_len = usize::from(read_u16_le(data, pos + 30));
+    let comment_len = usize::from(read_u16_le(data, pos + 32));
+    let local_header_offset = u64::from(read_u32_le(data, pos + 42));
+
+    let name_start = pos + 46;
+    if name_start
+        .checked_add(filename_len)
+        .is_none_or(|end| end > cd_end)
+    {
+        return Err(LoadError::ZipFormat {
+            msg: "central directory entry filename truncated".to_string(),
+        });
+    }
+
+    let name = String::from_utf8_lossy(&data[name_start..name_start + filename_len]).into_owned();
+
+    let next_pos = name_start
+        .checked_add(filename_len)
+        .and_then(|v| v.checked_add(extra_len))
+        .and_then(|v| v.checked_add(comment_len))
+        .ok_or_else(|| LoadError::ZipFormat {
+            msg: "central directory entry length overflow".to_string(),
+        })?;
+
+    if next_pos > cd_end {
+        return Err(LoadError::ZipFormat {
+            msg: "central directory entry extends past CD bounds".to_string(),
+        });
+    }
+
+    Ok((
+        ZipEntryInfo {
+            name,
+            compression_method,
+            crc32,
+            compressed_size,
+            uncompressed_size,
+            local_header_offset,
+        },
+        next_pos,
+    ))
+}
+
 /// Parse central directory entries into a `HashMap`.
 fn parse_central_directory(
     data: &[u8],
@@ -493,68 +560,9 @@ fn parse_central_directory(
     let mut pos = cd_offset;
 
     for _ in 0..expected_count {
-        // Each central directory header is at least 46 bytes.
-        if pos.checked_add(46).is_none_or(|end| end > cd_end) {
-            return Err(LoadError::ZipFormat {
-                msg: "central directory entry truncated".to_string(),
-            });
-        }
-        let sig = read_u32_le(data, pos);
-        if sig != CD_SIGNATURE {
-            return Err(LoadError::ZipFormat {
-                msg: format!(
-                    "expected central directory signature at offset {pos}, got {sig:#010x}"
-                ),
-            });
-        }
-
-        let compression_method = read_u16_le(data, pos + 10);
-        let crc32 = read_u32_le(data, pos + 16);
-        let compressed_size = u64::from(read_u32_le(data, pos + 20));
-        let uncompressed_size = u64::from(read_u32_le(data, pos + 24));
-        let filename_len = usize::from(read_u16_le(data, pos + 28));
-        let extra_len = usize::from(read_u16_le(data, pos + 30));
-        let comment_len = usize::from(read_u16_le(data, pos + 32));
-        let local_header_offset = u64::from(read_u32_le(data, pos + 42));
-
-        let name_start = pos + 46;
-        if name_start
-            .checked_add(filename_len)
-            .is_none_or(|end| end > cd_end)
-        {
-            return Err(LoadError::ZipFormat {
-                msg: "central directory entry filename truncated".to_string(),
-            });
-        }
-
-        let name =
-            String::from_utf8_lossy(&data[name_start..name_start + filename_len]).into_owned();
-
-        index.insert(
-            name.clone(),
-            ZipEntryInfo {
-                name,
-                compression_method,
-                crc32,
-                compressed_size,
-                uncompressed_size,
-                local_header_offset,
-            },
-        );
-
-        pos = name_start
-            .checked_add(filename_len)
-            .and_then(|v| v.checked_add(extra_len))
-            .and_then(|v| v.checked_add(comment_len))
-            .ok_or_else(|| LoadError::ZipFormat {
-                msg: "central directory entry length overflow".to_string(),
-            })?;
-
-        if pos > cd_end {
-            return Err(LoadError::ZipFormat {
-                msg: "central directory entry extends past CD bounds".to_string(),
-            });
-        }
+        let (entry, next_pos) = parse_central_directory_entry(data, pos, cd_end)?;
+        index.insert(entry.name.clone(), entry);
+        pos = next_pos;
     }
 
     Ok(index)


### PR DESCRIPTION
🚮 Smell: The `parse_central_directory` function inside `crates/duke-loader/src/zip.rs` contained a massive inline loop (70+ lines) responsible for validating bounds, checking signatures, reading headers, calculating lengths, and instantiating `ZipEntryInfo`. This deep nesting creates a "God Function" smell.
✨ Solution: Extracted the entire loop body into a strongly-typed helper function `parse_central_directory_entry` that returns the parsed entry and the next cursor position.
🧼 Benefit: Flattens the code, explicitly isolates parsing for a single entry from collection iteration, and vastly improves readability of the loop structure.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [641744795102242232](https://jules.google.com/task/641744795102242232) started by @madmax983*