### PR TITLE
🔭 Vantage: Spec for sun.misc.Unsafe (Concurrency Primitives)

### DIFF
--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -25424,13 +25424,13 @@ mod sentry_tests {
         let invalid_id = -999;
 
         let count_err = zip_entry_count(invalid_id).unwrap_err();
-        assert!(matches!(count_err, VmError::JavaException { ref class_name } if class_name == "java/io/IOException"));
+        assert!(matches!(count_err, Error::JavaException { ref class_name } if class_name == "java/io/IOException"));
 
         let info_err = zip_get_entry_info(invalid_id, "test").unwrap_err();
-        assert!(matches!(info_err, VmError::JavaException { ref class_name } if class_name == "java/io/IOException"));
+        assert!(matches!(info_err, Error::JavaException { ref class_name } if class_name == "java/io/IOException"));
 
         let read_err = zip_read_entry(invalid_id, "test").unwrap_err();
-        assert!(matches!(read_err, VmError::JavaException { ref class_name } if class_name == "java/io/IOException"));
+        assert!(matches!(read_err, Error::JavaException { ref class_name } if class_name == "java/io/IOException"));
 
         // This shouldn't panic
         zip_close(invalid_id);

--- a/docs/specs/vantage-spec-sun-misc-unsafe.md
+++ b/docs/specs/vantage-spec-sun-misc-unsafe.md
@@ -1,0 +1,26 @@
+# 🔭 Vantage: Spec for `sun.misc.Unsafe` (Concurrency Primitives)
+
+## 👤 User Story
+"As a Systems Engineer building high-throughput services on Duke, I want the VM to support `sun.misc.Unsafe` (or `jdk.internal.misc.Unsafe`), so that my application can leverage atomic operations, CAS (Compare-And-Swap), and concurrent data structures without locking overhead."
+
+## ❓ The "So What?"
+What business problem does this solve?
+Modern Java applications rely heavily on non-blocking concurrency (e.g., `java.util.concurrent.ConcurrentHashMap`, `AtomicInteger`, Netty). These standard library components depend entirely on the low-level intrinsic operations provided by `sun.misc.Unsafe`. Without supporting these intrinsics, Duke cannot run standard multi-threaded enterprise applications efficiently, and many libraries will simply fail to initialize. Implementing `Unsafe` is a critical path for supporting standard Java concurrency, maximizing CPU utilization, and proving Duke can handle real-world scale.
+
+## 📈 Metric Definition
+Success = A user can instantiate a `java.util.concurrent.atomic.AtomicInteger` and successfully execute `incrementAndGet()` from multiple threads concurrently without data races or JVM panics.
+
+## 🔍 Gap Analysis
+- **Current State:** Duke has basic threading support but lacks the low-level memory operations required by `java.util.concurrent`. Code attempting to use atomics or direct memory access fails because the native methods of `sun.misc.Unsafe` are unimplemented.
+- **Market/Standard Lib:** Standard JVMs implement `Unsafe` heavily as C/C++ intrinsics that map directly to CPU atomic instructions (e.g., `CMPXCHG` on x86).
+- **The Gap:** We need to implement the critical native methods of `sun.misc.Unsafe` (specifically `compareAndSwapInt`, `compareAndSwapObject`, `putObjectVolatile`, `getObjectVolatile`) bridging Java calls to atomic primitives on the underlying JVM data.
+
+## ✅ Acceptance Criteria
+- Must implement `sun.misc.Unsafe.compareAndSwapInt` leveraging atomic integer operations.
+- Must implement `sun.misc.Unsafe.compareAndSwapObject` leveraging thread-safe reference management.
+- Must support volatile read/write semantics for object fields (e.g., `getObjectVolatile`, `putObjectVolatile`).
+- Must handle the field offset logic (`objectFieldOffset`) correctly relative to Duke's internal object representation.
+
+## 🚫 Out of Scope
+- Complete implementation of every `Unsafe` method (e.g., direct off-heap memory allocation `allocateMemory` is not required for basic atomics).
+- Optimizing `Unsafe` calls into JIT-compiled inline assembly (this phase only requires interpreter-level atomic operations).


### PR DESCRIPTION
Adds a formal PM specification for implementing `sun.misc.Unsafe` primitives following the Vantage persona guidelines.

---
*PR created automatically by Jules for task [16758211575909833172](https://jules.google.com/task/16758211575909833172) started by @madmax983*