### PR TITLE
🛡️ Sentry: [test coverage improvement] Added io_tests for TelemetryStore::print_report

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -20,3 +20,6 @@
 ## 2024-05-24 - Testing JImage Parsing Bounds
 **Learning:** JImage parsing edge cases with artificially corrupted files (`0x0001_0000` version tag required) that use `u64::MAX` or out-of-bounds offset metadata effectively verify robust error propagation in `duke_loader::JImageReader::read_resource`, ensuring we catch regressions that could otherwise cause out-of-bounds panics or incorrect bounds checks against raw uncompressed lengths.
 **Action:** Always test metadata parsers using edge-case inputs (e.g. `u64::MAX`, bounds mismatches) to verify format-specific bounds checking fails gracefully rather than panicking on indexing.
+## 2024-05-24 - Testing error paths for print functions
+**Learning:** Using a custom struct that implements `Write` and intentionally returns `io::Error` is a clean way to test the error paths of display or report functions, making sure that errors propagate or get handled instead of just running the happy path.
+**Action:** Implement a `FailingWriter` dummy object for testing formatting and printing APIs.

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -529,3 +529,34 @@ mod tests {
         assert!(res.is_err());
     }
 }
+
+#[cfg(test)]
+mod io_tests {
+    use super::*;
+
+    struct FailingWriter;
+    impl std::io::Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("disk full"))
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "telemetry")]
+    fn test_print_report_io_error() {
+        let mut store = TelemetryStore::default();
+        store.bytecode_cost.record("iadd", "Foo", "bar", 10, 100);
+        store.object_lineage.record("java/lang/String", "Foo", 10, "bar");
+        store.class_init_dag.record("java/lang/String", "java/lang/System", 500);
+        store.exception_flow.record_throw("java/lang/Exception", "Foo", "bar", 10);
+        store.dispatch_resolution.record("Foo", 42, "java/lang/String", true);
+        store.native_boundary.record_call("java/lang/String", "intern", 100, true);
+
+        let mut w = FailingWriter;
+        let res = store.print_report(&mut w);
+        assert!(res.is_err());
+    }
+}


### PR DESCRIPTION
Added a test in `duke-telemetry/src/lib.rs` that passes a failing mock writer (`FailingWriter`) to `TelemetryStore::print_report`, verifying that `std::io::Error`s correctly bubble up instead of panicking or failing silently. Also updated `.jules/sentry.md` to document this learning.

---
*PR created automatically by Jules for task [6519534076885213743](https://jules.google.com/task/6519534076885213743) started by @madmax983*