### PR TITLE
⚒️ Forge: [refactoring control_flow_targets to use control_flow_edges]

### DIFF
--- a/crates/duke-bytecode/src/instruction.rs
+++ b/crates/duke-bytecode/src/instruction.rs
@@ -564,33 +564,10 @@ impl Instruction {
     )]
     #[must_use]
     pub fn control_flow_targets(&self, current_pc: usize, next_pc: Option<usize>) -> Vec<usize> {
-        let mut targets = Vec::new();
-        if self.is_return() {
-            return targets;
-        }
-        if let Some(offset) = self.unconditional_jump_target() {
-            targets.push((current_pc as isize + offset) as usize);
-            if self.is_subroutine_call() {
-                if let Some(next) = next_pc {
-                    targets.push(next);
-                }
-            }
-        } else if let Some(offset) = self.conditional_branch_target() {
-            targets.push((current_pc as isize + offset) as usize);
-            if let Some(next) = next_pc {
-                targets.push(next);
-            }
-        } else if let Some((default, pairs)) = self.switch_targets() {
-            targets.push((current_pc as isize + default as isize) as usize);
-            for (_, offset) in pairs {
-                targets.push((current_pc as isize + offset as isize) as usize);
-            }
-        } else {
-            if let Some(next) = next_pc {
-                targets.push(next);
-            }
-        }
-        targets
+        self.control_flow_edges(current_pc, next_pc)
+            .into_iter()
+            .map(|(target, _)| target)
+            .collect()
     }
 
     /// Returns a list of target PCs and their optional edge labels (e.g., `"true"`, `"false"`, `"default"`)


### PR DESCRIPTION
This PR addresses a code duplication smell in `Instruction::control_flow_targets`.

🚮 **Smell:** Duplicate logic in `Instruction::control_flow_targets` that largely copies what is in `Instruction::control_flow_edges`.
✨ **Solution:** Refactored `Instruction::control_flow_targets` to reuse `self.control_flow_edges` and map over the results to extract the target PCs.
🧼 **Benefit:** DRYs up the code, reducing the likelihood of these two conceptually similar functions drifting out of sync.
🛡️ **Verification:** `cargo clippy`, `cargo fmt`, and `cargo test` passed successfully without any changes in logic.

---
*PR created automatically by Jules for task [2237398220251925054](https://jules.google.com/task/2237398220251925054) started by @madmax983*