### PR TITLE
⚡ Bolt: Pre-allocate CFG reachability collections

### DIFF
--- a/crates/duke-bytecode/src/reachability.rs
+++ b/crates/duke-bytecode/src/reachability.rs
@@ -101,13 +101,14 @@ pub fn find_dead_blocks(blocks: &[BasicBlock], entry_pc: usize) -> Vec<usize> {
         return Vec::new();
     }
 
-    let mut block_map = HashMap::new();
+    // ⚡ Bolt: Pre-allocate capacities based on known block count to eliminate heap reallocations
+    let mut block_map = HashMap::with_capacity(blocks.len());
     for block in blocks {
         block_map.insert(block.start_pc, block);
     }
 
-    let mut visited = HashSet::new();
-    let mut queue = VecDeque::new();
+    let mut visited = HashSet::with_capacity(blocks.len());
+    let mut queue = VecDeque::with_capacity(blocks.len());
 
     if block_map.contains_key(&entry_pc) {
         queue.push_back(entry_pc);
@@ -181,7 +182,8 @@ pub fn find_shortest_path(
         return None;
     }
 
-    let mut block_map = HashMap::new();
+    // ⚡ Bolt: Pre-allocate capacities based on known block count to eliminate heap reallocations
+    let mut block_map = HashMap::with_capacity(blocks.len());
     for block in blocks {
         block_map.insert(block.start_pc, block);
     }
@@ -190,9 +192,9 @@ pub fn find_shortest_path(
         return None;
     }
 
-    let mut visited = HashSet::new();
-    let mut queue = VecDeque::new();
-    let mut parents: HashMap<usize, usize> = HashMap::new();
+    let mut visited = HashSet::with_capacity(blocks.len());
+    let mut queue = VecDeque::with_capacity(blocks.len());
+    let mut parents: HashMap<usize, usize> = HashMap::with_capacity(blocks.len());
 
     queue.push_back(start_pc);
     visited.insert(start_pc);


### PR DESCRIPTION
💡 What: Pre-allocated capacities for `HashMap`, `HashSet`, and `VecDeque` in the `reachability.rs` analysis functions `find_dead_blocks` and `find_shortest_path` using the exact `blocks.len()`.

🎯 Why: These CFG reachability analysis algorithms previously instantiated default, dynamically sized collections within hot paths. Since the number of nodes (basic blocks) is exactly known beforehand, pre-allocating the capacities bypasses intermediary resizing and rehashing phases entirely.

📊 Impact: Provides a zero-cost abstraction that completely eliminates dynamic heap reallocations when traversing CFGs and reduces the overhead of constructing reachability graphs.

🔭 Measurement: Run `cargo bench` or profile CFG pathfinding logic in heavily branching methods to measure the reduction in allocation overhead.

---
*PR created automatically by Jules for task [3471991622071037624](https://jules.google.com/task/3471991622071037624) started by @madmax983*