### PR TITLE
⚒️ Forge: [Extract Bounds-Checking Pre-Allocations]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -68,3 +68,7 @@
 **Extract Control Flow Graph Edges**
 **Learning:** `generate_mermaid_cfg`, `generate_basic_block_cfg`, and `cyclomatic_complexity` in `crates/duke-bytecode/src/cfg.rs` shared complex, duplicated matching logic to determine the control flow edges of instructions (using `is_return()`, `unconditional_jump_target()`, `conditional_branch_target()`, `switch_targets()`).
 **Action:** Created `Instruction::control_flow_edges` to centralize this logic, returning a generic list of `(target_pc, Option<label>)` tuples. This massively simplified all three functions by replacing their redundant if-else chains with a simple loop over the extracted edges.
+
+**Extract Bounds-Checking Pre-Allocations**
+**Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
+**Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -38,9 +38,19 @@ impl<'a> Cursor<'a> {
         self.pos
     }
 
-    #[allow(dead_code)]
     const fn remaining(&self) -> usize {
         self.data.len() - self.pos
+    }
+
+    /// Calculates a safe pre-allocation capacity that will not exceed the remaining
+    /// available bytes in the buffer, preventing OOM attacks from maliciously large counts.
+    const fn safe_capacity(&self, requested: usize, bytes_per_item: usize) -> usize {
+        let max_possible = self.remaining() / bytes_per_item;
+        if requested < max_possible {
+            requested
+        } else {
+            max_possible
+        }
     }
 
     fn read_u8(&mut self) -> Result<u8> {
@@ -174,21 +184,21 @@ fn parse_class_members(
 
     // interfaces
     let interfaces_count = c.read_u16()?;
-    let mut interfaces = Vec::with_capacity((interfaces_count as usize).min(c.remaining() / 2));
+    let mut interfaces = Vec::with_capacity(c.safe_capacity(interfaces_count as usize, 2));
     for _ in 0..interfaces_count {
         interfaces.push(c.read_cp_index()?);
     }
 
     // fields
     let fields_count = c.read_u16()?;
-    let mut fields = Vec::with_capacity((fields_count as usize).min(c.remaining() / 8));
+    let mut fields = Vec::with_capacity(c.safe_capacity(fields_count as usize, 8));
     for _ in 0..fields_count {
         fields.push(parse_field(c, cp_len)?);
     }
 
     // methods
     let methods_count = c.read_u16()?;
-    let mut methods = Vec::with_capacity((methods_count as usize).min(c.remaining() / 8));
+    let mut methods = Vec::with_capacity(c.safe_capacity(methods_count as usize, 8));
     for _ in 0..methods_count {
         methods.push(parse_method(c, cp_len)?);
     }
@@ -364,7 +374,7 @@ fn parse_method(c: &mut Cursor<'_>, cp_len: usize) -> Result<MethodInfo> {
 
 fn parse_attributes(c: &mut Cursor<'_>, cp_len: usize) -> Result<Vec<AttributeInfo>> {
     let count = c.read_u16()?;
-    let mut attributes = Vec::with_capacity((count as usize).min(c.remaining() / 6));
+    let mut attributes = Vec::with_capacity(c.safe_capacity(count as usize, 6));
     for _ in 0..count {
         attributes.push(parse_attribute(c, cp_len)?);
     }
@@ -449,7 +459,7 @@ fn decode_source_file(c: &mut Cursor<'_>) -> Result<CpIndex> {
 
 fn decode_line_number_table(c: &mut Cursor<'_>) -> Result<Vec<LineNumberEntry>> {
     let len = c.read_u16()? as usize;
-    let mut entries = Vec::with_capacity(len.min(c.remaining() / 4));
+    let mut entries = Vec::with_capacity(c.safe_capacity(len, 4));
     for _ in 0..len {
         entries.push(LineNumberEntry {
             start_pc: c.read_u16()?,
@@ -461,7 +471,7 @@ fn decode_line_number_table(c: &mut Cursor<'_>) -> Result<Vec<LineNumberEntry>> 
 
 fn decode_local_variable_table(c: &mut Cursor<'_>) -> Result<Vec<LocalVariableEntry>> {
     let len = c.read_u16()? as usize;
-    let mut entries = Vec::with_capacity(len.min(c.remaining() / 10));
+    let mut entries = Vec::with_capacity(c.safe_capacity(len, 10));
     for _ in 0..len {
         entries.push(LocalVariableEntry {
             start_pc: c.read_u16()?,
@@ -476,7 +486,7 @@ fn decode_local_variable_table(c: &mut Cursor<'_>) -> Result<Vec<LocalVariableEn
 
 fn decode_exceptions(c: &mut Cursor<'_>) -> Result<Vec<CpIndex>> {
     let num = c.read_u16()? as usize;
-    let mut table = Vec::with_capacity(num.min(c.remaining() / 2));
+    let mut table = Vec::with_capacity(c.safe_capacity(num, 2));
     for _ in 0..num {
         table.push(c.read_cp_index()?);
     }
@@ -485,11 +495,11 @@ fn decode_exceptions(c: &mut Cursor<'_>) -> Result<Vec<CpIndex>> {
 
 fn decode_bootstrap_methods(c: &mut Cursor<'_>) -> Result<Vec<BootstrapMethodEntry>> {
     let num = c.read_u16()? as usize;
-    let mut entries = Vec::with_capacity(num.min(c.remaining() / 4));
+    let mut entries = Vec::with_capacity(c.safe_capacity(num, 4));
     for _ in 0..num {
         let method_ref = c.read_cp_index()?;
         let num_args = c.read_u16()? as usize;
-        let mut arguments = Vec::with_capacity(num_args.min(c.remaining() / 2));
+        let mut arguments = Vec::with_capacity(c.safe_capacity(num_args, 2));
         for _ in 0..num_args {
             arguments.push(c.read_cp_index()?);
         }
@@ -503,7 +513,7 @@ fn decode_bootstrap_methods(c: &mut Cursor<'_>) -> Result<Vec<BootstrapMethodEnt
 
 fn decode_runtime_visible_annotations(c: &mut Cursor<'_>) -> Result<Vec<Annotation>> {
     let num_annotations = c.read_u16()? as usize;
-    let mut annotations = Vec::with_capacity(num_annotations.min(c.remaining() / 4));
+    let mut annotations = Vec::with_capacity(c.safe_capacity(num_annotations, 4));
     for _ in 0..num_annotations {
         annotations.push(decode_annotation(c)?);
     }
@@ -513,7 +523,7 @@ fn decode_runtime_visible_annotations(c: &mut Cursor<'_>) -> Result<Vec<Annotati
 fn decode_annotation(c: &mut Cursor<'_>) -> Result<Annotation> {
     let type_index = c.read_cp_index()?;
     let num_pairs = c.read_u16()? as usize;
-    let mut element_value_pairs = Vec::with_capacity(num_pairs.min(c.remaining() / 3));
+    let mut element_value_pairs = Vec::with_capacity(c.safe_capacity(num_pairs, 3));
     for _ in 0..num_pairs {
         element_value_pairs.push(ElementValuePair {
             element_name_index: c.read_cp_index()?,
@@ -540,7 +550,7 @@ fn decode_element_value(c: &mut Cursor<'_>) -> Result<ElementValue> {
         b'@' => Ok(ElementValue::AnnotationValue(decode_annotation(c)?)),
         b'[' => {
             let num_values = c.read_u16()? as usize;
-            let mut values = Vec::with_capacity(num_values.min(c.remaining() / 3));
+            let mut values = Vec::with_capacity(c.safe_capacity(num_values, 3));
             for _ in 0..num_values {
                 values.push(decode_element_value(c)?);
             }
@@ -558,7 +568,7 @@ fn parse_code_attribute(c: &mut Cursor<'_>) -> Result<CodeAttribute> {
     let code = c.read_bytes(code_len)?.to_vec();
 
     let ex_count = c.read_u16()? as usize;
-    let mut exception_table = Vec::with_capacity(ex_count.min(c.remaining() / 8));
+    let mut exception_table = Vec::with_capacity(c.safe_capacity(ex_count, 8));
     for _ in 0..ex_count {
         exception_table.push(ExceptionTableEntry {
             start_pc: c.read_u16()?,
@@ -571,7 +581,7 @@ fn parse_code_attribute(c: &mut Cursor<'_>) -> Result<CodeAttribute> {
     // Code sub-attributes (LineNumberTable etc.) — stored as Raw for now;
     // resolve_attributes will decode them.
     let attr_count = c.read_u16()? as usize;
-    let mut attributes = Vec::with_capacity(attr_count.min(c.remaining() / 6));
+    let mut attributes = Vec::with_capacity(c.safe_capacity(attr_count, 6));
     for _ in 0..attr_count {
         let name_index = c.read_cp_index()?;
         let attr_len = c.read_u32()? as usize;


### PR DESCRIPTION
🚮 **Smell:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.

✨ **Solution:** Extracted raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method `Cursor::safe_capacity`. Updated all 14 parsing sites to use this helper. Removed `#[allow(dead_code)]` from `Cursor::remaining` as it is now used.

🧼 **Benefit:** Strictly delineates parsing intent from anti-OOM arithmetic. Removes repeated visual noise and provides a single source of truth for safe capacity calculations.

🛡️ **Verification:** Tests passed. No logic changed.

---
*PR created automatically by Jules for task [11006966454512460334](https://jules.google.com/task/11006966454512460334) started by @madmax983*