### PR TITLE
Add initial JDWP agentlib listener and protocol handlers

### DIFF
--- a/duke/src/jdwp.rs
+++ b/duke/src/jdwp.rs
@@ -65,12 +65,13 @@ impl JdwpServer {
     }
 }
 
-pub fn start(config: JdwpConfig) -> std::io::Result<JdwpServer> {
+pub fn start(config: &JdwpConfig) -> std::io::Result<JdwpServer> {
     let listener = TcpListener::bind(&config.address)?;
     let (attached_tx, attached_rx) = mpsc::channel();
+    let cfg = config.clone();
     std::thread::spawn(move || {
         let next_request_id = Arc::new(AtomicI32::new(1));
-        let vm_suspended = Arc::new(AtomicBool::new(config.suspend));
+        let vm_suspended = Arc::new(AtomicBool::new(cfg.suspend));
 
         for stream in listener.incoming() {
             let Ok(mut stream) = stream else {
@@ -151,7 +152,7 @@ fn dispatch_command(
             vm_suspended.store(false, Ordering::SeqCst);
             (ERR_NONE, vec![], false)
         }
-        (1, 12) | (1, 17) => (ERR_NONE, vec![0; 32], false),
+        (1, 12 | 17) => (ERR_NONE, vec![0; 32], false),
         (1, 13) => (ERR_NONE, class_paths(), false),
         (1, 6) => (ERR_NONE, vec![], true),
 
@@ -182,7 +183,7 @@ fn dispatch_command(
         // StackFrame.GetValues
         (16, 1) => {
             let slots = payload
-                .get(16..20)
+                .get(8..12)
                 .map_or(0, |b| u32::from_be_bytes([b[0], b[1], b[2], b[3]]));
             let mut out = Vec::new();
             out.extend_from_slice(&slots.to_be_bytes());
@@ -204,7 +205,7 @@ fn dispatch_command(
 }
 
 fn send_reply(stream: &mut TcpStream, id: i32, err: u16, data: &[u8]) -> std::io::Result<()> {
-    let len = 11 + data.len() as u32;
+    let len = 11_u32 + to_u32_len(data.len());
     stream.write_all(&len.to_be_bytes())?;
     stream.write_all(&id.to_be_bytes())?;
     stream.write_all(&[REPLY_FLAG])?;
@@ -220,7 +221,7 @@ fn send_vm_start_event(stream: &mut TcpStream, suspended: bool) -> std::io::Resu
     data.extend_from_slice(&1_i32.to_be_bytes());
     data.extend_from_slice(&1_i64.to_be_bytes());
 
-    let len = 11 + data.len() as u32;
+    let len = 11_u32 + to_u32_len(data.len());
     stream.write_all(&len.to_be_bytes())?;
     stream.write_all(&1_i32.to_be_bytes())?;
     stream.write_all(&[0])?;
@@ -286,8 +287,12 @@ fn one_frame() -> Vec<u8> {
     out
 }
 
+fn to_u32_len(len: usize) -> u32 {
+    u32::try_from(len).unwrap_or(u32::MAX)
+}
+
 fn write_string(out: &mut Vec<u8>, value: &str) {
-    out.extend_from_slice(&(value.len() as u32).to_be_bytes());
+    out.extend_from_slice(&to_u32_len(value.len()).to_be_bytes());
     out.extend_from_slice(value.as_bytes());
 }
 

--- a/duke/src/jdwp.rs
+++ b/duke/src/jdwp.rs
@@ -1,0 +1,319 @@
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::sync::{Arc, mpsc};
+
+const HANDSHAKE: &[u8] = b"JDWP-Handshake";
+const REPLY_FLAG: u8 = 0x80;
+const ERR_NONE: u16 = 0;
+const ERR_NOT_IMPLEMENTED: u16 = 99;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JdwpConfig {
+    pub transport: String,
+    pub server: bool,
+    pub suspend: bool,
+    pub address: String,
+}
+
+impl Default for JdwpConfig {
+    fn default() -> Self {
+        Self {
+            transport: "dt_socket".to_string(),
+            server: true,
+            suspend: false,
+            address: "127.0.0.1:5005".to_string(),
+        }
+    }
+}
+
+pub fn parse_agentlib_jdwp(arg: &str) -> Option<JdwpConfig> {
+    let payload = arg.strip_prefix("-agentlib:jdwp=")?;
+    let mut config = JdwpConfig::default();
+    for part in payload.split(',') {
+        let mut kv = part.splitn(2, '=');
+        let key = kv.next().unwrap_or("").trim();
+        let value = kv.next().unwrap_or("").trim();
+        match key {
+            "transport" if !value.is_empty() => config.transport = value.to_string(),
+            "server" => config.server = value.eq_ignore_ascii_case("y"),
+            "suspend" => config.suspend = value.eq_ignore_ascii_case("y"),
+            "address" if !value.is_empty() => {
+                config.address = normalize_socket_addr(value);
+            }
+            _ => {}
+        }
+    }
+    Some(config)
+}
+
+fn normalize_socket_addr(raw: &str) -> String {
+    if raw.contains(':') {
+        raw.to_string()
+    } else {
+        format!("127.0.0.1:{raw}")
+    }
+}
+
+pub struct JdwpServer {
+    attached_rx: mpsc::Receiver<()>,
+}
+
+impl JdwpServer {
+    pub fn wait_for_attach(&self) {
+        let _ = self.attached_rx.recv();
+    }
+}
+
+pub fn start(config: JdwpConfig) -> std::io::Result<JdwpServer> {
+    let listener = TcpListener::bind(&config.address)?;
+    let (attached_tx, attached_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let next_request_id = Arc::new(AtomicI32::new(1));
+        let vm_suspended = Arc::new(AtomicBool::new(config.suspend));
+
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else {
+                continue;
+            };
+            if !do_handshake(&mut stream).unwrap_or(false) {
+                continue;
+            }
+            let _ = attached_tx.send(());
+            let _ = send_vm_start_event(&mut stream, vm_suspended.load(Ordering::SeqCst));
+
+            let _ = handle_client(&mut stream, &next_request_id, &vm_suspended);
+        }
+    });
+    Ok(JdwpServer { attached_rx })
+}
+
+fn do_handshake(stream: &mut TcpStream) -> std::io::Result<bool> {
+    let mut buf = [0u8; 14];
+    stream.read_exact(&mut buf)?;
+    if buf != HANDSHAKE {
+        return Ok(false);
+    }
+    stream.write_all(HANDSHAKE)?;
+    Ok(true)
+}
+
+fn handle_client(
+    stream: &mut TcpStream,
+    next_request_id: &AtomicI32,
+    vm_suspended: &AtomicBool,
+) -> std::io::Result<()> {
+    loop {
+        let mut header = [0u8; 11];
+        if stream.read_exact(&mut header).is_err() {
+            return Ok(());
+        }
+        let length = u32::from_be_bytes([header[0], header[1], header[2], header[3]]) as usize;
+        if length < 11 {
+            return Ok(());
+        }
+        let id = i32::from_be_bytes([header[4], header[5], header[6], header[7]]);
+        let flags = header[8];
+        let mut payload = vec![0; length - 11];
+        stream.read_exact(&mut payload)?;
+
+        if flags & REPLY_FLAG != 0 {
+            continue;
+        }
+
+        let cmd_set = header[9];
+        let cmd = header[10];
+        let (err, data, should_close) =
+            dispatch_command(cmd_set, cmd, &payload, next_request_id, vm_suspended);
+        send_reply(stream, id, err, &data)?;
+        if should_close {
+            return Ok(());
+        }
+    }
+}
+
+fn dispatch_command(
+    cmd_set: u8,
+    cmd: u8,
+    payload: &[u8],
+    next_request_id: &AtomicI32,
+    vm_suspended: &AtomicBool,
+) -> (u16, Vec<u8>, bool) {
+    match (cmd_set, cmd) {
+        (1, 1) => (ERR_NONE, vm_version(), false),
+        (1, 4) => (ERR_NONE, one_thread_list(), false),
+        (1, 7) => (ERR_NONE, id_sizes(), false),
+        (1, 8) => {
+            vm_suspended.store(true, Ordering::SeqCst);
+            (ERR_NONE, vec![], false)
+        }
+        (1, 9) => {
+            vm_suspended.store(false, Ordering::SeqCst);
+            (ERR_NONE, vec![], false)
+        }
+        (1, 12) | (1, 17) => (ERR_NONE, vec![0; 32], false),
+        (1, 13) => (ERR_NONE, class_paths(), false),
+        (1, 6) => (ERR_NONE, vec![], true),
+
+        // ReferenceType
+        (2, 1) => (ERR_NONE, signature_placeholder(), false),
+        (2, 5) => (ERR_NONE, write_u32(0), false),
+
+        // Method
+        (6, 1) => (ERR_NONE, method_line_table(), false),
+
+        // ThreadReference.Frames
+        (11, 6) => (ERR_NONE, one_frame(), false),
+
+        // ObjectReference.GetValues
+        (9, 2) => {
+            let count = payload
+                .get(8..12)
+                .map_or(0, |b| u32::from_be_bytes([b[0], b[1], b[2], b[3]]));
+            let mut out = Vec::new();
+            out.extend_from_slice(&count.to_be_bytes());
+            for _ in 0..count {
+                out.push(b'L');
+                out.extend_from_slice(&0_i64.to_be_bytes());
+            }
+            (ERR_NONE, out, false)
+        }
+
+        // StackFrame.GetValues
+        (16, 1) => {
+            let slots = payload
+                .get(16..20)
+                .map_or(0, |b| u32::from_be_bytes([b[0], b[1], b[2], b[3]]));
+            let mut out = Vec::new();
+            out.extend_from_slice(&slots.to_be_bytes());
+            for _ in 0..slots {
+                out.push(b'I');
+                out.extend_from_slice(&0_i32.to_be_bytes());
+            }
+            (ERR_NONE, out, false)
+        }
+
+        // EventRequest.Set (BREAKPOINT / STEP)
+        (15, 1) => {
+            let req_id = next_request_id.fetch_add(1, Ordering::SeqCst);
+            (ERR_NONE, req_id.to_be_bytes().to_vec(), false)
+        }
+
+        _ => (ERR_NOT_IMPLEMENTED, vec![], false),
+    }
+}
+
+fn send_reply(stream: &mut TcpStream, id: i32, err: u16, data: &[u8]) -> std::io::Result<()> {
+    let len = 11 + data.len() as u32;
+    stream.write_all(&len.to_be_bytes())?;
+    stream.write_all(&id.to_be_bytes())?;
+    stream.write_all(&[REPLY_FLAG])?;
+    stream.write_all(&err.to_be_bytes())?;
+    stream.write_all(data)
+}
+
+fn send_vm_start_event(stream: &mut TcpStream, suspended: bool) -> std::io::Result<()> {
+    let mut data = Vec::new();
+    data.push(if suspended { 2 } else { 0 });
+    data.extend_from_slice(&1_u32.to_be_bytes());
+    data.push(90); // VM_START
+    data.extend_from_slice(&1_i32.to_be_bytes());
+    data.extend_from_slice(&1_i64.to_be_bytes());
+
+    let len = 11 + data.len() as u32;
+    stream.write_all(&len.to_be_bytes())?;
+    stream.write_all(&1_i32.to_be_bytes())?;
+    stream.write_all(&[0])?;
+    stream.write_all(&[64, 100])?;
+    stream.write_all(&data)
+}
+
+fn vm_version() -> Vec<u8> {
+    let mut out = Vec::new();
+    write_string(&mut out, "Duke JDWP");
+    out.extend_from_slice(&1_i32.to_be_bytes());
+    out.extend_from_slice(&8_i32.to_be_bytes());
+    write_string(&mut out, "1.8");
+    write_string(&mut out, "DukeVM");
+    out
+}
+
+fn one_thread_list() -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&1_u32.to_be_bytes());
+    out.extend_from_slice(&1_i64.to_be_bytes());
+    out
+}
+
+fn id_sizes() -> Vec<u8> {
+    let mut out = Vec::new();
+    for _ in 0..5 {
+        out.extend_from_slice(&8_i32.to_be_bytes());
+    }
+    out
+}
+
+fn class_paths() -> Vec<u8> {
+    let mut out = Vec::new();
+    write_string(&mut out, ".");
+    out.extend_from_slice(&0_u32.to_be_bytes());
+    out.extend_from_slice(&0_u32.to_be_bytes());
+    out
+}
+
+fn signature_placeholder() -> Vec<u8> {
+    let mut out = Vec::new();
+    write_string(&mut out, "Ljava/lang/Object;");
+    out
+}
+
+fn method_line_table() -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&0_i64.to_be_bytes());
+    out.extend_from_slice(&0_i64.to_be_bytes());
+    out.extend_from_slice(&0_u32.to_be_bytes());
+    out
+}
+
+fn one_frame() -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&1_u32.to_be_bytes());
+    out.extend_from_slice(&1_i64.to_be_bytes()); // frame id
+    out.push(1); // type tag class
+    out.extend_from_slice(&1_i64.to_be_bytes()); // class id
+    out.extend_from_slice(&1_i64.to_be_bytes()); // method id
+    out.extend_from_slice(&0_u64.to_be_bytes()); // index
+    out
+}
+
+fn write_string(out: &mut Vec<u8>, value: &str) {
+    out.extend_from_slice(&(value.len() as u32).to_be_bytes());
+    out.extend_from_slice(value.as_bytes());
+}
+
+fn write_u32(value: u32) -> Vec<u8> {
+    value.to_be_bytes().to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_agentlib_config() {
+        let cfg = parse_agentlib_jdwp(
+            "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005",
+        )
+        .expect("config should parse");
+        assert_eq!(cfg.transport, "dt_socket");
+        assert!(cfg.server);
+        assert!(cfg.suspend);
+        assert_eq!(cfg.address, "127.0.0.1:5005");
+    }
+
+    #[test]
+    fn normalize_address() {
+        assert_eq!(normalize_socket_addr("5005"), "127.0.0.1:5005");
+        assert_eq!(normalize_socket_addr("0.0.0.0:5005"), "0.0.0.0:5005");
+    }
+}

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -16,6 +16,7 @@ mod html;
 #[cfg(feature = "nova")]
 mod html_jar;
 mod jar_analyze;
+mod jdwp;
 #[cfg(feature = "nova")]
 mod pathfinding;
 mod scan;
@@ -72,6 +73,19 @@ fn extract_jdk_flag(args: &mut Vec<String>) -> Option<String> {
 }
 
 /// Strip `-jar <path>` or `--jar <path>` from `args` and return the JAR path.
+fn extract_jdwp_flag(args: &mut Vec<String>) -> Option<jdwp::JdwpConfig> {
+    let mut cfg = None;
+    args.retain(|arg| {
+        if let Some(parsed) = jdwp::parse_agentlib_jdwp(arg) {
+            cfg = Some(parsed);
+            false
+        } else {
+            true
+        }
+    });
+    cfg
+}
+
 fn extract_jar_flag(args: &mut Vec<String>) -> Option<String> {
     let mut jar = None;
     let mut remove_next = false;
@@ -222,7 +236,31 @@ fn main() {
     let telemetry = extract_telemetry_flag(&mut args);
     let mermaid_dest = extract_mermaid_heap_flag(&mut args);
     let jdk_home = extract_jdk_flag(&mut args);
+    let jdwp_cfg = extract_jdwp_flag(&mut args);
     let jar_path = extract_jar_flag(&mut args);
+
+    let jdwp_server = jdwp_cfg.and_then(|cfg| {
+        if !cfg.server {
+            eprintln!("duke: warning: only server=y JDWP mode is currently supported");
+            return None;
+        }
+        match jdwp::start(cfg.clone()) {
+            Ok(server) => {
+                eprintln!("duke: JDWP listening on {}", cfg.address);
+                if cfg.suspend {
+                    eprintln!("duke: waiting for JDWP debugger attach (suspend=y)");
+                    server.wait_for_attach();
+                }
+                Some(server)
+            }
+            Err(err) => {
+                eprintln!("duke: warning: failed to start JDWP listener: {err}");
+                None
+            }
+        }
+    });
+
+    let _jdwp_server = jdwp_server;
 
     if jar_path.is_none() && args.len() < 2 {
         eprintln!("Usage: duke <classfile.class>");

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -76,12 +76,10 @@ fn extract_jdk_flag(args: &mut Vec<String>) -> Option<String> {
 fn extract_jdwp_flag(args: &mut Vec<String>) -> Option<jdwp::JdwpConfig> {
     let mut cfg = None;
     args.retain(|arg| {
-        if let Some(parsed) = jdwp::parse_agentlib_jdwp(arg) {
+        jdwp::parse_agentlib_jdwp(arg).is_none_or(|parsed| {
             cfg = Some(parsed);
             false
-        } else {
-            true
-        }
+        })
     });
     cfg
 }
@@ -244,7 +242,7 @@ fn main() {
             eprintln!("duke: warning: only server=y JDWP mode is currently supported");
             return None;
         }
-        match jdwp::start(cfg.clone()) {
+        match jdwp::start(&cfg) {
             Ok(server) => {
                 eprintln!("duke: JDWP listening on {}", cfg.address);
                 if cfg.suspend {


### PR DESCRIPTION
### Motivation
- Implement JDWP support to allow standard IDE debuggers to attach to Duke via `-agentlib:jdwp=...` and provide a foundation for breakpoints, thread suspension, and variable inspection as described in the Vantage JDWP spec.
- Provide a minimal wire-compatible JDWP listener so developers can attach, handshake, and use basic debugger flows (including `suspend=y`).

### Description
- Add a new module `duke/src/jdwp.rs` implementing `JdwpConfig`, `parse_agentlib_jdwp`, a socket-based JDWP `start` server, handshake handling, VM start event emission, request id tracking, and a packet dispatch loop with basic handlers for core command sets (`VirtualMachine`, `ReferenceType`, `Method`, `EventRequest`, `ThreadReference`, `StackFrame`, `ObjectReference`) returning stubbed or placeholder payloads where runtime integration is not yet implemented.
- Wire JDWP CLI extraction and startup into `duke/src/main.rs` by adding `extract_jdwp_flag`, starting the JDWP listener early, and honoring `suspend=y` via `JdwpServer::wait_for_attach` before continuing VM startup.
- Include small helper functions for JDWP framing and serialization (`send_reply`, `send_vm_start_event`, `write_string`, `id_sizes`, etc.) and a simple `NOT_IMPLEMENTED` fallback for unsupported commands.
- Add unit tests in `duke/src/jdwp.rs` for `parse_agentlib_jdwp` and `normalize_socket_addr` to validate argument parsing and address normalization.

### Testing
- Ran `cargo fmt` which completed successfully.
- Ran `cargo test -p duke parse_agentlib_config` which passed the `parse_agentlib_config` unit test.
- Ran `cargo test -p duke normalize_address` which passed the `normalize_address` unit test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eea9720884832ab3a01f4616087c12)