### PR TITLE
Add URLClassLoader loading support

### DIFF
--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -6092,6 +6092,44 @@ pub(crate) fn native_code_source_get_location(
     }
 }
 
+pub(crate) fn native_url_init(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let spec_slot = extract_slot_arg(args, 1);
+    match spec_slot {
+        Slot::Reference(Some(_)) => {
+            heap.get_mut(this_ref)?.fields[0] = spec_slot;
+            Ok(None)
+        }
+        Slot::Reference(None) => Err(Error::NullPointerException),
+        _ => Err(Error::TypeMismatch {
+            expected: "Reference",
+            got: "other",
+        }),
+    }
+}
+
+pub(crate) fn native_url_to_string(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    match heap.get(this_ref)?.fields.first().copied() {
+        Some(slot @ Slot::Reference(Some(_))) => Ok(Some(slot)),
+        Some(Slot::Reference(None)) => Err(Error::NullPointerException),
+        _ => Err(Error::TypeMismatch {
+            expected: "Reference",
+            got: "other",
+        }),
+    }
+}
+
 pub(crate) fn native_url_to_uri(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
@@ -6102,6 +6140,82 @@ pub(crate) fn native_url_to_uri(
     let spec = string_backed_object_value(heap, this_ref)?;
     let uri_ref = allocate_string_backed_object(heap, "java/net/URI", spec)?;
     Ok(Some(Slot::Reference(Some(uri_ref))))
+}
+
+pub(crate) fn native_url_class_loader_init(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    out: &mut dyn Write,
+    control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let urls_ref = extract_ref_arg(args, 1)?;
+    let url_slots = heap.get(urls_ref)?.fields.clone();
+
+    let path_list_ref = heap.allocate("java/util/ArrayList".to_string(), 1);
+    native_arraylist_init(
+        &[Slot::Reference(Some(path_list_ref))],
+        heap,
+        out,
+        control,
+    )?;
+    for url_slot in url_slots {
+        match url_slot {
+            Slot::Reference(Some(entry_ref)) => {
+                native_arraylist_add(
+                    &[
+                        Slot::Reference(Some(path_list_ref)),
+                        Slot::Reference(Some(entry_ref)),
+                    ],
+                    heap,
+                    out,
+                    control,
+                )?;
+            }
+            Slot::Reference(None) => return Err(Error::NullPointerException),
+            _ => {
+                return Err(Error::TypeMismatch {
+                    expected: "Reference",
+                    got: "other",
+                });
+            }
+        }
+    }
+
+    let ucp_ref = heap.allocate("jdk/internal/loader/URLClassPath".to_string(), 1);
+    heap.get_mut(ucp_ref)?.fields[0] = Slot::Reference(Some(path_list_ref));
+    heap.get_mut(this_ref)?.fields[0] = Slot::Reference(Some(ucp_ref));
+    Ok(None)
+}
+
+pub(crate) fn native_url_class_loader_load_class(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+    ops: &mut dyn CallbackOps,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let name_ref = extract_ref_arg(args, 1)?;
+    let binary_name = string_value_from_ref(heap, name_ref)?;
+    let internal_name = binary_name_to_internal_name(&binary_name);
+
+    if let Some(class_key) = ops.ensure_parent_loaded(&internal_name)? {
+        let class_ref = allocate_class_object(heap, &class_key)?;
+        return Ok(Some(Slot::Reference(Some(class_ref))));
+    }
+
+    match ops.ensure_loaded_with_runtime_loader(heap, this_ref, &internal_name) {
+        Ok(()) => {
+            let class_key = ops.class_key_for_runtime_loader(heap, this_ref, &internal_name)?;
+            let class_ref = allocate_class_object(heap, &class_key)?;
+            Ok(Some(Slot::Reference(Some(class_ref))))
+        }
+        Err(Error::ClassNotFound { .. }) => Err(Error::JavaException {
+            class_name: "java/lang/ClassNotFoundException".to_string(),
+        }),
+        Err(err) => Err(err),
+    }
 }
 
 #[allow(clippy::unnecessary_wraps)]
@@ -13463,6 +13577,17 @@ impl CallbackOps for InterpreterCallbackOps<'_> {
             Err(Error::ClassNotFound {
                 name: class.to_string(),
             })
+        }
+    }
+
+    fn ensure_parent_loaded(&mut self, class: &str) -> Result<Option<String>> {
+        if self.registry.contains(class) {
+            return Ok(Some(class.to_string()));
+        }
+        if self.registry.ensure_loaded(class, self.loader)? && self.registry.contains(class) {
+            Ok(Some(class.to_string()))
+        } else {
+            Ok(None)
         }
     }
 

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -815,6 +815,14 @@ pub trait CallbackOps {
     /// Returns an error if the class cannot be loaded or linked.
     fn ensure_loaded(&mut self, class: &str) -> Result<()>;
 
+    /// Load a class through the parent/default loader without resolving child-loader identities.
+    ///
+    /// # Errors
+    /// Returns an error if parent class lookup fails unexpectedly.
+    fn ensure_parent_loaded(&mut self, _class: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+
     /// Read reflection metadata for a loaded or loadable class.
     ///
     /// # Errors

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -1346,6 +1346,18 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
     registry.register(url_ctx);
     registry.natives_mut().register(
         "java/net/URL",
+        "<init>",
+        "(Ljava/lang/String;)V",
+        native_url_init,
+    );
+    registry.natives_mut().register(
+        "java/net/URL",
+        "toString",
+        "()Ljava/lang/String;",
+        native_url_to_string,
+    );
+    registry.natives_mut().register(
+        "java/net/URL",
         "toURI",
         "()Ljava/net/URI;",
         native_url_to_uri,
@@ -1355,6 +1367,60 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         "setURLStreamHandlerFactory",
         "(Ljava/net/URLStreamHandlerFactory;)V",
         native_url_set_url_stream_handler_factory,
+    );
+
+    let url_class_path_ctx = ClassContext {
+        class_name: "jdk/internal/loader/URLClassPath".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "path".to_string(),
+            descriptor: "Ljava/util/ArrayList;".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    registry.register(url_class_path_ctx);
+
+    let url_class_loader_ctx = ClassContext {
+        class_name: "java/net/URLClassLoader".to_string(),
+        super_class: Some("java/lang/ClassLoader".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "ucp".to_string(),
+            descriptor: "Ljdk/internal/loader/URLClassPath;".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    registry.register(url_class_loader_ctx);
+    registry.natives_mut().register(
+        "java/net/URLClassLoader",
+        "<init>",
+        "([Ljava/net/URL;)V",
+        native_url_class_loader_init,
+    );
+    registry.natives_mut().register(
+        "java/net/URLClassLoader",
+        "<init>",
+        "([Ljava/net/URL;Ljava/lang/ClassLoader;)V",
+        native_url_class_loader_init,
+    );
+    registry.natives_mut().register_callback(
+        "java/net/URLClassLoader",
+        "loadClass",
+        "(Ljava/lang/String;)Ljava/lang/Class;",
+        native_url_class_loader_load_class,
     );
 
     let uri_ctx = ClassContext {

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -18657,6 +18657,112 @@ fn allocate_url_class_loader_for_path(
     loader_ref
 }
 
+fn allocate_url_from_spec(
+    registry: &mut ClassRegistry,
+    heap: &mut duke_gc::Heap,
+    spec: String,
+) -> u64 {
+    let url_ref = heap.allocate(
+        "java/net/URL".to_string(),
+        total_instance_field_count(registry, "java/net/URL"),
+    );
+    init_object_fields(registry, heap, url_ref, "java/net/URL");
+    let spec_ref = heap.allocate_string(spec);
+    let init =
+        match registry
+            .natives_mut()
+            .get_kind("java/net/URL", "<init>", "(Ljava/lang/String;)V")
+        {
+            Some(HandlerKind::Simple(handler)) => handler,
+            other => panic!("expected URL(String) native constructor, got {other:?}"),
+        };
+    init(
+        &[
+            Slot::Reference(Some(url_ref)),
+            Slot::Reference(Some(spec_ref)),
+        ],
+        heap,
+        &mut Vec::new(),
+        &mut NativeControl::default(),
+    )
+    .expect("URL(String) should succeed");
+    url_ref
+}
+
+fn allocate_url_array(heap: &mut duke_gc::Heap, urls: &[u64]) -> u64 {
+    let array_ref = heap.allocate("[Ljava/net/URL;".to_string(), urls.len());
+    heap.get_mut(array_ref).expect("URL[] object").fields = urls
+        .iter()
+        .copied()
+        .map(|url_ref| Slot::Reference(Some(url_ref)))
+        .collect();
+    array_ref
+}
+
+fn allocate_constructed_url_class_loader(
+    registry: &mut ClassRegistry,
+    heap: &mut duke_gc::Heap,
+    urls_ref: u64,
+) -> u64 {
+    let loader_ref = heap.allocate(
+        "java/net/URLClassLoader".to_string(),
+        total_instance_field_count(registry, "java/net/URLClassLoader"),
+    );
+    init_object_fields(registry, heap, loader_ref, "java/net/URLClassLoader");
+    let init = match registry.natives_mut().get_kind(
+        "java/net/URLClassLoader",
+        "<init>",
+        "([Ljava/net/URL;)V",
+    ) {
+        Some(HandlerKind::Simple(handler)) => handler,
+        other => panic!("expected URLClassLoader(URL[]) native constructor, got {other:?}"),
+    };
+    init(
+        &[
+            Slot::Reference(Some(loader_ref)),
+            Slot::Reference(Some(urls_ref)),
+        ],
+        heap,
+        &mut Vec::new(),
+        &mut NativeControl::default(),
+    )
+    .expect("URLClassLoader(URL[]) should succeed");
+    loader_ref
+}
+
+fn load_class_via_url_class_loader(
+    boot_loader: &duke_loader::ZipLoader,
+    registry: &mut ClassRegistry,
+    heap: &mut duke_gc::Heap,
+    loader_ref: u64,
+    binary_name: &str,
+) -> Result<Option<Slot>> {
+    let name_ref = heap.allocate_string(binary_name.to_string());
+    match registry.natives_mut().get_kind(
+        "java/net/URLClassLoader",
+        "loadClass",
+        "(Ljava/lang/String;)Ljava/lang/Class;",
+    ) {
+        Some(HandlerKind::Callback(handler)) => {
+            let mut ops = InterpreterCallbackOps {
+                registry,
+                loader: boot_loader,
+            };
+            handler(
+                &[
+                    Slot::Reference(Some(loader_ref)),
+                    Slot::Reference(Some(name_ref)),
+                ],
+                heap,
+                &mut Vec::new(),
+                &mut NativeControl::default(),
+                &mut ops,
+            )
+        }
+        other => panic!("expected URLClassLoader.loadClass(String) callback, got {other:?}"),
+    }
+}
+
 fn load_duplicate_hello_world_classes() -> (
     duke_loader::ZipLoader,
     ClassRegistry,
@@ -18892,6 +18998,165 @@ fn class_for_name_uses_url_class_loader_file_urls() {
     assert!(
         class_key.starts_with("HelloWorld\0loader:"),
         "expected URLClassLoader class key, got {class_key:?}"
+    );
+}
+
+#[test]
+fn url_class_loader_load_class_reads_from_directory_url() {
+    let boot_loader =
+        duke_loader::ZipLoader::open(&repo_root().join("spring-boot-loader-3.5.12.jar"))
+            .expect("open spring-boot-loader jar");
+    let classes_dir = fixtures_dir().canonicalize().expect("canonical fixtures");
+    let mut registry = ClassRegistry::new();
+    let mut heap = duke_gc::Heap::new();
+    bootstrap_stdlib(&mut registry, &mut heap);
+
+    let classpath_url =
+        allocate_url_from_spec(&mut registry, &mut heap, path_to_file_url(&classes_dir));
+    let url_array_ref = allocate_url_array(&mut heap, &[classpath_url]);
+    let loader_ref = allocate_constructed_url_class_loader(&mut registry, &mut heap, url_array_ref);
+
+    let class_slot = load_class_via_url_class_loader(
+        &boot_loader,
+        &mut registry,
+        &mut heap,
+        loader_ref,
+        "HelloWorld",
+    )
+    .expect("loadClass should succeed")
+    .expect("loadClass should return a Class");
+    let Slot::Reference(Some(class_ref)) = class_slot else {
+        panic!("expected Class reference");
+    };
+    let class_key = class_key_from_ref(&heap, class_ref).expect("class key from mirror");
+    assert!(
+        class_key.starts_with("HelloWorld\0loader:"),
+        "expected directory URLClassLoader class key, got {class_key:?}"
+    );
+}
+
+#[test]
+fn url_class_loader_load_class_reads_from_jar_url() {
+    let boot_loader =
+        duke_loader::ZipLoader::open(&repo_root().join("spring-boot-loader-3.5.12.jar"))
+            .expect("open spring-boot-loader jar");
+    let jar_path = fixtures_dir()
+        .join("hello.jar")
+        .canonicalize()
+        .expect("canonical hello.jar");
+    let mut registry = ClassRegistry::new();
+    let mut heap = duke_gc::Heap::new();
+    bootstrap_stdlib(&mut registry, &mut heap);
+
+    let classpath_url =
+        allocate_url_from_spec(&mut registry, &mut heap, path_to_file_url(&jar_path));
+    let url_array_ref = allocate_url_array(&mut heap, &[classpath_url]);
+    let loader_ref = allocate_constructed_url_class_loader(&mut registry, &mut heap, url_array_ref);
+
+    let class_slot = load_class_via_url_class_loader(
+        &boot_loader,
+        &mut registry,
+        &mut heap,
+        loader_ref,
+        "HelloWorld",
+    )
+    .expect("loadClass should succeed")
+    .expect("loadClass should return a Class");
+    let Slot::Reference(Some(class_ref)) = class_slot else {
+        panic!("expected Class reference");
+    };
+    let class_key = class_key_from_ref(&heap, class_ref).expect("class key from mirror");
+    assert!(
+        class_key.starts_with("HelloWorld\0loader:"),
+        "expected jar URLClassLoader class key, got {class_key:?}"
+    );
+}
+
+#[test]
+fn url_class_loader_instances_isolate_same_binary_name() {
+    let boot_loader =
+        duke_loader::ZipLoader::open(&repo_root().join("spring-boot-loader-3.5.12.jar"))
+            .expect("open spring-boot-loader jar");
+    let jar_path = fixtures_dir()
+        .join("hello.jar")
+        .canonicalize()
+        .expect("canonical hello.jar");
+    let mut registry = ClassRegistry::new();
+    let mut heap = duke_gc::Heap::new();
+    bootstrap_stdlib(&mut registry, &mut heap);
+    let first_url = allocate_url_from_spec(&mut registry, &mut heap, path_to_file_url(&jar_path));
+    let second_url = allocate_url_from_spec(&mut registry, &mut heap, path_to_file_url(&jar_path));
+    let first_urls = allocate_url_array(&mut heap, &[first_url]);
+    let second_urls = allocate_url_array(&mut heap, &[second_url]);
+    let first_loader = allocate_constructed_url_class_loader(&mut registry, &mut heap, first_urls);
+    let second_loader =
+        allocate_constructed_url_class_loader(&mut registry, &mut heap, second_urls);
+
+    let first_slot = load_class_via_url_class_loader(
+        &boot_loader,
+        &mut registry,
+        &mut heap,
+        first_loader,
+        "HelloWorld",
+    )
+    .expect("first loadClass should succeed")
+    .expect("first loadClass should return a Class");
+    let second_slot = load_class_via_url_class_loader(
+        &boot_loader,
+        &mut registry,
+        &mut heap,
+        second_loader,
+        "HelloWorld",
+    )
+    .expect("second loadClass should succeed")
+    .expect("second loadClass should return a Class");
+    let Slot::Reference(Some(first_class_ref)) = first_slot else {
+        panic!("expected first Class reference");
+    };
+    let Slot::Reference(Some(second_class_ref)) = second_slot else {
+        panic!("expected second Class reference");
+    };
+    let first_key = class_key_from_ref(&heap, first_class_ref).expect("first class key");
+    let second_key = class_key_from_ref(&heap, second_class_ref).expect("second class key");
+
+    assert_ne!(first_key, second_key);
+    assert!(first_key.ends_with(&format!("loader:{first_loader}")));
+    assert!(second_key.ends_with(&format!("loader:{second_loader}")));
+}
+
+#[test]
+fn url_class_loader_load_class_missing_throws_class_not_found() {
+    let boot_loader =
+        duke_loader::ZipLoader::open(&repo_root().join("spring-boot-loader-3.5.12.jar"))
+            .expect("open spring-boot-loader jar");
+    let jar_path = fixtures_dir()
+        .join("hello.jar")
+        .canonicalize()
+        .expect("canonical hello.jar");
+    let mut registry = ClassRegistry::new();
+    let mut heap = duke_gc::Heap::new();
+    bootstrap_stdlib(&mut registry, &mut heap);
+
+    let classpath_url =
+        allocate_url_from_spec(&mut registry, &mut heap, path_to_file_url(&jar_path));
+    let url_array_ref = allocate_url_array(&mut heap, &[classpath_url]);
+    let loader_ref = allocate_constructed_url_class_loader(&mut registry, &mut heap, url_array_ref);
+
+    let result = load_class_via_url_class_loader(
+        &boot_loader,
+        &mut registry,
+        &mut heap,
+        loader_ref,
+        "com.example.DoesNotExist",
+    );
+
+    assert!(
+        matches!(
+            result,
+            Err(Error::JavaException { ref class_name })
+                if class_name == "java/lang/ClassNotFoundException"
+        ),
+        "missing class should throw ClassNotFoundException, got {result:?}"
     );
 }
 


### PR DESCRIPTION
## Summary
- Add native `java/net/URL` initialization and string conversion support
- Introduce synthetic `URLClassPath` and `URLClassLoader` stubs in the stdlib bootstrap
- Implement `URLClassLoader.loadClass` with parent-first loading and class-not-found handling
- Add unit tests covering directory URLs, jar URLs, loader isolation, and missing-class errors

## Testing
- Added unit tests for URL construction and `URLClassLoader` class loading behavior
- Not run (not requested)