### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -13,3 +13,7 @@
 ## 2024-05-20 - [SwitchTargets Documentation]
 **Confusion:** The `SwitchTargets` iterator for `tableswitch` and `lookupswitch` was completely undocumented, making it difficult to understand how switch targets are resolved at runtime.
 **Clarification:** Added module-level documentation and an executable doctest explaining how `SwitchTargets` unifies the two switch mechanisms and provides a clean iterator over match values and offsets.
+
+## 2024-05-21 - [ReflectedAnnotationConst Documentation]
+**Confusion:** The `ReflectedAnnotationConst` enum lacked documentation for its variants and was missing module-level examples, leading to `missing_docs` clippy warnings and making it hard to understand how raw JVM annotation values map to Rust.
+**Clarification:** Added complete documentation for each enum variant, explaining their JVM equivalents, and included an executable doctest demonstrating basic usage.

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -208,7 +208,9 @@ pub enum ReflectedAnnotationValue {
     Const(ReflectedAnnotationConst),
     /// Enum constant, stored as enum type internal name and constant name.
     Enum {
+        /// The internal name of the enum type (e.g., `java/lang/annotation/RetentionPolicy`).
         type_name: String,
+        /// The exact string name of the enum constant (e.g., `RUNTIME`).
         const_name: String,
     },
     /// Class literal internal name or primitive descriptor.
@@ -220,16 +222,39 @@ pub enum ReflectedAnnotationValue {
 }
 
 /// Primitive and `String` annotation constants.
+///
+/// This enum represents all possible primitive and `String` constant values
+/// that can be embedded directly within a Java annotation element. They are
+/// mapped from the raw classfile constant pool into these owned Rust types
+/// for easy runtime reflection access.
+///
+/// ## Examples
+///
+/// ```
+/// use duke_interpreter::ReflectedAnnotationConst;
+///
+/// let byte_val = ReflectedAnnotationConst::Byte(42);
+/// let str_val = ReflectedAnnotationConst::String("Test".to_string());
+/// ```
 #[derive(Debug, Clone, PartialEq)]
 pub enum ReflectedAnnotationConst {
+    /// A `byte` constant, internally promoted to `i32` following JVM conventions.
     Byte(i32),
+    /// A `char` constant, internally promoted to `i32` representing the UTF-16 code point.
     Char(i32),
+    /// A 64-bit IEEE 754 floating-point `double` constant.
     Double(f64),
+    /// A 32-bit IEEE 754 floating-point `float` constant.
     Float(f32),
+    /// A 32-bit signed `int` constant.
     Int(i32),
+    /// A 64-bit signed `long` constant.
     Long(i64),
+    /// A `short` constant, internally promoted to `i32` following JVM conventions.
     Short(i32),
+    /// A `boolean` constant, parsed from the integer `1` (true) or `0` (false) in the classfile.
     Boolean(bool),
+    /// A resolved `java.lang.String` constant value.
     String(String),
 }
 


### PR DESCRIPTION
📖 Chapter: The `ReflectedAnnotationValue::Enum` and `ReflectedAnnotationConst` types in `duke_interpreter::registry`.
🔦 Insight: Clarified how raw JVM annotation element values and primitive constants map directly to Rust types, fixing missing_docs lints.
🧪 Example: Added 1 executable doctest for `ReflectedAnnotationConst`.
🖼️ Preview: Resolved all clippy missing_docs warnings in the workspace.

---
*PR created automatically by Jules for task [636232557046606171](https://jules.google.com/task/636232557046606171) started by @madmax983*