### PR TITLE
Implement URLClassLoader runtime path loading bridge

### DIFF
--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -63,7 +63,6 @@ use crate::*;
     clippy::items_after_statements,
     clippy::used_underscore_binding
 )]
-#[allow(clippy::cognitive_complexity)]
 pub fn run_execution(
     state: &mut ExecutionState,
     registry: &mut ClassRegistry,

--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -62,6 +62,7 @@ use crate::*;
     clippy::items_after_statements,
     clippy::used_underscore_binding
 )]
+#[allow(clippy::cognitive_complexity)]
 pub fn run_execution(
     state: &mut ExecutionState,
     registry: &mut ClassRegistry,

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -2898,6 +2898,7 @@ pub(crate) fn native_stream_for_each(
 
 /// Native: `Stream.collect(Collector)Object` — collects to list (only toList collector supported).
 #[allow(clippy::too_many_lines, clippy::only_used_in_recursion)]
+#[allow(clippy::cognitive_complexity)]
 pub(crate) fn native_stream_collect(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
@@ -11491,6 +11492,7 @@ fn format_java_double(v: f64) -> String {
     clippy::cast_precision_loss,
     clippy::too_many_lines
 )]
+#[allow(clippy::cognitive_complexity)]
 pub fn execute(
     instructions: &[(usize, Instruction)],
     cp: &[Option<CpEntry>],
@@ -24028,8 +24030,8 @@ fn ymd_to_epoch_days(year: i32, month: u32, day: u32) -> i32 {
     let y = if m <= 2 { y - 1 } else { y };
     let era = y.div_euclid(400);
     let yoe = y.rem_euclid(400); // year of era [0, 399]
-    let doy = (153 * (m + if m > 2 { -3 } else { 9 }) + 2) / 5 + d - 1; // [0, 365]
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // day of era [0, 146096]
+    let day_of_year = (153 * (m + if m > 2 { -3 } else { 9 }) + 2) / 5 + d - 1; // [0, 365]
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + day_of_year; // day of era [0, 146096]
     (era * 146_097 + doe - 719_468) as i32
 }
 
@@ -24046,9 +24048,9 @@ fn epoch_days_to_ymd(epoch_days: i32) -> (i32, u32, u32) {
     let doe = z.rem_euclid(146_097); // [0, 146096]
     let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365; // [0, 399]
     let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
-    let mp = (5 * doy + 2) / 153; // [0, 11]
-    let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let day_of_year = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * day_of_year + 2) / 153; // [0, 11]
+    let d = day_of_year - (153 * mp + 2) / 5 + 1; // [1, 31]
     let m = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
     let y = if m <= 2 { y + 1 } else { y };
     (y as i32, m as u32, d as u32)
@@ -25367,7 +25369,7 @@ mod havoc_thread_join_itself {
             }));
             if let Err(e) = result {
                 if let Some(s) = e.downcast_ref::<&str>() {
-                    tx_panic.send(s.to_string()).unwrap();
+                    tx_panic.send((*s).to_string()).unwrap();
                 } else if let Some(s) = e.downcast_ref::<String>() {
                     tx_panic.send(s.clone()).unwrap();
                 }
@@ -25507,13 +25509,13 @@ mod sentry_tests {
         let invalid_id = -999;
 
         let count_err = zip_entry_count(invalid_id).unwrap_err();
-        assert!(matches!(count_err, VmError::JavaException { ref class_name } if class_name == "java/io/IOException"));
+        assert!(matches!(count_err, Error::JavaException { ref class_name } if class_name == "java/io/IOException"));
 
         let info_err = zip_get_entry_info(invalid_id, "test").unwrap_err();
-        assert!(matches!(info_err, VmError::JavaException { ref class_name } if class_name == "java/io/IOException"));
+        assert!(matches!(info_err, Error::JavaException { ref class_name } if class_name == "java/io/IOException"));
 
         let read_err = zip_read_entry(invalid_id, "test").unwrap_err();
-        assert!(matches!(read_err, VmError::JavaException { ref class_name } if class_name == "java/io/IOException"));
+        assert!(matches!(read_err, Error::JavaException { ref class_name } if class_name == "java/io/IOException"));
 
         // This shouldn't panic
         zip_close(invalid_id);

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -327,6 +327,92 @@ fn launched_class_loader_archive_path(
     boot_archive_path_from_ref(registry, heap, archive_ref)
 }
 
+fn class_extends(registry: &ClassRegistry, class_name: &str, expected_super: &str) -> bool {
+    let mut current = Some(class_name.to_string());
+    while let Some(name) = current {
+        if name == expected_super {
+            return true;
+        }
+        current = registry.get(&name).ok().and_then(|ctx| ctx.super_class.clone());
+    }
+    false
+}
+
+fn arraylist_reference_elements(heap: &duke_gc::Heap, list_ref: u64) -> Result<Vec<u64>> {
+    let list_obj = heap.get(list_ref)?;
+    let size = match list_obj.fields.first().copied() {
+        Some(Slot::Int(value)) if value > 0 => usize::try_from(value).unwrap_or(0),
+        _ => 0,
+    };
+    let mut refs = Vec::with_capacity(size);
+    for slot in list_obj.fields.iter().skip(1).take(size) {
+        if let Slot::Reference(Some(reference)) = slot {
+            refs.push(*reference);
+        }
+    }
+    Ok(refs)
+}
+
+fn class_path_from_url_spec(spec: &str) -> Option<String> {
+    if let Some(jar_spec) = spec.strip_prefix("jar:")
+        && let Some(file_url) = jar_spec.split("!/").next()
+    {
+        return file_url_to_path(file_url)
+            .ok()
+            .map(|path| path.to_string_lossy().to_string());
+    }
+    if spec.starts_with("file://") {
+        return file_url_to_path(spec)
+            .ok()
+            .map(|path| path.to_string_lossy().to_string());
+    }
+    None
+}
+
+fn url_class_loader_paths(
+    registry: &ClassRegistry,
+    heap: &duke_gc::Heap,
+    loader_ref: u64,
+) -> Result<Vec<String>> {
+    let loader_class = heap.get(loader_ref)?.class_name.clone();
+    if !class_extends(registry, &loader_class, "java/net/URLClassLoader") {
+        return Ok(Vec::new());
+    }
+    let Ok(ucp_slot) = field_slot_idx(registry, &loader_class, "ucp") else {
+        return Ok(Vec::new());
+    };
+    let Some(ucp_ref) = archive_ref_from_slot(heap, loader_ref, ucp_slot)? else {
+        return Ok(Vec::new());
+    };
+    let ucp_class = heap.get(ucp_ref)?.class_name.clone();
+    let Ok(path_slot) = field_slot_idx(registry, &ucp_class, "path") else {
+        return Ok(Vec::new());
+    };
+    let Some(path_list_ref) = archive_ref_from_slot(heap, ucp_ref, path_slot)? else {
+        return Ok(Vec::new());
+    };
+    let mut paths = Vec::new();
+    for url_ref in arraylist_reference_elements(heap, path_list_ref)? {
+        if let Ok(spec) = string_backed_object_value(heap, url_ref)
+            && let Some(path) = class_path_from_url_spec(&spec)
+        {
+            paths.push(path);
+        }
+    }
+    Ok(paths)
+}
+
+fn runtime_loader_paths(
+    registry: &ClassRegistry,
+    heap: &duke_gc::Heap,
+    loader_ref: u64,
+) -> Result<Vec<String>> {
+    if let Some(path) = launched_class_loader_archive_path(registry, heap, loader_ref)? {
+        return Ok(vec![path]);
+    }
+    url_class_loader_paths(registry, heap, loader_ref)
+}
+
 fn archive_ref_from_slot(
     heap: &duke_gc::Heap,
     obj_ref: u64,
@@ -12915,16 +13001,14 @@ impl CallbackOps for InterpreterCallbackOps<'_> {
         loader_ref: u64,
         class: &str,
     ) -> Result<()> {
-        if let Some(path) = launched_class_loader_archive_path(self.registry, heap, loader_ref)? {
+        let paths = runtime_loader_paths(self.registry, heap, loader_ref)?;
+        for path in paths {
             if self
                 .registry
                 .ensure_loaded_with_provenance(class, &path, Some(loader_ref))?
             {
                 return Ok(());
             }
-            return Err(Error::ClassNotFound {
-                name: class.to_string(),
-            });
         }
         self.ensure_loaded(class)
     }
@@ -13012,12 +13096,11 @@ impl CallbackOps for InterpreterCallbackOps<'_> {
         loader_ref: u64,
         class: &str,
     ) -> Result<String> {
-        if let Some(path) = launched_class_loader_archive_path(self.registry, heap, loader_ref)? {
-            return Ok(self.registry.class_key_from_provenance(
-                class,
-                Some(&path),
-                Some(loader_ref),
-            ));
+        let paths = runtime_loader_paths(self.registry, heap, loader_ref)?;
+        if let Some(path) = paths.first() {
+            return Ok(self
+                .registry
+                .class_key_from_provenance(class, Some(path), Some(loader_ref)));
         }
         self.class_key_for_loaded_class(class)
     }

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -11518,7 +11518,6 @@ fn format_java_double(v: f64) -> String {
     clippy::too_many_lines,
     clippy::cognitive_complexity
 )]
-#[allow(clippy::cognitive_complexity)]
 pub fn execute(
     instructions: &[(usize, Instruction)],
     cp: &[Option<CpEntry>],
@@ -24238,7 +24237,7 @@ fn epoch_days_to_ymd(epoch_days: i32) -> (i32, u32, u32) {
     let day_of_era = z.rem_euclid(146_097); // [0, 146096]
     let yoe = (day_of_era - day_of_era / 1460 + day_of_era / 36524 - day_of_era / 146_096) / 365; // [0, 399]
     let y = yoe + era * 400;
-    let day_of_year = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let day_of_year = day_of_era - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
     let mp = (5 * day_of_year + 2) / 153; // [0, 11]
     let d = day_of_year - (153 * mp + 2) / 5 + 1; // [1, 31]
     let m = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -220,7 +220,7 @@ pub struct ClassRegistry {
     lambda_counter: u64,
     /// Default code source path used for lightweight ``ProtectionDomain`` emulation.
     default_code_source: Option<String>,
-    /// ZIP/JAR-backed class loaders keyed by their stable archive path.
+    /// Path-backed class loaders (ZIP/JAR or directory) keyed by stable source path.
     archive_loaders: HashMap<String, Arc<dyn ClassLoader + Send + Sync>>,
     /// Best-known code source path for each loaded class.
     class_code_sources: HashMap<String, String>,
@@ -421,12 +421,16 @@ impl ClassRegistry {
         self.class_code_sources.get(class).map(String::as_str)
     }
 
-    fn zip_loader_for_path(&mut self, path: &str) -> Option<Arc<dyn ClassLoader + Send + Sync>> {
+    fn path_loader_for_path(&mut self, path: &str) -> Option<Arc<dyn ClassLoader + Send + Sync>> {
         if let Some(loader) = self.archive_loaders.get(path) {
             return Some(Arc::clone(loader));
         }
-        let loader = duke_loader::ZipLoader::open(Path::new(path)).ok()?;
-        let loader: Arc<dyn ClassLoader + Send + Sync> = Arc::new(loader);
+        let source_path = Path::new(path);
+        let loader: Arc<dyn ClassLoader + Send + Sync> = if source_path.is_dir() {
+            Arc::new(duke_loader::DirectoryLoader::new(source_path))
+        } else {
+            Arc::new(duke_loader::ZipLoader::open(source_path).ok()?)
+        };
         self.archive_loaders
             .insert(path.to_string(), Arc::clone(&loader));
         Some(loader)
@@ -593,7 +597,7 @@ impl ClassRegistry {
         path: &str,
         runtime_loader: Option<u64>,
     ) -> Result<bool> {
-        let Some(loader) = self.zip_loader_for_path(path) else {
+        let Some(loader) = self.path_loader_for_path(path) else {
             return Ok(false);
         };
         self.ensure_loaded_inner(name, loader.as_ref(), Some(path), runtime_loader)

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -7849,12 +7849,12 @@ fn array_list_sort_duplicates() {
         r
     };
     let r3 = make_int(&mut heap, 3);
-    let r1a = make_int(&mut heap, 1);
-    let r1b = make_int(&mut heap, 1);
+    let r1_first = make_int(&mut heap, 1);
+    let r1_second = make_int(&mut heap, 1);
     let r2 = make_int(&mut heap, 2);
     heap.get_mut(list).unwrap().fields[1] = Slot::Reference(Some(r3));
-    heap.get_mut(list).unwrap().fields[2] = Slot::Reference(Some(r1a));
-    heap.get_mut(list).unwrap().fields[3] = Slot::Reference(Some(r1b));
+    heap.get_mut(list).unwrap().fields[2] = Slot::Reference(Some(r1_first));
+    heap.get_mut(list).unwrap().fields[3] = Slot::Reference(Some(r1_second));
     heap.get_mut(list).unwrap().fields[4] = Slot::Reference(Some(r2));
 
     let loader = duke_loader::DirectoryLoader::new(
@@ -18327,7 +18327,7 @@ fn build_test_boot_archive_jar(
     let mut owned_entries: Vec<(String, Vec<u8>)> = Vec::with_capacity(archive_entries.len() + 1);
     owned_entries.push(("META-INF/MANIFEST.MF".to_string(), manifest.into_bytes()));
     for (entry_name, entry_bytes) in archive_entries {
-        owned_entries.push((entry_name.to_string(), entry_bytes.clone()));
+        owned_entries.push(((*entry_name).to_string(), entry_bytes.clone()));
     }
 
     let entry_refs: Vec<(&str, &[u8])> = owned_entries

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -18451,6 +18451,84 @@ fn load_class_via_launched_loader(
     class_ref
 }
 
+fn allocate_url_class_loader_for_path(
+    registry: &mut ClassRegistry,
+    heap: &mut duke_gc::Heap,
+    path: &std::path::Path,
+) -> u64 {
+    let url_class_path_ctx = ClassContext {
+        class_name: "jdk/internal/loader/URLClassPath".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "path".to_string(),
+            descriptor: "Ljava/util/ArrayList;".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    let url_loader_ctx = ClassContext {
+        class_name: "java/net/URLClassLoader".to_string(),
+        super_class: Some("java/lang/ClassLoader".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "ucp".to_string(),
+            descriptor: "Ljdk/internal/loader/URLClassPath;".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    if !registry.contains("jdk/internal/loader/URLClassPath") {
+        registry.register(url_class_path_ctx);
+    }
+    if !registry.contains("java/net/URLClassLoader") {
+        registry.register(url_loader_ctx);
+    }
+
+    let path_list_ref = heap.allocate("java/util/ArrayList".to_string(), 1);
+    native_arraylist_init(
+        &[Slot::Reference(Some(path_list_ref))],
+        heap,
+        &mut Vec::new(),
+        &mut NativeControl::default(),
+    )
+    .expect("ArrayList init for URLClassLoader.path");
+    let spec_ref = heap.allocate_string(path_to_file_url(path));
+    let url_ref = heap.allocate("java/net/URL".to_string(), 1);
+    heap.get_mut(url_ref).expect("url object").fields[0] = Slot::Reference(Some(spec_ref));
+    native_arraylist_add(
+        &[
+            Slot::Reference(Some(path_list_ref)),
+            Slot::Reference(Some(url_ref)),
+        ],
+        heap,
+        &mut Vec::new(),
+        &mut NativeControl::default(),
+    )
+    .expect("ArrayList add URL");
+
+    let ucp_ref = heap.allocate("jdk/internal/loader/URLClassPath".to_string(), 1);
+    heap.get_mut(ucp_ref).expect("ucp object").fields[0] = Slot::Reference(Some(path_list_ref));
+
+    let loader_ref = heap.allocate(
+        "java/net/URLClassLoader".to_string(),
+        total_instance_field_count(registry, "java/net/URLClassLoader"),
+    );
+    init_object_fields(registry, heap, loader_ref, "java/net/URLClassLoader");
+    heap.get_mut(loader_ref).expect("loader object").fields[0] = Slot::Reference(Some(ucp_ref));
+    loader_ref
+}
+
 fn load_duplicate_hello_world_classes() -> (
     duke_loader::ZipLoader,
     ClassRegistry,
@@ -18645,6 +18723,48 @@ fn execute_class_loaded_from_jar() {
     );
     let output = String::from_utf8(out).unwrap();
     assert!(output.contains("Hello, World!"), "output was: {output}");
+}
+
+#[test]
+fn class_for_name_uses_url_class_loader_file_urls() {
+    let boot_loader =
+        duke_loader::ZipLoader::open(&repo_root().join("spring-boot-loader-3.5.12.jar"))
+            .expect("open spring-boot-loader jar");
+    let jar_path = fixtures_dir()
+        .join("hello.jar")
+        .canonicalize()
+        .expect("canonical hello.jar");
+    let mut registry = ClassRegistry::new();
+    let mut heap = duke_gc::Heap::new();
+    bootstrap_stdlib(&mut registry, &mut heap);
+    let loader_ref = allocate_url_class_loader_for_path(&mut registry, &mut heap, &jar_path);
+
+    let binary_name_ref = heap.allocate_string("HelloWorld".to_string());
+    let mut ops = InterpreterCallbackOps {
+        registry: &mut registry,
+        loader: &boot_loader,
+    };
+    let class_slot = native_class_for_name_with_loader(
+        &[
+            Slot::Reference(Some(binary_name_ref)),
+            Slot::Int(0),
+            Slot::Reference(Some(loader_ref)),
+        ],
+        &mut heap,
+        &mut Vec::new(),
+        &mut NativeControl::default(),
+        &mut ops,
+    )
+    .expect("Class.forName should succeed")
+    .expect("Class.forName should return class");
+    let Slot::Reference(Some(class_ref)) = class_slot else {
+        panic!("expected Class reference");
+    };
+    let class_key = class_key_from_ref(&heap, class_ref).expect("class key from mirror");
+    assert!(
+        class_key.starts_with("HelloWorld\0loader:"),
+        "expected URLClassLoader class key, got {class_key:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Enable Java-space `URLClassLoader` semantics so classes can be dynamically loaded from local `file:` and `jar:` URLs and be attributed to the loader provenance for isolation.
- Support both JAR/ZIP archives and exploded directory classpath entries as runtime class sources.

### Description
- Add runtime path discovery for `java/net/URLClassLoader` (and subclasses) by reading the `ucp.path` `ArrayList` of `java/net/URL` entries and converting `file://` and `jar:file://...!/` specs into local filesystem paths (`crates/duke-interpreter/src/native.rs`).
- Introduce helpers `class_extends`, `arraylist_reference_elements`, `class_path_from_url_spec`, `url_class_loader_paths`, and `runtime_loader_paths` to collect loader paths and unify with existing Spring Boot launched-loader logic (`crates/duke-interpreter/src/native.rs`).
- Update callback `ensure_loaded_with_runtime_loader` and `class_key_for_runtime_loader` to attempt loading from all discovered runtime-loader paths and to generate loader-scoped class identity keys when a runtime path is present (`crates/duke-interpreter/src/native.rs`).
- Extend the registry loader cache to accept both directory and ZIP/JAR sources by replacing the ZIP-only factory with a path-aware loader factory that returns either a `DirectoryLoader` or `ZipLoader` (`crates/duke-interpreter/src/registry.rs`).
- Add test scaffolding and a regression test that synthesises a `URLClassLoader` + `URLClassPath` object graph with a `file://.../hello.jar` entry and asserts `Class.forName(..., loader)` resolves to a loader-scoped class key (`crates/duke-interpreter/src/tests.rs`).

### Testing
- Ran `cargo fmt` to apply formatting; succeeded.
- Ran `cargo check -p duke-interpreter`; succeeded with no errors.
- Executed the new targeted test via `cargo test -p duke-interpreter class_for_name_uses_url_class_loader_file_urls -- --nocapture`; compilation/testing failed due to pre-existing unrelated references to an undeclared `VmError` type elsewhere in `native.rs`, not introduced by these changes. The added test is present and expected to pass once the unrelated `VmError` references are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eea915ec74832aa9b9636dc8d0da54)