### PR TITLE
⚡ Bolt: [Remove intermediate HashMap allocation in Telemetry serialization]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 **Zero-cost abstractions around `Vec::clone()`**
 **Learning:** `heap.get(this_ref)?.fields.clone()` is a heavy operation for HashMaps/HashSets/Localdatetimes operations since we only read from the vector without taking ownership. But you must be careful because passing `&heap.get(this_ref)?.fields` holds a reference to `heap`, and later calling `heap.get_mut` will fail with "cannot borrow `*heap` as mutable because it is also borrowed as immutable".
 **Action:** Instead of `fields.clone()`, get the properties out of the reference (`fields[i + 1]`) and use those to perform the operation, or use `find_..._entry_index` to just get the index, then drop the immutable borrow, and then perform `heap.get_mut` if necessary.
+
+**[SerializeMap for custom map serialization]**
+**Learning:** Using `serde::ser::SerializeMap` directly removes the need for collecting intermediate HashMaps when writing a custom map serialization logic.
+**Action:** Always prefer iterating directly and using `ser.serialize_map` to prevent unnecessary allocations.

--- a/crates/duke-telemetry/src/helpers.rs
+++ b/crates/duke-telemetry/src/helpers.rs
@@ -3,9 +3,12 @@
 pub mod ser_helpers {
     use std::collections::HashMap;
 
-    use serde::Serialize;
+    use serde::{Serialize, ser::SerializeMap};
 
     /// Core helper: serialize any `HashMap<K, V>` by formatting each key with `key_fn`.
+    ///
+    /// ⚡ Bolt: Using `SerializeMap` to serialize directly removes the intermediate `HashMap`
+    /// collection, avoiding heap allocations and hashing overhead during telemetry generation.
     pub fn keyed_map<K, V, S, F>(map: &HashMap<K, V>, ser: S, key_fn: F) -> Result<S::Ok, S::Error>
     where
         K: Eq + std::hash::Hash,
@@ -13,8 +16,11 @@ pub mod ser_helpers {
         S: serde::Serializer,
         F: Fn(&K) -> String,
     {
-        let string_map: HashMap<String, &V> = map.iter().map(|(k, v)| (key_fn(k), v)).collect();
-        string_map.serialize(ser)
+        let mut map_ser = ser.serialize_map(Some(map.len()))?;
+        for (k, v) in map {
+            map_ser.serialize_entry(&key_fn(k), v)?;
+        }
+        map_ser.end()
     }
 
     /// `HashMap<(class, method, pc), V>` → `"class::method@pc"`.


### PR DESCRIPTION
💡 What: Switched to `serde::ser::SerializeMap` directly to serialize keyed map entries instead of collecting into an intermediate HashMap.
🎯 Why: Removing the intermediate HashMap reduces heap allocations and hashing overhead when generating telemetry logs for larger apps.
📊 Impact: Reduces allocations when generating the JSON structure telemetry.
🔬 Measurement: Run `cargo test -p duke-telemetry` to verify exact matching serialization results.

---
*PR created automatically by Jules for task [4339021169710683239](https://jules.google.com/task/4339021169710683239) started by @madmax983*