### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -20,3 +20,10 @@
 ## 2024-05-24 - Testing JImage Parsing Bounds
 **Learning:** JImage parsing edge cases with artificially corrupted files (`0x0001_0000` version tag required) that use `u64::MAX` or out-of-bounds offset metadata effectively verify robust error propagation in `duke_loader::JImageReader::read_resource`, ensuring we catch regressions that could otherwise cause out-of-bounds panics or incorrect bounds checks against raw uncompressed lengths.
 **Action:** Always test metadata parsers using edge-case inputs (e.g. `u64::MAX`, bounds mismatches) to verify format-specific bounds checking fails gracefully rather than panicking on indexing.
+## 2024-05-24 - Testing Zip Reader Truncated Central Directories
+**Learning:** Certain edge cases in `parse_central_directory` related to `checked_add` bounds checking (like `name_start + filename_len > cd_end`) were previously uncovered, because most fuzzed zips generate completely malformed data rather than specific boundary truncations.
+**Action:** Craft specific byte buffers representing minimal zip central directories, manually defining exact `filename_len` or `cd_size` values that force the `checked_add` validation to fail gracefully without overflowing.
+
+## 2024-05-24 - Testing Duke Telemetry Serde Map Emptiness
+**Learning:** `keyed_map` formatting utilities using `serialize_map` were missing tests to ensure empty HashMaps correctly serialize as `{}`.
+**Action:** Adding tests for `HashMap::new()` in serialization wrappers proves correct behavior.

--- a/crates/duke-loader/src/zip.rs
+++ b/crates/duke-loader/src/zip.rs
@@ -1297,6 +1297,77 @@ mod tests {
     }
 
     #[test]
+    fn test_cd_entry_filename_truncated() {
+        let mut zip_data = Vec::new();
+        let central_dir_offset = 0;
+        let cd_signature: u32 = 0x0201_4b50;
+        zip_data.extend_from_slice(&cd_signature.to_le_bytes()); // CD signature
+        zip_data.extend_from_slice(&[0; 24]);
+        let name = b"abcde";
+        zip_data.extend_from_slice(&(10_u16).to_le_bytes()); // filename len
+        zip_data.extend_from_slice(&0_u16.to_le_bytes()); // extra len
+        zip_data.extend_from_slice(&0_u16.to_le_bytes()); // comment len
+        zip_data.extend_from_slice(&[0; 8]);
+        zip_data.extend_from_slice(&0_u32.to_le_bytes()); // local header offset
+        zip_data.extend_from_slice(name); // filename (truncated)
+
+        let central_dir_size = (zip_data.len() as u32) - central_dir_offset;
+        let eocd_signature: u32 = 0x0605_4b50;
+        zip_data.extend_from_slice(&eocd_signature.to_le_bytes());
+        zip_data.extend_from_slice(&[0; 4]);
+        zip_data.extend_from_slice(&1_u16.to_le_bytes());
+        zip_data.extend_from_slice(&1_u16.to_le_bytes());
+        zip_data.extend_from_slice(&central_dir_size.to_le_bytes());
+        zip_data.extend_from_slice(&central_dir_offset.to_le_bytes());
+        zip_data.extend_from_slice(&0_u16.to_le_bytes());
+
+        let err = ZipReader::from_bytes(zip_data).unwrap_err();
+        assert!(
+            matches!(err, Error::ZipFormat { ref msg } if msg == "central directory entry filename truncated")
+        );
+    }
+
+    #[test]
+    fn test_cd_entry_truncated() {
+        let mut zip_data = Vec::new();
+        let central_dir_offset = 0;
+        let cd_signature: u32 = 0x0201_4b50;
+        zip_data.extend_from_slice(&cd_signature.to_le_bytes());
+        zip_data.extend_from_slice(&[0; 10]); // Truncated CD entry
+        let central_dir_size = (zip_data.len() as u32) - central_dir_offset;
+
+        let eocd_signature: u32 = 0x0605_4b50;
+        zip_data.extend_from_slice(&eocd_signature.to_le_bytes());
+        zip_data.extend_from_slice(&[0; 4]);
+        zip_data.extend_from_slice(&1_u16.to_le_bytes());
+        zip_data.extend_from_slice(&1_u16.to_le_bytes());
+        zip_data.extend_from_slice(&central_dir_size.to_le_bytes());
+        zip_data.extend_from_slice(&central_dir_offset.to_le_bytes());
+        zip_data.extend_from_slice(&0_u16.to_le_bytes());
+
+        let err = ZipReader::from_bytes(zip_data).unwrap_err();
+        assert!(
+            matches!(err, Error::ZipFormat { ref msg } if msg == "central directory entry truncated")
+        );
+    }
+
+    #[test]
+    fn test_zip_uncompressed_limit_exceeded() {
+        // Build a minimal zip and corrupt the uncompressed size.
+        let zip = build_deflated_zip("huge.txt", b"small data");
+        let reader = ZipReader::from_bytes(zip).expect("should parse");
+
+        let info = reader.get_entry("huge.txt").unwrap();
+        let mut corrupted_info = info.clone();
+
+        // Corrupt uncompressed size to be greater than 256MB
+        corrupted_info.uncompressed_size = (1024 * 1024 * 257) as u64;
+
+        let err = reader.read_entry_info(&corrupted_info).unwrap_err();
+        assert!(matches!(err, Error::ZipFormat { ref msg } if msg.contains("exceeds limit")));
+    }
+
+    #[test]
     fn test_zip_loader_try_nested_read_entry_error() {
         let mut nested_jar = build_stored_zip("Bad.class", b"data");
         nested_jar[0] ^= 0xFF;

--- a/crates/duke-telemetry/src/helpers.rs
+++ b/crates/duke-telemetry/src/helpers.rs
@@ -107,6 +107,13 @@ mod tests {
     }
 
     #[test]
+    fn test_empty_serialize() {
+        let empty_map = HashMap::<i32, &'static str>::new();
+        let w = MapWrapper { map: empty_map };
+        let json = serde_json::to_string(&w).unwrap();
+        assert_eq!(json, r#"{"map":{}}"#);
+    }
+    #[test]
     fn test_keyed_map() {
         let mut map = HashMap::new();
         map.insert(1, "one");

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -417,6 +417,18 @@ mod tests {
 
     #[test]
     #[cfg(feature = "telemetry")]
+    fn test_print_report_empty() {
+        let store = TelemetryStore::default();
+        let mut buf = Vec::new();
+        store.print_report(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("=== Duke VM Telemetry Report ==="));
+        assert!(s.contains("No class initialization events recorded."));
+        assert!(s.contains("No exception flow events recorded."));
+    }
+
+    #[test]
+    #[cfg(feature = "telemetry")]
     fn should_correctly_format_print_report_with_populated_data() {
         let mut store = TelemetryStore::default();
         store.bytecode_cost.record("iadd", "Foo", "bar", 10, 100);

--- a/pr_details.txt
+++ b/pr_details.txt
@@ -1,7 +1,6 @@
-Title: ⚡ Bolt: [Optimize loading times by pre-allocating HashMaps]
-
-Description:
-- 💡 What: Switched `HashMap::new()` to `HashMap::with_capacity()` during parsing headers in test setups for `zip::ZipLoader` and `jimage::JImageReader`.
-- 🎯 Why: The size of these mappings is strictly known up front by inspecting the zip central directory count or the jimage header table size. Allocating with the known capacity avoids continuous re-allocations and resizing operations while populating thousands of file paths, eliminating heavy O(N) memory allocation costs.
-- 📊 Impact: Measurably reduces heap allocations, memory copying overhead, and CPU cycles during class loading phases.
-- 🔬 Measurement: Run bench `cargo bench` to observe reduced memory allocations and faster startup/loading times.
+Title: 🛡️ Sentry: [test coverage improvement]
+Body:
+🎯 Target: `duke_loader::ZipReader::read_entry_info`, `duke_loader::parse_central_directory`, and `duke_telemetry::ser_helpers`.
+💣 Risk: Edge cases where zip central directories have truncated entries or mismatched local header offsets, and missing telemetry map empty paths could panic or fail implicitly if refactored.
+🧪 Strategy: Added specific inline tests inside `crates/duke-loader/src/zip.rs` to reach missing branches of Zip Format errors (e.g. truncated `filename_len`, exceeded `uncompressed_size`). Added tests in `crates/duke-telemetry/src/helpers.rs` for empty map serialization. Added an empty check for `print_report`.
+🔭 Verification: `cargo test -p duke-loader` and `cargo test -p duke-telemetry`


### PR DESCRIPTION
🎯 Target: `duke_loader::ZipReader::read_entry_info`, `duke_loader::parse_central_directory`, and `duke_telemetry::ser_helpers`.
💣 Risk: Edge cases where zip central directories have truncated entries or mismatched local header offsets, and missing telemetry map empty paths could panic or fail implicitly if refactored.
🧪 Strategy: Added specific inline tests inside `crates/duke-loader/src/zip.rs` to reach missing branches of Zip Format errors (e.g. truncated `filename_len`, exceeded `uncompressed_size`). Added tests in `crates/duke-telemetry/src/helpers.rs` for empty map serialization. Added an empty check for `print_report`.
🔭 Verification: `cargo test -p duke-loader` and `cargo test -p duke-telemetry`

---
*PR created automatically by Jules for task [15273578496202629287](https://jules.google.com/task/15273578496202629287) started by @madmax983*