### PR TITLE
🗺️ Atlas: [restrict reachability module]

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -1,3 +1,7 @@
 **Standardize Workspace Error Types**
 **Tangle:** Each module defined its own duplicate aliases like `VmResult`, `LoadResult`, and `ParseError`, breaking standardized `Result<T, crate::Error>` rules.
 **Blueprint:** Removed domain-specific error aliases in favor of standard `Result` and `Error` types across all crates.
+
+**Restrict Internal Submodules**
+**Tangle:** The `reachability` module in `duke-bytecode` was exposed as `pub mod` but acted strictly as an internal implementation detail, leaking the architectural boundary.
+**Blueprint:** Altered its visibility to `pub(crate) mod` and explicitly exported only the necessary types in the facade `lib.rs` (via `pub use`) to enforce encapsulation.

--- a/crates/duke-bytecode/src/lib.rs
+++ b/crates/duke-bytecode/src/lib.rs
@@ -17,10 +17,9 @@ pub(crate) mod error;
 pub(crate) mod instruction;
 pub(crate) mod opcodes;
 #[cfg(feature = "nova")]
-pub mod reachability;
+pub(crate) mod reachability;
 pub(crate) mod verifier;
 
-#[cfg(feature = "nova")]
 pub use basic_block::{BasicBlock, build_basic_blocks};
 pub use call_graph::generate_mermaid_call_graph;
 #[cfg(feature = "nova")]
@@ -29,6 +28,8 @@ pub use cfg::{cyclomatic_complexity, generate_mermaid_cfg};
 pub use decoder::decode;
 pub use error::{DecodeError, Error, Result, VerifyError};
 pub use instruction::{ArrayType, Instruction};
+#[cfg(feature = "nova")]
+pub use reachability::{find_dead_blocks, find_shortest_path, get_successors};
 pub use verifier::verify;
 
 #[cfg(test)]

--- a/duke/src/pathfinding.rs
+++ b/duke/src/pathfinding.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::items_after_statements)]
 #[cfg(feature = "nova")]
-use duke_bytecode::{build_basic_blocks, decode, reachability::find_shortest_path};
+use duke_bytecode::{build_basic_blocks, decode, find_shortest_path};
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,


### PR DESCRIPTION
🕸️ Tangle: The `reachability` module in `duke-bytecode` was exposed as `pub mod` but acted strictly as an internal implementation detail, leaking the architectural boundary.
📐 Blueprint: Altered its visibility to `pub(crate) mod` and explicitly exported only the necessary types in the facade `lib.rs` (via `pub use`) to enforce encapsulation.
🧱 Stability: Reduced coupling, preventing leaky abstractions.
🔬 Verification: Builds successfully, strict separation enforced. Tested with `cargo clippy`, `cargo test`, and `cargo fmt`.

---
*PR created automatically by Jules for task [8636138388978911011](https://jules.google.com/task/8636138388978911011) started by @madmax983*