### PR TITLE
⚒️ Forge: Refactor build_basic_blocks to extract algorithmic phases

### DIFF
--- a/crates/duke-bytecode/src/basic_block.rs
+++ b/crates/duke-bytecode/src/basic_block.rs
@@ -64,20 +64,20 @@ pub struct BasicBlock {
 /// assert_eq!(blocks[1].start_pc, 4); // Contains Iconst1, Ireturn
 /// assert_eq!(blocks[2].start_pc, 6); // Contains Iconst2, Ireturn
 /// ```
-#[allow(
-    clippy::cast_possible_wrap,
-    clippy::cast_sign_loss,
-    clippy::too_many_lines
-)]
+#[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
 #[must_use]
 pub fn build_basic_blocks(instructions: &[(usize, Instruction)]) -> Vec<BasicBlock> {
     if instructions.is_empty() {
         return Vec::new();
     }
 
-    let mut leaders = BTreeSet::new();
+    let leaders = find_leaders(instructions);
+    construct_blocks(instructions, &leaders)
+}
 
-    // Rule 1: The first instruction is always a leader.
+#[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+fn find_leaders(instructions: &[(usize, Instruction)]) -> BTreeSet<usize> {
+    let mut leaders = BTreeSet::new();
     leaders.insert(instructions[0].0);
 
     for (i, (pc, instr)) in instructions.iter().enumerate() {
@@ -100,11 +100,16 @@ pub fn build_basic_blocks(instructions: &[(usize, Instruction)]) -> Vec<BasicBlo
         };
 
         if is_branch_or_return && i + 1 < instructions.len() {
-            // Rule 3: The instruction immediately following a branch/return is a leader.
             leaders.insert(instructions[i + 1].0);
         }
     }
+    leaders
+}
 
+fn construct_blocks(
+    instructions: &[(usize, Instruction)],
+    leaders: &BTreeSet<usize>,
+) -> Vec<BasicBlock> {
     let mut blocks = Vec::with_capacity(leaders.len());
     let mut current_start_pc = instructions[0].0;
     let mut current_start_idx = 0;


### PR DESCRIPTION
🛁 Smell: The `build_basic_blocks` function in `crates/duke-bytecode/src/basic_block.rs` had a `#[allow(clippy::too_many_lines)]` attribute because it mixed two distinct phases: finding block leaders and constructing the actual blocks. This created a God Function that was harder to read.
✨ Solution: Extracted the two phases into `find_leaders` and `construct_blocks` helper functions and removed the clippy allow attribute from the main function.
🧼 Benefit: Naturally shortens the main function, eliminating the need for the linter suppression, and drastically improves readability by giving the distinct phases clear names.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [5663561420834806665](https://jules.google.com/task/5663561420834806665) started by @madmax983*