### PR TITLE
⚡ Bolt: Use Vec::with_capacity for reflection array collections

### DIFF
--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -10252,26 +10252,26 @@ pub(crate) fn native_class_get_declared_methods(
     let class_ref = extract_ref_arg(args, 0)?;
     let class_key = class_key_from_ref(heap, class_ref)?;
     let reflected = ops.inspect_class(&class_key)?;
-    let method_refs = reflected
-        .methods
-        .into_iter()
-        .filter(|method| method.name != "<init>" && method.name != "<clinit>")
-        .map(|method| {
-            allocate_reflection_member_object(
-                heap,
-                "java/lang/reflect/Method",
-                &class_key,
-                &method.name,
-                &method.descriptor,
-                method.is_public,
-                method.is_static,
-            )
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let mut method_refs = Vec::with_capacity(reflected.methods.len());
+    for method in reflected.methods {
+        if method.name == "<init>" || method.name == "<clinit>" {
+            continue;
+        }
+        method_refs.push(allocate_reflection_member_object(
+            heap,
+            "java/lang/reflect/Method",
+            &class_key,
+            &method.name,
+            &method.descriptor,
+            method.is_public,
+            method.is_static,
+        )?);
+    }
     let array_ref = allocate_reference_array(heap, "[Ljava/lang/reflect/Method;", &method_refs)?;
     Ok(Some(Slot::Reference(Some(array_ref))))
 }
 
+/// Eliminates intermediate `Vec` reallocations by using `Vec::with_capacity` in a pre-allocated loop.
 pub(crate) fn native_class_get_declared_constructors(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
@@ -10282,20 +10282,19 @@ pub(crate) fn native_class_get_declared_constructors(
     let class_ref = extract_ref_arg(args, 0)?;
     let class_key = class_key_from_ref(heap, class_ref)?;
     let reflected = ops.inspect_class(&class_key)?;
-    let constructor_refs = reflected_constructors(reflected, false)
-        .into_iter()
-        .map(|constructor| {
-            allocate_reflection_member_object(
-                heap,
-                "java/lang/reflect/Constructor",
-                &class_key,
-                &constructor.name,
-                &constructor.descriptor,
-                constructor.is_public,
-                constructor.is_static,
-            )
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let constructors = reflected_constructors(reflected, false);
+    let mut constructor_refs = Vec::with_capacity(constructors.len());
+    for constructor in constructors {
+        constructor_refs.push(allocate_reflection_member_object(
+            heap,
+            "java/lang/reflect/Constructor",
+            &class_key,
+            &constructor.name,
+            &constructor.descriptor,
+            constructor.is_public,
+            constructor.is_static,
+        )?);
+    }
     let array_ref =
         allocate_reference_array(heap, "[Ljava/lang/reflect/Constructor;", &constructor_refs)?;
     Ok(Some(Slot::Reference(Some(array_ref))))
@@ -10310,20 +10309,19 @@ pub(crate) fn native_class_get_methods(
 ) -> Result<Option<Slot>> {
     let class_ref = extract_ref_arg(args, 0)?;
     let class_key = class_key_from_ref(heap, class_ref)?;
-    let method_refs = collect_public_reflected_methods(ops, &class_key)?
-        .into_iter()
-        .map(|(declaring_class, method)| {
-            allocate_reflection_member_object(
-                heap,
-                "java/lang/reflect/Method",
-                &declaring_class,
-                &method.name,
-                &method.descriptor,
-                method.is_public,
-                method.is_static,
-            )
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let methods = collect_public_reflected_methods(ops, &class_key)?;
+    let mut method_refs = Vec::with_capacity(methods.len());
+    for (declaring_class, method) in methods {
+        method_refs.push(allocate_reflection_member_object(
+            heap,
+            "java/lang/reflect/Method",
+            &declaring_class,
+            &method.name,
+            &method.descriptor,
+            method.is_public,
+            method.is_static,
+        )?);
+    }
     let array_ref = allocate_reference_array(heap, "[Ljava/lang/reflect/Method;", &method_refs)?;
     Ok(Some(Slot::Reference(Some(array_ref))))
 }
@@ -10338,20 +10336,19 @@ pub(crate) fn native_class_get_constructors(
     let class_ref = extract_ref_arg(args, 0)?;
     let class_key = class_key_from_ref(heap, class_ref)?;
     let reflected = ops.inspect_class(&class_key)?;
-    let constructor_refs = reflected_constructors(reflected, true)
-        .into_iter()
-        .map(|constructor| {
-            allocate_reflection_member_object(
-                heap,
-                "java/lang/reflect/Constructor",
-                &class_key,
-                &constructor.name,
-                &constructor.descriptor,
-                constructor.is_public,
-                constructor.is_static,
-            )
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let constructors = reflected_constructors(reflected, true);
+    let mut constructor_refs = Vec::with_capacity(constructors.len());
+    for constructor in constructors {
+        constructor_refs.push(allocate_reflection_member_object(
+            heap,
+            "java/lang/reflect/Constructor",
+            &class_key,
+            &constructor.name,
+            &constructor.descriptor,
+            constructor.is_public,
+            constructor.is_static,
+        )?);
+    }
     let array_ref =
         allocate_reference_array(heap, "[Ljava/lang/reflect/Constructor;", &constructor_refs)?;
     Ok(Some(Slot::Reference(Some(array_ref))))
@@ -10367,21 +10364,18 @@ pub(crate) fn native_class_get_declared_fields(
     let class_ref = extract_ref_arg(args, 0)?;
     let class_key = class_key_from_ref(heap, class_ref)?;
     let reflected = ops.inspect_class(&class_key)?;
-    let field_refs = reflected
-        .fields
-        .into_iter()
-        .map(|field| {
-            allocate_reflection_member_object(
-                heap,
-                "java/lang/reflect/Field",
-                &class_key,
-                &field.name,
-                &field.descriptor,
-                field.is_public,
-                field.is_static,
-            )
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let mut field_refs = Vec::with_capacity(reflected.fields.len());
+    for field in reflected.fields {
+        field_refs.push(allocate_reflection_member_object(
+            heap,
+            "java/lang/reflect/Field",
+            &class_key,
+            &field.name,
+            &field.descriptor,
+            field.is_public,
+            field.is_static,
+        )?);
+    }
     let array_ref = allocate_reference_array(heap, "[Ljava/lang/reflect/Field;", &field_refs)?;
     Ok(Some(Slot::Reference(Some(array_ref))))
 }
@@ -10395,20 +10389,19 @@ pub(crate) fn native_class_get_fields(
 ) -> Result<Option<Slot>> {
     let class_ref = extract_ref_arg(args, 0)?;
     let class_key = class_key_from_ref(heap, class_ref)?;
-    let field_refs = collect_public_reflected_fields(ops, &class_key)?
-        .into_iter()
-        .map(|(declaring_class, field)| {
-            allocate_reflection_member_object(
-                heap,
-                "java/lang/reflect/Field",
-                &declaring_class,
-                &field.name,
-                &field.descriptor,
-                field.is_public,
-                field.is_static,
-            )
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let fields = collect_public_reflected_fields(ops, &class_key)?;
+    let mut field_refs = Vec::with_capacity(fields.len());
+    for (declaring_class, field) in fields {
+        field_refs.push(allocate_reflection_member_object(
+            heap,
+            "java/lang/reflect/Field",
+            &declaring_class,
+            &field.name,
+            &field.descriptor,
+            field.is_public,
+            field.is_static,
+        )?);
+    }
     let array_ref = allocate_reference_array(heap, "[Ljava/lang/reflect/Field;", &field_refs)?;
     Ok(Some(Slot::Reference(Some(array_ref))))
 }


### PR DESCRIPTION
💡 What: Replaced intermediate `.collect()` chains with explicit `Vec::with_capacity` loops. 
🎯 Why: To avoid unnecessary `Vec` reallocations when collecting reflection arrays, since `allocate_reference_array` cannot safely take an iterator without hitting overlapping mutable borrow issues on the GC heap. 
📊 Impact: Eliminates unpredictable reallocations when building arrays of reflected members. 
🔬 Measurement: Run `cargo test` to verify correctness.

---
*PR created automatically by Jules for task [11223661165385091138](https://jules.google.com/task/11223661165385091138) started by @madmax983*