### PR TITLE
🌟 Nova: jar-search

### DIFF
--- a/duke/src/jar_search.rs
+++ b/duke/src/jar_search.rs
@@ -1,0 +1,111 @@
+#![allow(clippy::items_after_statements)]
+#[cfg(feature = "nova")]
+use duke_bytecode::decode;
+#[cfg(feature = "nova")]
+use duke_classfile::{
+    parse,
+    types::{AttributeData, CpEntry, CpIndex},
+};
+#[cfg(feature = "nova")]
+use duke_loader::{ClassLoader, ZipLoader};
+use std::path::Path;
+use std::process;
+
+#[cfg(feature = "nova")]
+#[cfg(not(tarpaulin_include))]
+#[allow(unexpected_cfgs)]
+fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
+    cf.constant_pool
+        .get(idx.0 as usize)
+        .and_then(|slot| slot.as_ref())
+        .and_then(|entry| {
+            if let CpEntry::Utf8(s) = entry {
+                Some(s.as_str())
+            } else {
+                None
+            }
+        })
+}
+
+#[cfg(feature = "nova")]
+#[cfg(not(tarpaulin_include))]
+#[allow(
+    unexpected_cfgs,
+    clippy::print_stdout,
+    clippy::use_debug,
+    clippy::collapsible_if
+)]
+pub fn dump_jar_search(jar_path: &str, query: &str) {
+    let loader = ZipLoader::open(Path::new(jar_path)).unwrap_or_else(|e| {
+        eprintln!("duke: failed to open JAR '{jar_path}': {e}");
+        process::exit(1);
+    });
+
+    let reader = loader.reader();
+    let class_entries: Vec<String> = reader
+        .entry_names()
+        .filter(|name| {
+            std::path::Path::new(name)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("class"))
+        })
+        .map(std::string::ToString::to_string)
+        .collect();
+
+    let query_lower = query.to_lowercase();
+    let mut found_any = false;
+
+    for entry_name in class_entries {
+        let class_name_internal = entry_name.strip_suffix(".class").unwrap();
+        if let Ok(bytes) = loader.find_class(class_name_internal) {
+            if let Ok(cf) = parse(&bytes) {
+                for method in &cf.methods {
+                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+                    let full_name = format!("{class_name_internal}.{name_str}{desc_str}");
+
+                    for attr in &method.attributes {
+                        if let AttributeData::Code(code) = &attr.data {
+                            if let Ok(instructions) = decode(&code.code) {
+                                let mut found_in_method = false;
+                                for (pc, instr) in instructions {
+                                    let mnemonic = instr.mnemonic().to_lowercase();
+                                    if mnemonic.contains(&query_lower) {
+                                        if !found_in_method {
+                                            println!("Method: {full_name}");
+                                            found_in_method = true;
+                                            found_any = true;
+                                        }
+                                        println!("  {pc:>4}: {mnemonic}");
+                                    }
+                                }
+                                if found_in_method {
+                                    println!();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if !found_any {
+        println!("No instructions matching '{query}' found.");
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "nova")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dump_jar_search_valid() {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../tests/fixtures/hello.jar");
+        let path_str = path.to_str().unwrap();
+
+        dump_jar_search(path_str, "invokevirtual");
+    }
+}

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -16,6 +16,8 @@ mod html;
 #[cfg(feature = "nova")]
 mod html_jar;
 mod jar_analyze;
+#[cfg(feature = "nova")]
+mod jar_search;
 mod jdwp;
 #[cfg(feature = "nova")]
 mod pathfinding;
@@ -292,6 +294,8 @@ fn main() {
         eprintln!("       duke dead-code <classfile.class>");
         #[cfg(feature = "nova")]
         eprintln!("       duke jar-dead-code <file.jar>");
+        #[cfg(feature = "nova")]
+        eprintln!("       duke jar-search <file.jar> <query>");
         eprintln!("       duke -jar <file.jar> [string-arg...]");
         eprintln!("Options: --telemetry[=path]  dump telemetry JSON after execution");
         eprintln!("         --telemetry-md[=p]  dump telemetry Markdown report after execution");
@@ -314,6 +318,24 @@ fn main() {
         #[cfg(not(feature = "nova"))]
         {
             eprintln!("duke: unknown subcommand 'jar-dead-code'");
+            std::process::exit(1);
+        }
+    }
+
+    // Dispatch `jar-search`
+    if args.len() > 1 && args[1] == "jar-search" {
+        if args.len() < 4 {
+            eprintln!("Usage: duke jar-search <file.jar> <query>");
+            std::process::exit(1);
+        }
+        #[cfg(feature = "nova")]
+        {
+            jar_search::dump_jar_search(&args[2], &args[3]);
+            return;
+        }
+        #[cfg(not(feature = "nova"))]
+        {
+            eprintln!("duke: unknown subcommand 'jar-search'");
             std::process::exit(1);
         }
     }


### PR DESCRIPTION
💡 **The Spark:** We have a feature to search inside `.class` files, and a module to parse `.jar` files, but no quick way to search the bytecode inside an entire JAR archive.
🚀 **The Feature:** Implemented `jar-search` to find opcodes recursively across an entire JAR file.
🔮 **The Potential:** Massively accelerates debugging library/framework issues by allowing quick queries (e.g. finding all `invokedynamic` instructions in a complex framework jar).
⚠️ **Risk:** Low. Isolated to `duke/src/jar_search.rs` and a subcommand branch.

---
*PR created automatically by Jules for task [15631783204528545315](https://jules.google.com/task/15631783204528545315) started by @madmax983*