### PR TITLE
Implement JCA baseline support for SecureRandom and MessageDigest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +243,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "duke"
 version = "0.1.0"
 dependencies = [
@@ -275,9 +313,13 @@ dependencies = [
  "duke-loader",
  "duke-runtime",
  "duke-telemetry",
+ "getrandom 0.3.4",
  "loom",
+ "md-5",
  "proptest",
  "regex",
+ "sha1",
+ "sha2",
 ]
 
 [[package]]
@@ -375,6 +417,16 @@ dependencies = [
  "rustversion",
  "windows-link",
  "windows-result",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -544,6 +596,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]
@@ -877,6 +939,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1128,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ proptest = "1"
 bitflags = "2"
 flate2 = "1"
 regex = "1"
+sha1 = "0.10"
+sha2 = "0.10"
+md-5 = "0.10"
+getrandom = "0.3"
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/duke-interpreter/Cargo.toml
+++ b/crates/duke-interpreter/Cargo.toml
@@ -12,6 +12,10 @@ duke-gc = { path = "../duke-gc" }
 duke-loader = { path = "../duke-loader" }
 duke-telemetry = { path = "../duke-telemetry", optional = true }
 regex.workspace = true
+sha1.workspace = true
+sha2.workspace = true
+md-5.workspace = true
+getrandom.workspace = true
 
 [features]
 telemetry = ["dep:duke-telemetry", "duke-telemetry/telemetry"]

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -17996,6 +17996,139 @@ pub(crate) fn native_random_next_boolean(
     Ok(Some(Slot::Int(v)))
 }
 
+fn byte_array_from_ref(heap: &duke_gc::Heap, array_ref: u64) -> Result<Vec<u8>> {
+    let arr = heap.get(array_ref)?;
+    let mut bytes = Vec::with_capacity(arr.fields.len());
+    for slot in &arr.fields {
+        let Slot::Int(v) = slot else {
+            return Err(Error::TypeMismatch {
+                expected: "Int",
+                got: "other",
+            });
+        };
+        bytes.push(v.to_le_bytes()[0]);
+    }
+    Ok(bytes)
+}
+
+fn alloc_byte_array(heap: &mut duke_gc::Heap, bytes: &[u8]) -> u64 {
+    let array_ref = heap.allocate("[B".to_string(), bytes.len());
+    if let Ok(array) = heap.get_mut(array_ref) {
+        for (idx, byte) in bytes.iter().copied().enumerate() {
+            array.fields[idx] = Slot::Int(i32::from(byte));
+        }
+    }
+    array_ref
+}
+
+fn compute_message_digest(algorithm: &str, bytes: &[u8]) -> Result<Vec<u8>> {
+    use sha1::Digest as _;
+    let digest = match algorithm {
+        "SHA-256" => sha2::Sha256::digest(bytes).to_vec(),
+        "SHA-1" => sha1::Sha1::digest(bytes).to_vec(),
+        "MD5" => md5::Md5::digest(bytes).to_vec(),
+        _ => {
+            return Err(Error::JavaException {
+                class_name: "java/security/NoSuchAlgorithmException".to_string(),
+            });
+        }
+    };
+    Ok(digest)
+}
+
+/// Native: `MessageDigest.getInstance(String)MessageDigest` — creates a digest for supported algorithms.
+pub(crate) fn native_message_digest_get_instance(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let algorithm_ref = extract_ref_arg(args, 0)?;
+    let algorithm = heap
+        .get(algorithm_ref)?
+        .string_value
+        .clone()
+        .unwrap_or_default();
+    // Validate upfront to match expected Java behavior for unknown algorithms.
+    let _ = compute_message_digest(&algorithm, &[])?;
+    let digest_ref = heap.allocate("java/security/MessageDigest".to_string(), 1);
+    heap.get_mut(digest_ref)?.string_value = Some(algorithm);
+    Ok(Some(Slot::Reference(Some(digest_ref))))
+}
+
+/// Native: `MessageDigest.digest([B)[B` — one-shot digest of provided bytes.
+pub(crate) fn native_message_digest_digest_bytes(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let digest_ref = extract_ref_arg(args, 0)?;
+    let input_ref = extract_ref_arg(args, 1)?;
+    let algorithm = heap
+        .get(digest_ref)?
+        .string_value
+        .clone()
+        .unwrap_or_default();
+    let input = byte_array_from_ref(heap, input_ref)?;
+    let output = compute_message_digest(&algorithm, &input)?;
+    let out_ref = alloc_byte_array(heap, &output);
+    Ok(Some(Slot::Reference(Some(out_ref))))
+}
+
+/// Native: `MessageDigest.digest()[B` — digest any buffered bytes (none in this minimal implementation).
+pub(crate) fn native_message_digest_digest(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let digest_ref = extract_ref_arg(args, 0)?;
+    let algorithm = heap
+        .get(digest_ref)?
+        .string_value
+        .clone()
+        .unwrap_or_default();
+    let output = compute_message_digest(&algorithm, &[])?;
+    let out_ref = alloc_byte_array(heap, &output);
+    Ok(Some(Slot::Reference(Some(out_ref))))
+}
+
+/// Native: `SecureRandom.nextBytes([B)V` — fills target array using host CSPRNG.
+pub(crate) fn native_secure_random_next_bytes(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let array_ref = extract_ref_arg(args, 1)?;
+    let mut bytes = vec![0_u8; heap.get(array_ref)?.fields.len()];
+    getrandom::fill(&mut bytes).map_err(|_| Error::JavaException {
+        class_name: "java/lang/InternalError".to_string(),
+    })?;
+    let arr = heap.get_mut(array_ref)?;
+    for (idx, byte) in bytes.iter().copied().enumerate() {
+        arr.fields[idx] = Slot::Int(i32::from(byte));
+    }
+    Ok(None)
+}
+
+/// Native: `SecureRandom.generateSeed(I)[B` — returns a fresh random byte array.
+pub(crate) fn native_secure_random_generate_seed(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let len = usize::try_from(extract_int_arg(args, 1)?.max(0)).unwrap_or(0);
+    let mut bytes = vec![0_u8; len];
+    getrandom::fill(&mut bytes).map_err(|_| Error::JavaException {
+        class_name: "java/lang/InternalError".to_string(),
+    })?;
+    let out_ref = alloc_byte_array(heap, &bytes);
+    Ok(Some(Slot::Reference(Some(out_ref))))
+}
+
 // ---------------------------------------------------------------------------
 // java.util.regex.Pattern / Matcher
 // Pattern: string_value = regex string.
@@ -25424,13 +25557,13 @@ mod sentry_tests {
         let invalid_id = -999;
 
         let count_err = zip_entry_count(invalid_id).unwrap_err();
-        assert!(matches!(count_err, VmError::JavaException { ref class_name } if class_name == "java/io/IOException"));
+        assert!(matches!(count_err, Error::JavaException { ref class_name } if class_name == "java/io/IOException"));
 
         let info_err = zip_get_entry_info(invalid_id, "test").unwrap_err();
-        assert!(matches!(info_err, VmError::JavaException { ref class_name } if class_name == "java/io/IOException"));
+        assert!(matches!(info_err, Error::JavaException { ref class_name } if class_name == "java/io/IOException"));
 
         let read_err = zip_read_entry(invalid_id, "test").unwrap_err();
-        assert!(matches!(read_err, VmError::JavaException { ref class_name } if class_name == "java/io/IOException"));
+        assert!(matches!(read_err, Error::JavaException { ref class_name } if class_name == "java/io/IOException"));
 
         // This shouldn't panic
         zip_close(invalid_id);

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -6841,6 +6841,82 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         native_random_next_boolean,
     );
 
+    let no_such_algorithm_ctx = ClassContext {
+        class_name: "java/security/NoSuchAlgorithmException".to_string(),
+        super_class: Some("java/lang/Exception".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    registry.register(no_such_algorithm_ctx);
+
+    let secure_random_ctx = ClassContext {
+        class_name: "java/security/SecureRandom".to_string(),
+        super_class: Some("java/util/Random".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    registry.register(secure_random_ctx);
+    registry.natives_mut().register(
+        "java/security/SecureRandom",
+        "nextBytes",
+        "([B)V",
+        native_secure_random_next_bytes,
+    );
+    registry.natives_mut().register(
+        "java/security/SecureRandom",
+        "generateSeed",
+        "(I)[B",
+        native_secure_random_generate_seed,
+    );
+
+    let message_digest_ctx = ClassContext {
+        class_name: "java/security/MessageDigest".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "algorithm".to_string(),
+            descriptor: "Ljava/lang/String;".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    registry.register(message_digest_ctx);
+    registry.natives_mut().register(
+        "java/security/MessageDigest",
+        "getInstance",
+        "(Ljava/lang/String;)Ljava/security/MessageDigest;",
+        native_message_digest_get_instance,
+    );
+    registry.natives_mut().register(
+        "java/security/MessageDigest",
+        "digest",
+        "([B)[B",
+        native_message_digest_digest_bytes,
+    );
+    registry.natives_mut().register(
+        "java/security/MessageDigest",
+        "digest",
+        "()[B",
+        native_message_digest_digest,
+    );
+
     // java/lang/StringBuffer — mutable string (thread-safe in Java; here aliases StringBuilder)
     // string_value used as the buffer
     let sb_buf_ctx = ClassContext {

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use sha2::Digest as _;
 
 macro_rules! wrap_simple_native_for_tests {
     ($($name:ident),* $(,)?) => {
@@ -217,6 +218,98 @@ fn class_registry_all_classes_iterates_registered() {
     // registry starts empty; verify iteration works
     let count = reg.all_classes().count();
     assert_eq!(count, 0); // before bootstrap
+}
+
+#[test]
+fn message_digest_sha256_get_instance_and_digest_bytes() {
+    let mut registry = ClassRegistry::new();
+    let mut heap = duke_gc::Heap::new();
+    bootstrap_stdlib(&mut registry, &mut heap);
+    let mut out = Vec::new();
+
+    let algo_ref = heap.allocate_string("SHA-256".to_string());
+    let get_instance = registry
+        .natives()
+        .get(
+            "java/security/MessageDigest",
+            "getInstance",
+            "(Ljava/lang/String;)Ljava/security/MessageDigest;",
+        )
+        .expect("MessageDigest.getInstance native should be registered");
+    let digest_ref = match get_instance(
+        &[Slot::Reference(Some(algo_ref))],
+        &mut heap,
+        &mut out,
+        &mut NativeControl::default(),
+    )
+    .expect("getInstance should succeed")
+    {
+        Some(Slot::Reference(Some(r))) => r,
+        other => panic!("unexpected getInstance return: {other:?}"),
+    };
+
+    let input_ref = heap.allocate("[B".to_string(), 3);
+    heap.get_mut(input_ref).unwrap().fields = vec![Slot::Int(97), Slot::Int(98), Slot::Int(99)];
+    let digest_bytes = registry
+        .natives()
+        .get("java/security/MessageDigest", "digest", "([B)[B")
+        .expect("MessageDigest.digest([B)[B native should be registered");
+    let result_ref = match digest_bytes(
+        &[
+            Slot::Reference(Some(digest_ref)),
+            Slot::Reference(Some(input_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut NativeControl::default(),
+    )
+    .expect("digest should succeed")
+    {
+        Some(Slot::Reference(Some(r))) => r,
+        other => panic!("unexpected digest return: {other:?}"),
+    };
+
+    let result: Vec<u8> = heap
+        .get(result_ref)
+        .unwrap()
+        .fields
+        .iter()
+        .map(|slot| match slot {
+            Slot::Int(v) => v.to_le_bytes()[0],
+            other => panic!("unexpected digest byte slot: {other:?}"),
+        })
+        .collect();
+    let expected = sha2::Sha256::digest(b"abc").to_vec();
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn secure_random_next_bytes_populates_array() {
+    let mut registry = ClassRegistry::new();
+    let mut heap = duke_gc::Heap::new();
+    bootstrap_stdlib(&mut registry, &mut heap);
+    let mut out = Vec::new();
+
+    let secure_random_ref = heap.allocate("java/security/SecureRandom".to_string(), 0);
+    let bytes_ref = heap.allocate("[B".to_string(), 32);
+    let next_bytes = registry
+        .natives()
+        .get("java/security/SecureRandom", "nextBytes", "([B)V")
+        .expect("SecureRandom.nextBytes native should be registered");
+    next_bytes(
+        &[
+            Slot::Reference(Some(secure_random_ref)),
+            Slot::Reference(Some(bytes_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut NativeControl::default(),
+    )
+    .expect("nextBytes should succeed");
+
+    let generated = &heap.get(bytes_ref).unwrap().fields;
+    assert_eq!(generated.len(), 32);
+    assert!(generated.iter().all(|slot| matches!(slot, Slot::Int(_))));
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Provide a minimal Java Cryptography Architecture (JCA) baseline so Duke can perform common cryptographic tasks like secure random generation and message digests via the standard `java.security` APIs.
- Delegate hashing to well-tested Rust crates and use the host CSPRNG for `SecureRandom` to avoid ad-hoc crypto implementations.

### Description
- Added workspace and crate dependencies for `sha1`, `sha2`, `md-5`, and `getrandom`, and wired them into `crates/duke-interpreter/Cargo.toml` and top-level `Cargo.toml`.
- Implemented byte-array marshaling helpers and native handlers in `crates/duke-interpreter/src/native.rs` for `MessageDigest.getInstance(String)`, `MessageDigest.digest([B)[B`, `MessageDigest.digest()[B`, `SecureRandom.nextBytes([B)V`, and `SecureRandom.generateSeed(I)[B` using `sha2`/`sha1`/`md5` and `getrandom`.
- Bootstrapped synthetic stdlib `ClassContext`s and native registrations in `crates/duke-interpreter/src/stdlib.rs` for `java/security/MessageDigest`, `java/security/SecureRandom`, and `java/security/NoSuchAlgorithmException` so lookups via `.getInstance()` resolve.
- Added unit tests in `crates/duke-interpreter/src/tests.rs` to verify `MessageDigest` SHA-256 digest correctness and that `SecureRandom.nextBytes` populates arrays, and fixed an existing test reference (`VmError` → `Error`) to compile against the current error type.

### Testing
- Ran `cargo fmt` successfully to normalize formatting.
- Ran `cargo test -p duke-interpreter message_digest_sha256_get_instance_and_digest_bytes` and the test passed (`ok`).
- Ran `cargo test -p duke-interpreter secure_random_next_bytes_populates_array` and the test passed (`ok`).
- Ran both targeted tests together sequentially and both passed; no changes to unrelated tests were performed in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eea939fe34832aab0467d81720bfa1)