### PR TITLE
🌟 Nova: Basic Block CFG Exporter

### DIFF
--- a/duke/src/jar_bbcfg.rs
+++ b/duke/src/jar_bbcfg.rs
@@ -1,0 +1,154 @@
+#[cfg(feature = "nova")]
+use duke_bytecode::{build_basic_blocks, decode, generate_basic_block_cfg};
+#[cfg(feature = "nova")]
+use duke_classfile::{
+    parse,
+    types::{AttributeData, ClassFile, CpEntry, CpIndex},
+};
+#[cfg(feature = "nova")]
+use duke_loader::{ClassLoader, ZipLoader};
+#[cfg(feature = "nova")]
+use std::{fmt::Write, fs, path::Path};
+
+#[cfg(feature = "nova")]
+#[allow(unexpected_cfgs)]
+fn cp_str(cf: &ClassFile, idx: CpIndex) -> Option<&str> {
+    cf.constant_pool
+        .get(idx.0 as usize)
+        .and_then(|slot| slot.as_ref())
+        .and_then(|entry| {
+            if let CpEntry::Utf8(s) = entry {
+                Some(s.as_str())
+            } else {
+                None
+            }
+        })
+}
+
+/// Generates a static HTML site containing Mermaid Basic Block CFGs for every method in a JAR.
+///
+/// **Why it exists:** Visualizing control flow across an entire library is difficult.
+/// This exporter iterates through a JAR and produces interactive Mermaid diagrams,
+/// allowing developers to see the fundamental shape of all bytecode in one place.
+#[cfg(feature = "nova")]
+#[allow(
+    clippy::case_sensitive_file_extension_comparisons,
+    clippy::too_many_lines,
+    clippy::cast_precision_loss,
+    clippy::collapsible_if
+)]
+pub fn export_jar_bbcfg(jar_path: &str, output_dir: &str) -> std::io::Result<()> {
+    let loader = ZipLoader::open(Path::new(jar_path)).map_err(|e| {
+        std::io::Error::other(format!("duke: failed to open JAR '{jar_path}': {e}"))
+    })?;
+
+    fs::create_dir_all(output_dir)?;
+
+    let reader = loader.reader();
+    let mut class_names = Vec::new();
+
+    for entry_name in reader.entry_names() {
+        if !entry_name.ends_with(".class") {
+            continue;
+        }
+        let class_name_internal = entry_name.strip_suffix(".class").unwrap();
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
+        let Ok(cf) = parse(&bytes) else {
+            continue;
+        };
+
+        let mut class_html = String::new();
+        class_html.push_str("<!DOCTYPE html>\n<html>\n<head>\n");
+        class_html.push_str("<meta charset=\"utf-8\">\n");
+        let _ = writeln!(class_html, "<title>CFG: {class_name_internal}</title>");
+        class_html.push_str("<script type=\"module\">\n");
+        class_html.push_str("  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';\n");
+        class_html.push_str("  mermaid.initialize({ startOnLoad: true });\n");
+        class_html.push_str("</script>\n</head>\n<body style=\"font-family: sans-serif;\">\n");
+        let _ = writeln!(
+            class_html,
+            "<h1>Class: {}</h1>",
+            class_name_internal.replace('/', ".")
+        );
+        class_html.push_str("<a href=\"index.html\">Back to Index</a>\n<hr>\n");
+
+        for method in &cf.methods {
+            let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+            let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+
+            for attr in &method.attributes {
+                if let AttributeData::Code(code) = &attr.data {
+                    if let Ok(instructions) = decode(&code.code) {
+                        let blocks = build_basic_blocks(&instructions);
+                        let cfg_mermaid = generate_basic_block_cfg(&blocks);
+
+                        let _ = writeln!(class_html, "<h2>Method: {name_str}{desc_str}</h2>");
+                        class_html.push_str("<pre class=\"mermaid\">\n");
+                        class_html.push_str(&cfg_mermaid);
+                        class_html.push_str("\n</pre>\n<hr>\n");
+                    }
+                }
+            }
+        }
+
+        class_html.push_str("</body>\n</html>");
+
+        let safe_name = class_name_internal.replace('/', "_");
+        let file_name = format!("{safe_name}.html");
+        let out_path = Path::new(output_dir).join(&file_name);
+
+        if fs::write(&out_path, class_html).is_ok() {
+            class_names.push((class_name_internal.to_string(), file_name));
+        }
+    }
+
+    class_names.sort();
+
+    let mut index_html = String::new();
+    index_html.push_str("<!DOCTYPE html>\n<html>\n<head>\n<meta charset=\"utf-8\">\n");
+    let _ = writeln!(index_html, "<title>JAR BBCFG Report: {jar_path}</title>");
+    index_html.push_str("</head>\n<body style=\"font-family: sans-serif;\">\n");
+    let _ = write!(
+        index_html,
+        "<h1>Basic Block CFG Export: {jar_path}</h1>\n<ul>\n"
+    );
+
+    for (name, link) in class_names {
+        let _ = writeln!(
+            index_html,
+            "  <li><a href=\"{link}\">{}</a></li>",
+            name.replace('/', ".")
+        );
+    }
+    index_html.push_str("</ul>\n</body>\n</html>");
+
+    let index_path = Path::new(output_dir).join("index.html");
+    fs::write(&index_path, index_html)?;
+
+    println!("✅ Generated JAR BBCFG site at {output_dir}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[cfg(feature = "nova")]
+    fn test_export_jar_bbcfg() {
+        use super::*;
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        let out_dir = dir.path().to_str().unwrap();
+
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../tests/fixtures/hello.jar");
+        let path_str = path.to_str().unwrap();
+
+        export_jar_bbcfg(path_str, out_dir).unwrap();
+
+        let index = std::fs::read_to_string(dir.path().join("index.html")).unwrap();
+        assert!(index.contains("Basic Block CFG Export:"));
+        assert!(index.contains("HelloWorld.html"));
+    }
+}

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -17,6 +17,8 @@ mod html;
 mod html_jar;
 mod jar_analyze;
 #[cfg(feature = "nova")]
+mod jar_bbcfg;
+#[cfg(feature = "nova")]
 mod jar_search;
 mod jdwp;
 #[cfg(feature = "nova")]
@@ -272,6 +274,8 @@ fn main() {
         #[cfg(feature = "nova")]
         eprintln!("       duke html-jar <file.jar> <output_dir>");
         #[cfg(feature = "nova")]
+        eprintln!("       duke bbcfg-jar <file.jar> <output_dir>");
+        #[cfg(feature = "nova")]
         eprintln!("       duke cycle-detect <file.jar>");
         eprintln!("       duke deps-graph <classfile.class>");
         eprintln!("       duke load <ClassName>");
@@ -361,6 +365,15 @@ fn main() {
     // Dispatch `html`: output HTML report for class.
 
     #[cfg(feature = "nova")]
+    #[cfg(feature = "nova")]
+    if args.len() >= 4 && args[1] == "bbcfg-jar" {
+        if let Err(e) = jar_bbcfg::export_jar_bbcfg(&args[2], &args[3]) {
+            eprintln!("{e}");
+            process::exit(1);
+        }
+        return;
+    }
+
     if args.len() >= 4 && args[1] == "html-jar" {
         if let Err(e) = html_jar::generate_jar_html_site(&args[2], &args[3]) {
             eprintln!("{e}");

--- a/patch_clippy.py
+++ b/patch_clippy.py
@@ -1,0 +1,39 @@
+import sys
+
+def main():
+    with open('duke/src/jar_bbcfg.rs', 'r') as f:
+        content = f.read()
+
+    content = content.replace(
+        "class_html.push_str(&format!(\"<title>CFG: {class_name_internal}</title>\\n\"));",
+        "let _ = write!(class_html, \"<title>CFG: {class_name_internal}</title>\\n\");"
+    )
+    content = content.replace(
+        "class_html.push_str(&format!(\"<h1>Class: {}</h1>\\n\", class_name_internal.replace('/', \".\")));",
+        "let _ = write!(class_html, \"<h1>Class: {}</h1>\\n\", class_name_internal.replace('/', \".\"));"
+    )
+    content = content.replace(
+        "class_html.push_str(&format!(\"<h2>Method: {name_str}{desc_str}</h2>\\n\"));",
+        "let _ = write!(class_html, \"<h2>Method: {name_str}{desc_str}</h2>\\n\");"
+    )
+    content = content.replace(
+        "index_html.push_str(&format!(\"<title>JAR BBCFG Report: {jar_path}</title>\\n\"));",
+        "let _ = write!(index_html, \"<title>JAR BBCFG Report: {jar_path}</title>\\n\");"
+    )
+    content = content.replace(
+        "index_html.push_str(&format!(\"<h1>Basic Block CFG Export: {jar_path}</h1>\\n<ul>\\n\"));",
+        "let _ = write!(index_html, \"<h1>Basic Block CFG Export: {jar_path}</h1>\\n<ul>\\n\");"
+    )
+    content = content.replace(
+        "index_html.push_str(&format!(\"  <li><a href=\\\"{link}\\\">{}</a></li>\\n\", name.replace('/', \".\")));",
+        "let _ = write!(index_html, \"  <li><a href=\\\"{link}\\\">{}</a></li>\\n\", name.replace('/', \".\"));"
+    )
+
+    if "std::fmt::Write" not in content:
+        content = content.replace("use std::{fs, path::Path};", "use std::{fmt::Write, fs, path::Path};")
+
+    with open('duke/src/jar_bbcfg.rs', 'w') as f:
+        f.write(content)
+
+if __name__ == '__main__':
+    main()

--- a/patch_clippy2.py
+++ b/patch_clippy2.py
@@ -1,0 +1,32 @@
+import sys
+
+def main():
+    with open('duke/src/jar_bbcfg.rs', 'r') as f:
+        content = f.read()
+
+    content = content.replace(
+        "let _ = write!(class_html, \"<title>CFG: {class_name_internal}</title>\\n\");",
+        "let _ = writeln!(class_html, \"<title>CFG: {class_name_internal}</title>\");"
+    )
+    content = content.replace(
+        "let _ = write!(class_html, \"<h1>Class: {}</h1>\\n\", class_name_internal.replace('/', \".\"));",
+        "let _ = writeln!(class_html, \"<h1>Class: {}</h1>\", class_name_internal.replace('/', \".\"));"
+    )
+    content = content.replace(
+        "let _ = write!(class_html, \"<h2>Method: {name_str}{desc_str}</h2>\\n\");",
+        "let _ = writeln!(class_html, \"<h2>Method: {name_str}{desc_str}</h2>\");"
+    )
+    content = content.replace(
+        "let _ = write!(index_html, \"<title>JAR BBCFG Report: {jar_path}</title>\\n\");",
+        "let _ = writeln!(index_html, \"<title>JAR BBCFG Report: {jar_path}</title>\");"
+    )
+    content = content.replace(
+        "let _ = write!(index_html, \"  <li><a href=\\\"{link}\\\">{}</a></li>\\n\", name.replace('/', \".\"));",
+        "let _ = writeln!(index_html, \"  <li><a href=\\\"{link}\\\">{}</a></li>\", name.replace('/', \".\"));"
+    )
+
+    with open('duke/src/jar_bbcfg.rs', 'w') as f:
+        f.write(content)
+
+if __name__ == '__main__':
+    main()

--- a/patch_main.py
+++ b/patch_main.py
@@ -1,0 +1,35 @@
+import sys
+
+def main():
+    with open('duke/src/main.rs', 'r') as f:
+        lines = f.readlines()
+
+    out = []
+    for line in lines:
+        if line.strip() == "mod html_jar;":
+            out.append(line)
+            out.append("#[cfg(feature = \"nova\")]\n")
+            out.append("mod jar_bbcfg;\n")
+        elif line.strip() == "eprintln!(\"       duke html-jar <file.jar> <output_dir>\");":
+            out.append(line)
+            out.append("        #[cfg(feature = \"nova\")]\n")
+            out.append("        eprintln!(\"       duke bbcfg-jar <file.jar> <output_dir>\");\n")
+        elif line.strip() == "if args.len() >= 4 && args[1] == \"html-jar\" {":
+            out.append("    #[cfg(feature = \"nova\")]\n")
+            out.append("    if args.len() >= 4 && args[1] == \"bbcfg-jar\" {\n")
+            out.append("        if let Err(e) = jar_bbcfg::export_jar_bbcfg(&args[2], &args[3]) {\n")
+            out.append("            eprintln!(\"{e}\");\n")
+            out.append("            process::exit(1);\n")
+            out.append("        }\n")
+            out.append("        return;\n")
+            out.append("    }\n")
+            out.append("\n")
+            out.append(line)
+        else:
+            out.append(line)
+
+    with open('duke/src/main.rs', 'w') as f:
+        f.writelines(out)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
💡 The Spark: I noticed we have Basic Block CFG visualization and JAR loading. Can I make an exporter that generates a full static HTML site for an entire JAR's CFGs?

🚀 The Feature: Created `bbcfg-jar` command to orchestrate `duke_loader`, `duke_classfile`, and `duke_bytecode` to generate interactive Mermaid diagrams.

🔮 The Potential: Developers can visualize the control flow of all methods in their dependencies or applications.

⚠️ Risk: Low, gated behind the `nova` feature flag and self-contained.

---
*PR created automatically by Jules for task [122854956070421638](https://jules.google.com/task/122854956070421638) started by @madmax983*