### PR TITLE
Add RuntimeVisibleAnnotations parsing and reflection native stubs

### DIFF
--- a/crates/duke-classfile/src/attributes.rs
+++ b/crates/duke-classfile/src/attributes.rs
@@ -59,6 +59,44 @@ pub struct BootstrapMethodEntry {
     pub arguments: Vec<CpIndex>,
 }
 
+/// One parsed runtime annotation instance (§4.7.16.1).
+#[derive(Debug, Clone)]
+pub struct Annotation {
+    /// Type descriptor of the annotation (`type_index` in the class file).
+    pub type_index: CpIndex,
+    /// Named element value pairs declared on the annotation usage.
+    pub element_value_pairs: Vec<ElementValuePair>,
+}
+
+/// One `name=value` pair in an annotation usage (§4.7.16.1).
+#[derive(Debug, Clone)]
+pub struct ElementValuePair {
+    /// Constant pool index of the element (method) name in the annotation interface.
+    pub element_name_index: CpIndex,
+    /// Encoded value payload.
+    pub value: ElementValue,
+}
+
+/// Encoded annotation element value (§4.7.16.1).
+#[derive(Debug, Clone)]
+pub enum ElementValue {
+    /// Primitive/String constant pool reference.
+    ConstValueIndex(CpIndex),
+    /// Enum element value.
+    EnumConstValue {
+        /// Descriptor of enum type.
+        type_name_index: CpIndex,
+        /// Enum constant simple name.
+        const_name_index: CpIndex,
+    },
+    /// Class literal element (`Class<?>`).
+    ClassInfoIndex(CpIndex),
+    /// Nested annotation element.
+    AnnotationValue(Annotation),
+    /// Array element containing child element values.
+    ArrayValue(Vec<ElementValue>),
+}
+
 /// Typed attribute payload.
 #[derive(Debug, Clone)]
 pub enum AttributeData {
@@ -85,6 +123,8 @@ pub enum AttributeData {
     },
     /// `BootstrapMethods` attribute (§4.7.23) — required for invokedynamic.
     BootstrapMethods(Vec<BootstrapMethodEntry>),
+    /// `RuntimeVisibleAnnotations` (§4.7.16).
+    RuntimeVisibleAnnotations(Vec<Annotation>),
     /// Any attribute we don't parse in detail yet.
     Raw(Vec<u8>),
 }

--- a/crates/duke-classfile/src/attributes.rs
+++ b/crates/duke-classfile/src/attributes.rs
@@ -94,7 +94,7 @@ pub enum ElementValue {
     /// Nested annotation element.
     AnnotationValue(Annotation),
     /// Array element containing child element values.
-    ArrayValue(Vec<ElementValue>),
+    ArrayValue(Vec<Self>),
 }
 
 /// Typed attribute payload.

--- a/crates/duke-classfile/src/error.rs
+++ b/crates/duke-classfile/src/error.rs
@@ -122,6 +122,13 @@ pub enum Error {
         /// Actual number of bytes available.
         got: usize,
     },
+
+    /// An annotation element-value tag was unknown.
+    #[error("invalid annotation element-value tag {tag:#04X}")]
+    InvalidAnnotationElementValueTag {
+        /// Raw tag byte.
+        tag: u8,
+    },
 }
 
 /// Convenience alias.

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -3,8 +3,8 @@
 use crate::{
     access_flags::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags},
     attributes::{
-        AttributeData, AttributeInfo, BootstrapMethodEntry, CodeAttribute, ExceptionTableEntry,
-        LineNumberEntry, LocalVariableEntry,
+        Annotation, AttributeData, AttributeInfo, BootstrapMethodEntry, CodeAttribute,
+        ElementValue, ElementValuePair, ExceptionTableEntry, LineNumberEntry, LocalVariableEntry,
     },
     class::{ClassFile, FieldInfo, MethodInfo},
     constant_pool::{CpEntry, CpIndex},
@@ -430,6 +430,9 @@ fn decode_known_attribute(name: &str, raw: &[u8]) -> Result<AttributeData> {
             exception_index_table: decode_exceptions(&mut c)?,
         },
         "BootstrapMethods" => AttributeData::BootstrapMethods(decode_bootstrap_methods(&mut c)?),
+        "RuntimeVisibleAnnotations" => {
+            AttributeData::RuntimeVisibleAnnotations(decode_runtime_visible_annotations(&mut c)?)
+        }
         _ => AttributeData::Raw(raw.to_vec()),
     };
     Ok(data)
@@ -495,6 +498,55 @@ fn decode_bootstrap_methods(c: &mut Cursor<'_>) -> Result<Vec<BootstrapMethodEnt
         });
     }
     Ok(entries)
+}
+
+fn decode_runtime_visible_annotations(c: &mut Cursor<'_>) -> Result<Vec<Annotation>> {
+    let num_annotations = c.read_u16()? as usize;
+    let mut annotations = Vec::with_capacity(num_annotations.min(c.remaining() / 4));
+    for _ in 0..num_annotations {
+        annotations.push(decode_annotation(c)?);
+    }
+    Ok(annotations)
+}
+
+fn decode_annotation(c: &mut Cursor<'_>) -> Result<Annotation> {
+    let type_index = c.read_cp_index()?;
+    let num_pairs = c.read_u16()? as usize;
+    let mut element_value_pairs = Vec::with_capacity(num_pairs.min(c.remaining() / 3));
+    for _ in 0..num_pairs {
+        element_value_pairs.push(ElementValuePair {
+            element_name_index: c.read_cp_index()?,
+            value: decode_element_value(c)?,
+        });
+    }
+    Ok(Annotation {
+        type_index,
+        element_value_pairs,
+    })
+}
+
+fn decode_element_value(c: &mut Cursor<'_>) -> Result<ElementValue> {
+    let tag = c.read_u8()?;
+    match tag {
+        b'B' | b'C' | b'D' | b'F' | b'I' | b'J' | b'S' | b'Z' | b's' => {
+            Ok(ElementValue::ConstValueIndex(c.read_cp_index()?))
+        }
+        b'e' => Ok(ElementValue::EnumConstValue {
+            type_name_index: c.read_cp_index()?,
+            const_name_index: c.read_cp_index()?,
+        }),
+        b'c' => Ok(ElementValue::ClassInfoIndex(c.read_cp_index()?)),
+        b'@' => Ok(ElementValue::AnnotationValue(decode_annotation(c)?)),
+        b'[' => {
+            let num_values = c.read_u16()? as usize;
+            let mut values = Vec::with_capacity(num_values.min(c.remaining() / 3));
+            for _ in 0..num_values {
+                values.push(decode_element_value(c)?);
+            }
+            Ok(ElementValue::ArrayValue(values))
+        }
+        _ => Err(Error::InvalidAnnotationElementValueTag { tag }),
+    }
 }
 
 /// ⚡ Bolt: Pre-allocates vectors for known attribute table sizes to eliminate intermediate heap allocations.
@@ -611,5 +663,30 @@ mod tests {
         assert_eq!(cursor.remaining(), 3);
         cursor.read_u8().unwrap();
         assert_eq!(cursor.remaining(), 2);
+    }
+
+    #[test]
+    fn should_decode_runtime_visible_annotations_with_nested_values() {
+        let raw = [
+            0x00, 0x01, // num_annotations
+            0x00, 0x02, // annotation.type_index
+            0x00, 0x03, // num_element_value_pairs
+            0x00, 0x04, // pair #1 name index
+            b's', 0x00, 0x05, // const string value index
+            0x00, 0x06, // pair #2 name index
+            b'@', 0x00, 0x07, 0x00, 0x00, // nested annotation with no pairs
+            0x00, 0x08, // pair #3 name index
+            b'[', 0x00, 0x02, // array[2]
+            b'c', 0x00, 0x09, // class literal
+            b'e', 0x00, 0x0A, 0x00, 0x0B, // enum const
+        ];
+
+        let decoded = decode_known_attribute("RuntimeVisibleAnnotations", &raw).unwrap();
+        let AttributeData::RuntimeVisibleAnnotations(annotations) = decoded else {
+            panic!("expected RuntimeVisibleAnnotations");
+        };
+        assert_eq!(annotations.len(), 1);
+        assert_eq!(annotations[0].type_index, CpIndex(2));
+        assert_eq!(annotations[0].element_value_pairs.len(), 3);
     }
 }

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -6910,6 +6910,40 @@ pub(crate) fn native_class_get_fields(
     Ok(Some(Slot::Reference(Some(array_ref))))
 }
 
+fn allocate_empty_annotation_array(heap: &mut duke_gc::Heap) -> Result<Option<Slot>> {
+    let array_ref = allocate_reference_array(heap, "[Ljava/lang/annotation/Annotation;", &[])?;
+    Ok(Some(Slot::Reference(Some(array_ref))))
+}
+
+pub(crate) fn native_class_get_annotations(
+    _args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    allocate_empty_annotation_array(heap)
+}
+
+pub(crate) fn native_class_get_declared_annotations(
+    _args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    allocate_empty_annotation_array(heap)
+}
+
+pub(crate) fn native_class_get_annotation(
+    args: &[Slot],
+    _heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let _ = extract_ref_arg(args, 0)?;
+    let _ = extract_ref_arg(args, 1)?;
+    Ok(Some(Slot::Reference(None)))
+}
+
 pub(crate) fn native_reflect_method_get_name(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
@@ -6918,6 +6952,35 @@ pub(crate) fn native_reflect_method_get_name(
 ) -> Result<Option<Slot>> {
     let method_ref = extract_ref_arg(args, 0)?;
     Ok(Some(reflection_member_name_slot(heap, method_ref)?))
+}
+
+pub(crate) fn native_reflect_method_get_annotations(
+    _args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    allocate_empty_annotation_array(heap)
+}
+
+pub(crate) fn native_reflect_method_get_declared_annotations(
+    _args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    allocate_empty_annotation_array(heap)
+}
+
+pub(crate) fn native_reflect_method_get_annotation(
+    args: &[Slot],
+    _heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let _ = extract_ref_arg(args, 0)?;
+    let _ = extract_ref_arg(args, 1)?;
+    Ok(Some(Slot::Reference(None)))
 }
 
 pub(crate) fn native_reflect_constructor_get_name(
@@ -7029,6 +7092,35 @@ pub(crate) fn native_reflect_field_get_name(
 ) -> Result<Option<Slot>> {
     let field_ref = extract_ref_arg(args, 0)?;
     Ok(Some(reflection_member_name_slot(heap, field_ref)?))
+}
+
+pub(crate) fn native_reflect_field_get_annotations(
+    _args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    allocate_empty_annotation_array(heap)
+}
+
+pub(crate) fn native_reflect_field_get_declared_annotations(
+    _args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    allocate_empty_annotation_array(heap)
+}
+
+pub(crate) fn native_reflect_field_get_annotation(
+    args: &[Slot],
+    _heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let _ = extract_ref_arg(args, 0)?;
+    let _ = extract_ref_arg(args, 1)?;
+    Ok(Some(Slot::Reference(None)))
 }
 
 pub(crate) fn native_reflection_member_set_accessible(

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -25516,13 +25516,13 @@ mod sentry_tests {
         let invalid_id = -999;
 
         let count_err = zip_entry_count(invalid_id).unwrap_err();
-        assert!(matches!(count_err, VmError::JavaException { ref class_name } if class_name == "java/io/IOException"));
+        assert!(matches!(count_err, Error::JavaException { ref class_name } if class_name == "java/io/IOException"));
 
         let info_err = zip_get_entry_info(invalid_id, "test").unwrap_err();
-        assert!(matches!(info_err, VmError::JavaException { ref class_name } if class_name == "java/io/IOException"));
+        assert!(matches!(info_err, Error::JavaException { ref class_name } if class_name == "java/io/IOException"));
 
         let read_err = zip_read_entry(invalid_id, "test").unwrap_err();
-        assert!(matches!(read_err, VmError::JavaException { ref class_name } if class_name == "java/io/IOException"));
+        assert!(matches!(read_err, Error::JavaException { ref class_name } if class_name == "java/io/IOException"));
 
         // This shouldn't panic
         zip_close(invalid_id);

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -1164,6 +1164,24 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         "()[Ljava/lang/reflect/Constructor;",
         native_class_get_constructors,
     );
+    registry.natives_mut().register(
+        "java/lang/Class",
+        "getAnnotations",
+        "()[Ljava/lang/annotation/Annotation;",
+        native_class_get_annotations,
+    );
+    registry.natives_mut().register(
+        "java/lang/Class",
+        "getDeclaredAnnotations",
+        "()[Ljava/lang/annotation/Annotation;",
+        native_class_get_declared_annotations,
+    );
+    registry.natives_mut().register(
+        "java/lang/Class",
+        "getAnnotation",
+        "(Ljava/lang/Class;)Ljava/lang/annotation/Annotation;",
+        native_class_get_annotation,
+    );
     registry.natives_mut().register_callback(
         "java/lang/Class",
         "getDeclaredMethod",
@@ -1638,6 +1656,24 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         "()[Ljava/lang/Class;",
         native_reflect_executable_get_parameter_types,
     );
+    registry.natives_mut().register(
+        "java/lang/reflect/Method",
+        "getAnnotations",
+        "()[Ljava/lang/annotation/Annotation;",
+        native_reflect_method_get_annotations,
+    );
+    registry.natives_mut().register(
+        "java/lang/reflect/Method",
+        "getDeclaredAnnotations",
+        "()[Ljava/lang/annotation/Annotation;",
+        native_reflect_method_get_declared_annotations,
+    );
+    registry.natives_mut().register(
+        "java/lang/reflect/Method",
+        "getAnnotation",
+        "(Ljava/lang/Class;)Ljava/lang/annotation/Annotation;",
+        native_reflect_method_get_annotation,
+    );
 
     let reflect_constructor_ctx = ClassContext {
         class_name: "java/lang/reflect/Constructor".to_string(),
@@ -1799,6 +1835,24 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         "setAccessible",
         "(Z)V",
         native_reflection_member_set_accessible,
+    );
+    registry.natives_mut().register(
+        "java/lang/reflect/Field",
+        "getAnnotations",
+        "()[Ljava/lang/annotation/Annotation;",
+        native_reflect_field_get_annotations,
+    );
+    registry.natives_mut().register(
+        "java/lang/reflect/Field",
+        "getDeclaredAnnotations",
+        "()[Ljava/lang/annotation/Annotation;",
+        native_reflect_field_get_declared_annotations,
+    );
+    registry.natives_mut().register(
+        "java/lang/reflect/Field",
+        "getAnnotation",
+        "(Ljava/lang/Class;)Ljava/lang/annotation/Annotation;",
+        native_reflect_field_get_annotation,
     );
 
     let runnable_ctx = ClassContext {


### PR DESCRIPTION
### Motivation
- The classfile parser previously ignored runtime-visible annotation attributes, preventing frameworks from using reflection to discover annotation metadata at runtime. 
- Implement binary parsing of `RuntimeVisibleAnnotations` and provide a safe native reflection surface so the runtime can begin exposing annotation APIs without missing-native failures.

### Description
- Add classfile model types `Annotation`, `ElementValuePair`, and `ElementValue` and expose `AttributeData::RuntimeVisibleAnnotations` in `crates/duke-classfile/src/attributes.rs`.
- Extend attribute decoding in `crates/duke-classfile/src/parser.rs` to parse `RuntimeVisibleAnnotations` payloads (primitive/string consts, enum constants, class literals, nested annotations, arrays) and add a parser unit test for nested annotation payloads.
- Add a dedicated parse error variant `InvalidAnnotationElementValueTag` in `crates/duke-classfile/src/error.rs` and use it for unknown element-value tags.
- Wire reflection-side native stubs in `crates/duke-interpreter/src/native.rs` and register them in `crates/duke-interpreter/src/stdlib.rs` for `Class`, `Method`, and `Field` APIs (`getAnnotations`, `getDeclaredAnnotations`, `getAnnotation`); stubs currently return empty annotation arrays or `null` for typed lookups as a safe baseline.

### Testing
- Ran `cargo fmt` to normalize formatting (succeeded).
- Ran `cargo test -p duke-classfile` including unit and doc-tests and the new parser regression (all tests passed).
- Ran `cargo check -p duke-interpreter --lib` to validate the interpreter build (succeeded).
- Ran `cargo test -p duke-interpreter --no-run` which failed to compile tests due to pre-existing unrelated unresolved `VmError` references in interpreter tests; this failure is not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eea92b2320832aa8b18a5c4caf942d)