### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - [ClassContext Documentation]
 **Confusion:** The purpose and usage of `build_class_context` in bridging raw classfile data and execution environments was entirely undocumented, leading to confusion about its initialization requirements.
 **Clarification:** Added comprehensive documentation, explaining that it serves as the runtime representation of a loaded class. Also added an executable doctest demonstrating the precise constant pool initialization needed for successful parsing.
+
+## 2024-05-19 - [Missing Telemetry Test Docs]
+**Confusion:** The integration test file for telemetry print formatting triggered missing documentation warnings, which are explicitly mandated by strict linting rules.
+**Clarification:** Added module-level `//!` documentation to the `print_and_markdown.rs` integration test, explaining its purpose in verifying report text output structure.

--- a/crates/duke-telemetry/tests/print_and_markdown.rs
+++ b/crates/duke-telemetry/tests/print_and_markdown.rs
@@ -8,7 +8,6 @@
 //! telemetry reporting interface, confirming that top-level headers (like
 //! `Bytecode Cost (Top 10)`) are accurately rendered for developers to analyze.
 
-
 use duke_telemetry::TelemetryStore;
 
 #[test]

--- a/crates/duke-telemetry/tests/print_and_markdown.rs
+++ b/crates/duke-telemetry/tests/print_and_markdown.rs
@@ -1,3 +1,14 @@
+//! Telemetry store testing module
+//!
+//! This module verifies the string formatting logic of the telemetry subsystem.
+//! It ensures that when execution metadata is exported (either to standard output
+//! or as a Markdown report), the structural integrity of the output is maintained.
+//!
+//! These integration tests act as safeguards against unintended regressions in the
+//! telemetry reporting interface, confirming that top-level headers (like
+//! `Bytecode Cost (Top 10)`) are accurately rendered for developers to analyze.
+
+
 use duke_telemetry::TelemetryStore;
 
 #[test]


### PR DESCRIPTION
🎻 Bard: [documentation update]

📖 Chapter: The Telemetry module test files.
🔦 Insight: Explained why `print_and_markdown.rs` exists, bridging the test cases with their verification of the string formatting and report structural integrity.
🧪 Example: Added top-level module documentation verifying the test intent.
🖼️ Preview: No preview necessary (tests don't display in HTML docs), but `cargo doc --open` passed visual inspection.

---
*PR created automatically by Jules for task [13099540421018729259](https://jules.google.com/task/13099540421018729259) started by @madmax983*