### PR TITLE
👺 Havoc: Prevent Stack Overflow in Annotation Parsing

### DIFF
--- a/crates/duke-classfile/src/error.rs
+++ b/crates/duke-classfile/src/error.rs
@@ -129,6 +129,13 @@ pub enum Error {
         /// Raw tag byte.
         tag: u8,
     },
+
+    /// The recursion depth exceeded the maximum allowed limit.
+    #[error("recursion limit exceeded at depth {depth}")]
+    RecursionLimitExceeded {
+        /// The depth at which the limit was exceeded.
+        depth: usize,
+    },
 }
 
 /// Convenience alias.

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -430,10 +430,12 @@ fn decode_known_attribute(name: &str, raw: &[u8], depth: usize) -> Result<Attrib
             exception_index_table: decode_exceptions(&mut c)?,
         },
         "BootstrapMethods" => AttributeData::BootstrapMethods(decode_bootstrap_methods(&mut c)?),
-        "RuntimeVisibleAnnotations" => {
-            AttributeData::RuntimeVisibleAnnotations(decode_runtime_visible_annotations(&mut c, depth)?)
+        "RuntimeVisibleAnnotations" => AttributeData::RuntimeVisibleAnnotations(
+            decode_runtime_visible_annotations(&mut c, depth)?,
+        ),
+        "AnnotationDefault" => {
+            AttributeData::AnnotationDefault(decode_element_value(&mut c, depth)?)
         }
-        "AnnotationDefault" => AttributeData::AnnotationDefault(decode_element_value(&mut c, depth)?),
         _ => AttributeData::Raw(raw.to_vec()),
     };
     Ok(data)
@@ -543,7 +545,10 @@ fn decode_element_value(c: &mut Cursor<'_>, depth: usize) -> Result<ElementValue
             const_name_index: c.read_cp_index()?,
         }),
         b'c' => Ok(ElementValue::ClassInfoIndex(c.read_cp_index()?)),
-        b'@' => Ok(ElementValue::AnnotationValue(decode_annotation(c, depth + 1)?)),
+        b'@' => Ok(ElementValue::AnnotationValue(decode_annotation(
+            c,
+            depth + 1,
+        )?)),
         b'[' => {
             let num_values = c.read_u16()? as usize;
             let mut values = Vec::with_capacity(num_values.min(c.remaining() / 3));

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -407,12 +407,12 @@ pub fn resolve_attributes(attrs: &mut [AttributeInfo], pool: &[Option<CpEntry>])
             AttributeData::Raw(b) => std::mem::take(b),
             _ => continue, // already resolved
         };
-        attr.data = decode_known_attribute(name, &raw)?;
+        attr.data = decode_known_attribute(name, &raw, 0)?;
     }
     Ok(())
 }
 
-fn decode_known_attribute(name: &str, raw: &[u8]) -> Result<AttributeData> {
+fn decode_known_attribute(name: &str, raw: &[u8], depth: usize) -> Result<AttributeData> {
     let mut c = Cursor::new(raw);
     let data = match name {
         "ConstantValue" => AttributeData::ConstantValue {
@@ -431,9 +431,9 @@ fn decode_known_attribute(name: &str, raw: &[u8]) -> Result<AttributeData> {
         },
         "BootstrapMethods" => AttributeData::BootstrapMethods(decode_bootstrap_methods(&mut c)?),
         "RuntimeVisibleAnnotations" => {
-            AttributeData::RuntimeVisibleAnnotations(decode_runtime_visible_annotations(&mut c)?)
+            AttributeData::RuntimeVisibleAnnotations(decode_runtime_visible_annotations(&mut c, depth)?)
         }
-        "AnnotationDefault" => AttributeData::AnnotationDefault(decode_element_value(&mut c)?),
+        "AnnotationDefault" => AttributeData::AnnotationDefault(decode_element_value(&mut c, depth)?),
         _ => AttributeData::Raw(raw.to_vec()),
     };
     Ok(data)
@@ -501,23 +501,26 @@ fn decode_bootstrap_methods(c: &mut Cursor<'_>) -> Result<Vec<BootstrapMethodEnt
     Ok(entries)
 }
 
-fn decode_runtime_visible_annotations(c: &mut Cursor<'_>) -> Result<Vec<Annotation>> {
+fn decode_runtime_visible_annotations(c: &mut Cursor<'_>, depth: usize) -> Result<Vec<Annotation>> {
     let num_annotations = c.read_u16()? as usize;
     let mut annotations = Vec::with_capacity(num_annotations.min(c.remaining() / 4));
     for _ in 0..num_annotations {
-        annotations.push(decode_annotation(c)?);
+        annotations.push(decode_annotation(c, depth + 1)?);
     }
     Ok(annotations)
 }
 
-fn decode_annotation(c: &mut Cursor<'_>) -> Result<Annotation> {
+fn decode_annotation(c: &mut Cursor<'_>, depth: usize) -> Result<Annotation> {
+    if depth >= 16 {
+        return Err(Error::RecursionLimitExceeded { depth });
+    }
     let type_index = c.read_cp_index()?;
     let num_pairs = c.read_u16()? as usize;
     let mut element_value_pairs = Vec::with_capacity(num_pairs.min(c.remaining() / 3));
     for _ in 0..num_pairs {
         element_value_pairs.push(ElementValuePair {
             element_name_index: c.read_cp_index()?,
-            value: decode_element_value(c)?,
+            value: decode_element_value(c, depth + 1)?,
         });
     }
     Ok(Annotation {
@@ -526,7 +529,10 @@ fn decode_annotation(c: &mut Cursor<'_>) -> Result<Annotation> {
     })
 }
 
-fn decode_element_value(c: &mut Cursor<'_>) -> Result<ElementValue> {
+fn decode_element_value(c: &mut Cursor<'_>, depth: usize) -> Result<ElementValue> {
+    if depth >= 16 {
+        return Err(Error::RecursionLimitExceeded { depth });
+    }
     let tag = c.read_u8()?;
     match tag {
         b'B' | b'C' | b'D' | b'F' | b'I' | b'J' | b'S' | b'Z' | b's' => {
@@ -537,12 +543,12 @@ fn decode_element_value(c: &mut Cursor<'_>) -> Result<ElementValue> {
             const_name_index: c.read_cp_index()?,
         }),
         b'c' => Ok(ElementValue::ClassInfoIndex(c.read_cp_index()?)),
-        b'@' => Ok(ElementValue::AnnotationValue(decode_annotation(c)?)),
+        b'@' => Ok(ElementValue::AnnotationValue(decode_annotation(c, depth + 1)?)),
         b'[' => {
             let num_values = c.read_u16()? as usize;
             let mut values = Vec::with_capacity(num_values.min(c.remaining() / 3));
             for _ in 0..num_values {
-                values.push(decode_element_value(c)?);
+                values.push(decode_element_value(c, depth + 1)?);
             }
             Ok(ElementValue::ArrayValue(values))
         }
@@ -682,7 +688,7 @@ mod tests {
             b'e', 0x00, 0x0A, 0x00, 0x0B, // enum const
         ];
 
-        let decoded = decode_known_attribute("RuntimeVisibleAnnotations", &raw).unwrap();
+        let decoded = decode_known_attribute("RuntimeVisibleAnnotations", &raw, 0).unwrap();
         let AttributeData::RuntimeVisibleAnnotations(annotations) = decoded else {
             panic!("expected RuntimeVisibleAnnotations");
         };
@@ -699,7 +705,7 @@ mod tests {
             b's', 0x00, 0x02, // string const
         ];
 
-        let decoded = decode_known_attribute("AnnotationDefault", &raw).unwrap();
+        let decoded = decode_known_attribute("AnnotationDefault", &raw, 0).unwrap();
         let AttributeData::AnnotationDefault(ElementValue::ArrayValue(values)) = decoded else {
             panic!("expected AnnotationDefault array value");
         };

--- a/crates/duke-classfile/tests/havoc_annotation_recursion.rs
+++ b/crates/duke-classfile/tests/havoc_annotation_recursion.rs
@@ -9,29 +9,19 @@ fn test_annotation_stack_overflow() {
         0x00, 0x00, // minor version
         0x00, 0x41, // major version (65)
         0x00, 0x05, // constant pool count (5)
-
         // cp info: 1 - utf8 "RuntimeVisibleAnnotations"
-        0x01, 0x00, 0x19,
-        b'R', b'u', b'n', b't', b'i', b'm', b'e', b'V', b'i', b's', b'i', b'b', b'l', b'e', b'A', b'n', b'n', b'o', b't', b'a', b't', b'i', b'o', b'n', b's',
-
+        0x01, 0x00, 0x19, b'R', b'u', b'n', b't', b'i', b'm', b'e', b'V', b'i', b's', b'i', b'b',
+        b'l', b'e', b'A', b'n', b'n', b'o', b't', b'a', b't', b'i', b'o', b'n', b's',
         // cp info: 2 - utf8 "foo"
-        0x01, 0x00, 0x03, b'f', b'o', b'o',
-
-        // cp info: 3 - utf8 "bar"
-        0x01, 0x00, 0x03, b'b', b'a', b'r',
-
-        // cp info: 4 - utf8 "baz"
-        0x01, 0x00, 0x03, b'b', b'a', b'z',
-
-        0x00, 0x00, // access flags
+        0x01, 0x00, 0x03, b'f', b'o', b'o', // cp info: 3 - utf8 "bar"
+        0x01, 0x00, 0x03, b'b', b'a', b'r', // cp info: 4 - utf8 "baz"
+        0x01, 0x00, 0x03, b'b', b'a', b'z', 0x00, 0x00, // access flags
         0x00, 0x00, // this class
         0x00, 0x00, // super class
         0x00, 0x00, // interfaces count
         0x00, 0x00, // fields count
         0x00, 0x00, // methods count
-
         0x00, 0x01, // attributes count
-
         // attribute RuntimeVisibleAnnotations
         0x00, 0x01, // name index (1)
     ];
@@ -56,15 +46,17 @@ fn test_annotation_stack_overflow() {
     attr_data.extend_from_slice(&[0x00, 0x04]); // const value index
 
     // attr length
-    let attr_len = attr_data.len() as u32;
+    let attr_len = u32::try_from(attr_data.len()).unwrap();
     data.extend_from_slice(&attr_len.to_be_bytes());
     data.extend(attr_data);
 
     // This used to panic with a stack overflow! Now it should return RecursionLimitExceeded.
     let result = parse(&data);
     assert!(
-        matches!(result, Err(duke_classfile::Error::RecursionLimitExceeded { depth: 16 })),
-        "Expected RecursionLimitExceeded, got {:?}",
-        result
+        matches!(
+            result,
+            Err(duke_classfile::Error::RecursionLimitExceeded { depth: 16 })
+        ),
+        "Expected RecursionLimitExceeded, got {result:?}",
     );
 }

--- a/crates/duke-classfile/tests/havoc_annotation_recursion.rs
+++ b/crates/duke-classfile/tests/havoc_annotation_recursion.rs
@@ -1,0 +1,70 @@
+#![allow(missing_docs)]
+
+use duke_classfile::parse;
+
+#[test]
+fn test_annotation_stack_overflow() {
+    let mut data = vec![
+        0xca, 0xfe, 0xba, 0xbe, // magic
+        0x00, 0x00, // minor version
+        0x00, 0x41, // major version (65)
+        0x00, 0x05, // constant pool count (5)
+
+        // cp info: 1 - utf8 "RuntimeVisibleAnnotations"
+        0x01, 0x00, 0x19,
+        b'R', b'u', b'n', b't', b'i', b'm', b'e', b'V', b'i', b's', b'i', b'b', b'l', b'e', b'A', b'n', b'n', b'o', b't', b'a', b't', b'i', b'o', b'n', b's',
+
+        // cp info: 2 - utf8 "foo"
+        0x01, 0x00, 0x03, b'f', b'o', b'o',
+
+        // cp info: 3 - utf8 "bar"
+        0x01, 0x00, 0x03, b'b', b'a', b'r',
+
+        // cp info: 4 - utf8 "baz"
+        0x01, 0x00, 0x03, b'b', b'a', b'z',
+
+        0x00, 0x00, // access flags
+        0x00, 0x00, // this class
+        0x00, 0x00, // super class
+        0x00, 0x00, // interfaces count
+        0x00, 0x00, // fields count
+        0x00, 0x00, // methods count
+
+        0x00, 0x01, // attributes count
+
+        // attribute RuntimeVisibleAnnotations
+        0x00, 0x01, // name index (1)
+    ];
+
+    let mut attr_data = vec![];
+    attr_data.extend_from_slice(&[0x00, 0x01]); // num_annotations
+
+    // Let's create deeply nested arrays
+    attr_data.extend_from_slice(&[0x00, 0x02]); // annotation.type_index
+    attr_data.extend_from_slice(&[0x00, 0x01]); // num_element_value_pairs
+    attr_data.extend_from_slice(&[0x00, 0x03]); // element_name_index
+
+    // Value: lots of nested arrays
+    let depth = 50_000;
+    for _ in 0..depth {
+        attr_data.push(b'[');
+        attr_data.extend_from_slice(&[0x00, 0x01]); // num_values = 1
+    }
+
+    // Final value
+    attr_data.push(b'I');
+    attr_data.extend_from_slice(&[0x00, 0x04]); // const value index
+
+    // attr length
+    let attr_len = attr_data.len() as u32;
+    data.extend_from_slice(&attr_len.to_be_bytes());
+    data.extend(attr_data);
+
+    // This used to panic with a stack overflow! Now it should return RecursionLimitExceeded.
+    let result = parse(&data);
+    assert!(
+        matches!(result, Err(duke_classfile::Error::RecursionLimitExceeded { depth: 16 })),
+        "Expected RecursionLimitExceeded, got {:?}",
+        result
+    );
+}


### PR DESCRIPTION
🧨 The Trigger: Deeply nested arrays inside `RuntimeVisibleAnnotations` cause unbounded recursion in `decode_annotation` and `decode_element_value`.
📉 The Stack Trace: `thread 'test_annotation_stack_overflow' has overflowed its stack` -> `fatal runtime error: stack overflow, aborting`.
🧪 Reproduction: Run `cargo test -p duke-classfile --test havoc_annotation_recursion`.
😈 Comment: You assumed nobody would ever nest annotations 50,000 layers deep. You were wrong.

---
*PR created automatically by Jules for task [15402227262417232601](https://jules.google.com/task/15402227262417232601) started by @madmax983*