### PR TITLE
🛡️ Sentry: [test coverage improvement] for duke-telemetry

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -1,3 +1,6 @@
+## 2024-05-24 - Testing Format and Serialization Output Gaps
+**Learning:** Functions that generate user-facing outputs or interact with deep serialization layers like `serde` might fail testing because error flows only occur when standard types wrap custom objects specifically built to fail during serialization. Additionally, testing format outputs (like empty reports vs populated reports) requires full mock states or testing for length boundaries inside iterator consumers like `take(10)`.
+**Action:** When filling telemetry or reporting coverage gaps, use custom struct mock objects (e.g. `FailingSerializer`) or explicitly trigger less-than bounds logic (e.g. 1 item for a `take(10)`) to get 100% path coverage for outputs.
 ## 2026-04-16 - Increased code coverage for duke-telemetry
 **Learning:** Using tools like `cargo tarpaulin` allowed finding untested behavior in `duke-telemetry`. Many `assert!` clauses were checking for string content that relied upon default settings. I added several targeted tests for `duke-bytecode` and `duke-telemetry`.
 **Action:** Adding new tests to handle explicit empty states and different JSON outputs helps prevent regressions in formatting logic.

--- a/crates/duke-telemetry/src/helpers.rs
+++ b/crates/duke-telemetry/src/helpers.rs
@@ -204,4 +204,235 @@ mod tests {
         let json = serde_json::to_string(&w).unwrap();
         assert_eq!(json, r#"{"set":["a","b","c"]}"#);
     }
+
+    #[derive(Serialize)]
+    struct FailingDummy {
+        #[serde(serialize_with = "failing_serialize")]
+        val: i32,
+    }
+
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    fn failing_serialize<S: serde::Serializer>(_val: &i32, _ser: S) -> Result<S::Ok, S::Error> {
+        Err(serde::ser::Error::custom("test error"))
+    }
+
+    #[derive(Serialize)]
+    struct Site3FailingWrapper {
+        #[serde(serialize_with = "super::ser_helpers::site3")]
+        map: HashMap<(String, String, usize), FailingDummy>,
+    }
+
+    #[derive(Serialize)]
+    struct Site2FailingWrapper {
+        #[serde(serialize_with = "super::ser_helpers::site2_u16")]
+        map: HashMap<(String, u16), FailingDummy>,
+    }
+
+    #[derive(Serialize)]
+    struct PairFailingWrapper {
+        #[serde(serialize_with = "super::ser_helpers::pair_str")]
+        map: HashMap<(String, String), FailingDummy>,
+    }
+
+    #[derive(Serialize)]
+    struct CustomKeyedMapFailingWrapper {
+        #[serde(serialize_with = "failing_custom_keyed_map")]
+        map: HashMap<i32, FailingDummy>,
+    }
+
+    fn failing_custom_keyed_map<S: serde::Serializer>(
+        map: &HashMap<i32, FailingDummy>,
+        ser: S,
+    ) -> Result<S::Ok, S::Error> {
+        super::ser_helpers::keyed_map(map, ser, |k| format!("key_{k}"))
+    }
+
+    #[test]
+    fn test_keyed_map_error() {
+        let mut map = HashMap::new();
+        map.insert(
+            ("java/lang/String".to_string(), "intern".to_string(), 42),
+            FailingDummy { val: 1 },
+        );
+        let w = Site3FailingWrapper { map };
+        let res = serde_json::to_string(&w);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_site2_u16_error() {
+        let mut map = HashMap::new();
+        map.insert(
+            ("java/lang/String".to_string(), 42),
+            FailingDummy { val: 1 },
+        );
+        let w = Site2FailingWrapper { map };
+        let res = serde_json::to_string(&w);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_pair_str_error() {
+        let mut map = HashMap::new();
+        map.insert(
+            ("java/lang/String".to_string(), "intern".to_string()),
+            FailingDummy { val: 1 },
+        );
+        let w = PairFailingWrapper { map };
+        let res = serde_json::to_string(&w);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_custom_keyed_map_error() {
+        let mut map = HashMap::new();
+        map.insert(1, FailingDummy { val: 1 });
+        let w = CustomKeyedMapFailingWrapper { map };
+        let res = serde_json::to_string(&w);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn test_sorted_set_error() {
+        struct FailingSerializer;
+        impl serde::Serializer for FailingSerializer {
+            type Ok = ();
+            type Error = serde::de::value::Error;
+            type SerializeSeq = serde::ser::Impossible<(), Self::Error>;
+            type SerializeTuple = serde::ser::Impossible<(), Self::Error>;
+            type SerializeTupleStruct = serde::ser::Impossible<(), Self::Error>;
+            type SerializeTupleVariant = serde::ser::Impossible<(), Self::Error>;
+            type SerializeMap = serde::ser::Impossible<(), Self::Error>;
+            type SerializeStruct = serde::ser::Impossible<(), Self::Error>;
+            type SerializeStructVariant = serde::ser::Impossible<(), Self::Error>;
+            fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_some<T: ?Sized + Serialize>(
+                self,
+                _v: &T,
+            ) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_unit_variant(
+                self,
+                _n: &'static str,
+                _vi: u32,
+                _va: &'static str,
+            ) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_newtype_struct<T: ?Sized + Serialize>(
+                self,
+                _name: &'static str,
+                _v: &T,
+            ) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_newtype_variant<T: ?Sized + Serialize>(
+                self,
+                _n: &'static str,
+                _vi: u32,
+                _va: &'static str,
+                _v: &T,
+            ) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_tuple_struct(
+                self,
+                _name: &'static str,
+                _len: usize,
+            ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_tuple_variant(
+                self,
+                _n: &'static str,
+                _vi: u32,
+                _va: &'static str,
+                _len: usize,
+            ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+                Err(serde::de::Error::custom("map err"))
+            }
+            fn serialize_struct(
+                self,
+                _name: &'static str,
+                _len: usize,
+            ) -> Result<Self::SerializeStruct, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_struct_variant(
+                self,
+                _n: &'static str,
+                _vi: u32,
+                _va: &'static str,
+                _len: usize,
+            ) -> Result<Self::SerializeStructVariant, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+        }
+
+        let mut set = std::collections::HashSet::new();
+        set.insert("a".to_string());
+        let res = super::ser_helpers::sorted_set(&set, FailingSerializer);
+        assert!(res.is_err());
+    }
 }

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -540,4 +540,50 @@ mod tests {
         let res = store.print_report(&mut w);
         assert!(res.is_err());
     }
+
+    #[test]
+    fn test_print_bytecode_cost_with_less_than_10() {
+        let mut store = crate::TelemetryStore::default();
+        store.bytecode_cost.record("iadd", "Foo", "bar", 10, 100);
+        let mut buf = Vec::new();
+        store.print_bytecode_cost(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("iadd"));
+    }
+
+    #[test]
+    fn test_print_object_lineage_with_less_than_10() {
+        let mut store = crate::TelemetryStore::default();
+        store
+            .object_lineage
+            .record("java/lang/String", "Foo", 10, "bar");
+        let mut buf = Vec::new();
+        store.print_object_lineage(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("java/lang/String"));
+    }
+
+    #[test]
+    fn test_print_class_init_dag_populated() {
+        let mut store = crate::TelemetryStore::default();
+        store
+            .class_init_dag
+            .record("java/lang/String", "java/lang/System", 500);
+        let mut buf = Vec::new();
+        store.print_class_init_dag(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("java/lang/String"));
+    }
+
+    #[test]
+    fn test_print_exception_flow_populated() {
+        let mut store = crate::TelemetryStore::default();
+        store
+            .exception_flow
+            .record_throw("java/lang/Exception", "Foo", "bar", 10);
+        let mut buf = Vec::new();
+        store.print_exception_flow(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("java/lang/Exception"));
+    }
 }


### PR DESCRIPTION
🎯 Target: duke-telemetry::helpers and duke-telemetry::lib

💣 Risk: Gaps in reporting outputs meant that serialization failures or empty/small reports were untested.

🧪 Strategy: Added specific error boundaries using custom Failure wrappers and tested less-than counts for top-10 report sections.

🔬 Verification: cargo test -p duke-telemetry

---
*PR created automatically by Jules for task [2520200460797175922](https://jules.google.com/task/2520200460797175922) started by @madmax983*