### PR TITLE
⚡ Bolt: Remove format! allocations in ZipLoader

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,6 @@
 **Pre-allocate HashMap with `HashMap::with_capacity` when size is known**
 **Learning:** `HashMap::new()` requires constant reallocation when inserting elements, which is extremely expensive, especially in critical paths like parsing large class files or JAR headers where the size is easily knowable beforehand.
 **Action:** Always prefer `HashMap::with_capacity` instead of `HashMap::new` when the capacity of the map is known up front to eliminate unnecessary intermediate memory allocations and resizing.
+**Pre-allocate String capacity instead of format! macro**
+**Learning:** Using `format!("prefix{value}")` inside loops or hot paths creates unnecessary intermediate heap allocations and string operations that slow down the application.
+**Action:** When creating strings from known prefixes/suffixes, calculate the exact length with `String::with_capacity(prefix.len() + value.len())` and use `push_str()` directly to achieve zero-cost abstraction.

--- a/crates/duke-loader/src/zip.rs
+++ b/crates/duke-loader/src/zip.rs
@@ -385,7 +385,10 @@ impl ClassLoader for ZipLoader {
             result => return result,
         }
 
-        let boot_inf_name = format!("BOOT-INF/classes/{name}");
+        // ⚡ Bolt: Eliminate intermediate String allocation and format! macro overhead
+        let mut boot_inf_name = String::with_capacity(name.len() + 17);
+        boot_inf_name.push_str("BOOT-INF/classes/");
+        boot_inf_name.push_str(name);
         match self.reader.read_entry(&boot_inf_name) {
             Err(Error::NotFound { .. }) => {}
             result => return result,
@@ -410,7 +413,10 @@ impl ClassLoader for ZipLoader {
             Err(err) => return Err(err),
         }
 
-        let boot_inf_name = format!("BOOT-INF/classes/{name}");
+        // ⚡ Bolt: Eliminate intermediate String allocation and format! macro overhead
+        let mut boot_inf_name = String::with_capacity(name.len() + 17);
+        boot_inf_name.push_str("BOOT-INF/classes/");
+        boot_inf_name.push_str(name);
         match self.reader.read_entry(&boot_inf_name) {
             Ok(bytes) => resources.push(bytes),
             Err(Error::NotFound { .. }) => {}


### PR DESCRIPTION
💡 What: Replaced the `format!("BOOT-INF/classes/{name}")` macro inside `ZipLoader` with `String::with_capacity` and `push_str`.
🎯 Why: `find_resource` and `find_resources` are called constantly as the classloader traverses dependencies to resolve paths. `format!` creates temporary string buffers and has formatting machinery overhead.
📊 Impact: Removes unnecessary intermediate heap allocations and string formatting overhead, calculating exact string capacity required.
🔬 Measurement: Verify via `cargo test -p duke-loader` indicating all functionality resolves as previously, and verify code coverage.

---
*PR created automatically by Jules for task [960556938688055690](https://jules.google.com/task/960556938688055690) started by @madmax983*