### PR TITLE
🗺️ Atlas: [Extract Zip natives]

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -4,3 +4,7 @@
 **[Encapsulate Module Facades]
 **Tangle:** The `pub mod` declarations for internal sub-modules like `reachability` and `ser_helpers` were publicly exposed, violating encapsulation boundaries.
 **Blueprint:** Changed the visibilities to `pub(crate) mod` to encapsulate the modules, while re-exporting only the specific items like `find_shortest_path` where needed.
+**[Extract Zip Natives]**\n**Tangle:** The  file was a massive ~38K line god module handling both JNI native bridges and internal zip file management caching.\n**Blueprint:** Splitting  via multiple  macros into  removes hundreds of lines of decoupled file management logic.
+**[Extract Zip Natives]**
+**Tangle:** The `native.rs` file was a massive ~38K line god module handling both JNI native bridges and internal zip file management caching.
+**Blueprint:** Splitting `native.rs` via multiple `include!` macros into `native_zip.rs` removes hundreds of lines of decoupled file management logic.

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -56,6 +56,7 @@ use duke_runtime::{Error, Frame, Result, Slot};
 // Creates synthetic `java/lang/System` and `java/io/PrintStream` classes and
 // registers native `println` handlers for `(Ljava/lang/String;)V`, `(I)V`,
 include!("native.rs");
+include!("native_zip.rs");
 
 // Tests
 // ---------------------------------------------------------------------------

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -2,54 +2,6 @@
 use std::sync::{RwLock, OnceLock};
 use std::sync::atomic::{AtomicI32, Ordering};
 
-fn zip_files() -> &'static RwLock<HashMap<i32, duke_loader::ZipReader>> {
-    static ZIP_FILES: OnceLock<RwLock<HashMap<i32, duke_loader::ZipReader>>> = OnceLock::new();
-    ZIP_FILES.get_or_init(|| RwLock::new(HashMap::new()))
-}
-
-static NEXT_ZIP_ID: AtomicI32 = AtomicI32::new(100_000_000);
-
-fn zip_open(path: &std::path::Path) -> Result<i32> {
-    let reader = duke_loader::ZipReader::open(path).map_err(|err| match err {
-        duke_loader::Error::Io { .. } => Error::JavaException {
-            class_name: "java/io/FileNotFoundException".to_string(),
-        },
-        _ => Error::JavaException {
-            class_name: "java/util/zip/ZipException".to_string(),
-        },
-    })?;
-    let id = NEXT_ZIP_ID.fetch_add(1, Ordering::Relaxed);
-    zip_files().write().unwrap_or_else(std::sync::PoisonError::into_inner).insert(id, reader);
-    Ok(id)
-}
-
-fn zip_entry_count(id: i32) -> Result<usize> {
-    let map = zip_files().read().unwrap_or_else(std::sync::PoisonError::into_inner);
-    map.get(&id).map_or_else(
-        || Err(Error::JavaException { class_name: "java/io/IOException".into() }),
-        |reader| Ok(reader.entry_count())
-    )
-}
-
-fn zip_get_entry_info(id: i32, name: &str) -> Result<Option<duke_loader::ZipEntryInfo>> {
-    let map = zip_files().read().unwrap_or_else(std::sync::PoisonError::into_inner);
-    map.get(&id).map_or_else(
-        || Err(Error::JavaException { class_name: "java/io/IOException".into() }),
-        |reader| Ok(reader.get_entry(name).cloned())
-    )
-}
-
-fn zip_read_entry(id: i32, name: &str) -> Result<Vec<u8>> {
-    let map = zip_files().read().unwrap_or_else(std::sync::PoisonError::into_inner);
-    map.get(&id).map_or_else(
-        || Err(Error::JavaException { class_name: "java/io/IOException".into() }),
-        |reader| reader.read_entry(name).map_err(|_| Error::JavaException { class_name: "java/util/zip/ZipException".into() })
-    )
-}
-
-fn zip_close(id: i32) {
-    zip_files().write().unwrap_or_else(std::sync::PoisonError::into_inner).remove(&id);
-}
 
 fn extract_slot_arg(args: &[Slot], idx: usize) -> Slot {
     args.get(idx).copied().unwrap_or(Slot::Reference(None))
@@ -3016,351 +2968,12 @@ pub(crate) fn native_socket_close(
 
 // ── ZIP / JAR natives ──────────────────────────────────────────────────
 
-/// Native: `ZipFile.<init>(String)` — open and index a ZIP/JAR archive.
-pub(crate) fn native_zip_file_init(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    _out: &mut dyn Write,
-    _control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    let path_ref = extract_ref_arg(args, 1)?;
-    let path_str = heap
-        .get(path_ref)?
-        .string_value
-        .as_deref()
-        .ok_or(Error::NullPointerException)?
-        .to_string();
-    let fd = zip_open(std::path::Path::new(&path_str))?;
-    let obj = heap.get_mut(this_ref)?;
-    obj.fields[0] = Slot::Int(fd);
-    Ok(None)
-}
-
-/// Native: `JarFile.<init>(File)` — open and index a JAR archive from a File object.
-pub(crate) fn native_jar_file_init_from_file(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    _out: &mut dyn Write,
-    _control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    let file_ref = extract_ref_arg(args, 1)?;
-    let path = file_path_from_ref(file_ref, heap)?;
-    let fd = zip_open(&path)?;
-    let obj = heap.get_mut(this_ref)?;
-    obj.fields[0] = Slot::Int(fd);
-    Ok(None)
-}
-
-pub(crate) fn native_jar_file_init_with_mode_and_version(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    out: &mut dyn Write,
-    control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let forwarded_args = match args {
-        [this_slot, file_slot, ..] => [*this_slot, *file_slot],
-        _ => {
-            return Err(Error::TypeMismatch {
-                expected: "this,file",
-                got: "other",
-            });
-        }
-    };
-    native_jar_file_init_from_file(&forwarded_args, heap, out, control)
-}
-
-pub(crate) fn native_jar_file_get_manifest(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    _out: &mut dyn Write,
-    _control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    let fd = extract_io_fd(heap, this_ref)?;
-    let Ok(manifest_bytes) = zip_read_entry(fd, "META-INF/MANIFEST.MF") else {
-        return Ok(Some(Slot::Reference(None)));
-    };
-    let manifest_ref = allocate_manifest_from_bytes(heap, &manifest_bytes)?;
-    Ok(Some(Slot::Reference(Some(manifest_ref))))
-}
-
-pub(crate) fn native_boot_nested_jar_file_get_manifest(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    out: &mut dyn Write,
-    control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    native_jar_file_get_manifest(args, heap, out, control)
-}
-
-const BOOT_JAR_FILE_ARCHIVE_JAR_FILE_SLOT: usize = 1;
-const BOOT_EXPLODED_ARCHIVE_ROOT_DIRECTORY_SLOT: usize = 0;
-const BOOT_EXPLODED_ARCHIVE_MANIFEST_SLOT: usize = 2;
-
 fn allocate_manifest_from_bytes(heap: &mut duke_gc::Heap, bytes: &[u8]) -> Result<u64> {
     let raw_ref = heap.allocate_string(String::from_utf8_lossy(bytes).into_owned());
     let manifest_ref = heap.allocate("java/util/jar/Manifest".to_string(), 1);
     heap.get_mut(manifest_ref)?.fields[0] = Slot::Reference(Some(raw_ref));
     Ok(manifest_ref)
 }
-
-pub(crate) fn native_boot_jar_file_archive_get_manifest(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    out: &mut dyn Write,
-    control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    let jar_file_ref = match heap
-        .get(this_ref)?
-        .fields
-        .get(BOOT_JAR_FILE_ARCHIVE_JAR_FILE_SLOT)
-        .copied()
-    {
-        Some(Slot::Reference(Some(jar_file_ref))) => jar_file_ref,
-        Some(Slot::Reference(None)) | None => return Err(Error::NullPointerException),
-        Some(_) => {
-            return Err(Error::TypeMismatch {
-                expected: "reference",
-                got: "other",
-            });
-        }
-    };
-    native_jar_file_get_manifest(&[Slot::Reference(Some(jar_file_ref))], heap, out, control)
-}
-
-pub(crate) fn native_boot_archive_get_manifest(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    out: &mut dyn Write,
-    control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    match heap.get(this_ref)?.class_name.as_str() {
-        "org/springframework/boot/loader/launch/JarFileArchive" => {
-            native_boot_jar_file_archive_get_manifest(args, heap, out, control)
-        }
-        "org/springframework/boot/loader/launch/ExplodedArchive" => {
-            native_boot_exploded_archive_get_manifest(args, heap, out, control)
-        }
-        _ => Err(Error::MethodNotFound {
-            name: format!("{}.getManifest", heap.get(this_ref)?.class_name),
-            descriptor: "()Ljava/util/jar/Manifest;".to_string(),
-        }),
-    }
-}
-
-pub(crate) fn native_boot_exploded_archive_get_manifest(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    _out: &mut dyn Write,
-    _control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    if let Some(slot @ Slot::Reference(Some(_))) = heap
-        .get(this_ref)?
-        .fields
-        .get(BOOT_EXPLODED_ARCHIVE_MANIFEST_SLOT)
-        .copied()
-    {
-        return Ok(Some(slot));
-    }
-
-    let root_directory_ref = match heap
-        .get(this_ref)?
-        .fields
-        .get(BOOT_EXPLODED_ARCHIVE_ROOT_DIRECTORY_SLOT)
-        .copied()
-    {
-        Some(Slot::Reference(Some(root_directory_ref))) => root_directory_ref,
-        Some(Slot::Reference(None)) | None => return Err(Error::NullPointerException),
-        Some(_) => {
-            return Err(Error::TypeMismatch {
-                expected: "reference",
-                got: "other",
-            });
-        }
-    };
-    let manifest_path = file_path_from_ref(root_directory_ref, heap)?.join("META-INF/MANIFEST.MF");
-    let manifest_bytes = match std::fs::read(&manifest_path) {
-        Ok(bytes) => bytes,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(Some(Slot::Reference(None)));
-        }
-        Err(_) => {
-            return Err(Error::JavaException {
-                class_name: "java/io/IOException".to_string(),
-            });
-        }
-    };
-    let manifest_ref = allocate_manifest_from_bytes(heap, &manifest_bytes)?;
-    heap.get_mut(this_ref)?.fields[BOOT_EXPLODED_ARCHIVE_MANIFEST_SLOT] =
-        Slot::Reference(Some(manifest_ref));
-    Ok(Some(Slot::Reference(Some(manifest_ref))))
-}
-
-/// Native: `ZipFile.getEntry(String) -> ZipEntry` — look up an entry by name.
-#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-pub(crate) fn native_zip_file_get_entry(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    _out: &mut dyn Write,
-    _control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    let name_ref = extract_ref_arg(args, 1)?;
-    let fd = extract_io_fd(heap, this_ref)?;
-    let entry_name = heap
-        .get(name_ref)?
-        .string_value
-        .as_deref()
-        .ok_or(Error::NullPointerException)?
-        .to_string();
-    let info = zip_get_entry_info(fd, &entry_name)?;
-    let Some(info) = info else {
-        return Ok(Some(Slot::Reference(None)));
-    };
-    // Allocate a ZipEntry HeapObject with 6 fields.
-    let name_heap_ref = heap.allocate_string(info.name);
-    let entry_ref = heap.allocate("java/util/zip/ZipEntry".to_string(), 6);
-    let entry_obj = heap.get_mut(entry_ref)?;
-    entry_obj.fields[0] = Slot::Reference(Some(name_heap_ref));
-    entry_obj.fields[1] = Slot::Int(info.compressed_size as i32);
-    entry_obj.fields[2] = Slot::Int((info.compressed_size >> 32) as i32);
-    entry_obj.fields[3] = Slot::Int(info.uncompressed_size as i32);
-    entry_obj.fields[4] = Slot::Int((info.uncompressed_size >> 32) as i32);
-    entry_obj.fields[5] = Slot::Int(i32::from(info.compression_method));
-    Ok(Some(Slot::Reference(Some(entry_ref))))
-}
-
-/// Native: `ZipFile.getInputStream(ZipEntry) -> InputStream`
-pub(crate) fn native_zip_file_get_input_stream(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    _out: &mut dyn Write,
-    _control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    let entry_ref = extract_ref_arg(args, 1)?;
-    let fd = extract_io_fd(heap, this_ref)?;
-    // Get entry name from the ZipEntry object.
-    let name_slot_ref = match heap.get(entry_ref)?.fields.first() {
-        Some(Slot::Reference(Some(r))) => *r,
-        _ => return Err(Error::NullPointerException),
-    };
-    let entry_name = heap
-        .get(name_slot_ref)?
-        .string_value
-        .as_deref()
-        .ok_or(Error::NullPointerException)?
-        .to_string();
-    // Decompress the entry and wrap in a ByteBuffer.
-    let data = zip_read_entry(fd, &entry_name)?;
-    let buf_fd = heap.open_host_byte_buffer(data);
-    let is_ref = heap.allocate("duke/zip/ByteBufferInputStream".to_string(), 1);
-    let is_obj = heap.get_mut(is_ref)?;
-    is_obj.fields[0] = Slot::Int(buf_fd);
-    Ok(Some(Slot::Reference(Some(is_ref))))
-}
-
-/// Native: `ZipFile.close()`
-pub(crate) fn native_zip_file_close(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    _out: &mut dyn Write,
-    _control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    let fd = match heap.get(this_ref)?.fields.first() {
-        Some(Slot::Int(id)) => *id,
-        _ => return Ok(None),
-    };
-    zip_close(fd);
-    let obj = heap.get_mut(this_ref)?;
-    obj.fields[0] = Slot::Int(0);
-    Ok(None)
-}
-
-/// Native: `ZipFile.size() -> int`
-#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-pub(crate) fn native_zip_file_size(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    _out: &mut dyn Write,
-    _control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    let fd = extract_io_fd(heap, this_ref)?;
-    let count = zip_entry_count(fd)?;
-    Ok(Some(Slot::Int(count as i32)))
-}
-
-/// Native: `ZipEntry.getName() -> String`
-pub(crate) fn native_zip_entry_get_name(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    _out: &mut dyn Write,
-    _control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    Ok(Some(heap.get(this_ref)?.fields[0]))
-}
-
-/// Native: `ZipEntry.getCompressedSize() -> long`
-pub(crate) fn native_zip_entry_get_compressed_size(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    _out: &mut dyn Write,
-    _control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    let fields = &heap.get(this_ref)?.fields;
-    let lo = match fields[1] {
-        Slot::Int(v) => v,
-        _ => 0,
-    };
-    let hi = match fields[2] {
-        Slot::Int(v) => v,
-        _ => 0,
-    };
-    let val = (i64::from(hi) << 32) | (i64::from(lo) & 0xFFFF_FFFF);
-    Ok(Some(Slot::Long(val)))
-}
-
-/// Native: `ZipEntry.getSize() -> long`
-pub(crate) fn native_zip_entry_get_size(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    _out: &mut dyn Write,
-    _control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    let fields = &heap.get(this_ref)?.fields;
-    let lo = match fields[3] {
-        Slot::Int(v) => v,
-        _ => 0,
-    };
-    let hi = match fields[4] {
-        Slot::Int(v) => v,
-        _ => 0,
-    };
-    let val = (i64::from(hi) << 32) | (i64::from(lo) & 0xFFFF_FFFF);
-    Ok(Some(Slot::Long(val)))
-}
-
-/// Native: `ZipEntry.getMethod() -> int`
-pub(crate) fn native_zip_entry_get_method(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    _out: &mut dyn Write,
-    _control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    Ok(Some(heap.get(this_ref)?.fields[5]))
-}
-
 /// Native: `String.length()` — returns string length as int.
 #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub(crate) fn native_string_length(
@@ -9646,87 +9259,6 @@ pub(crate) fn native_attributes_get_value(
     Ok(Some(result))
 }
 
-const BOOT_ARCHIVE_ENTRY_NAME_SLOT: usize = 0;
-const BOOT_ARCHIVE_ENTRY_DIRECTORY_SLOT: usize = 1;
-
-#[cfg(test)]
-fn boot_archive_entry_name(heap: &duke_gc::Heap, entry_ref: u64) -> Result<String> {
-    let Some(Slot::Reference(Some(name_ref))) = heap
-        .get(entry_ref)?
-        .fields
-        .get(BOOT_ARCHIVE_ENTRY_NAME_SLOT)
-        .copied()
-    else {
-        return Err(Error::NullPointerException);
-    };
-    string_value_from_ref(heap, name_ref)
-}
-
-fn boot_archive_entry_is_directory_flag(heap: &duke_gc::Heap, entry_ref: u64) -> Result<bool> {
-    match heap
-        .get(entry_ref)?
-        .fields
-        .get(BOOT_ARCHIVE_ENTRY_DIRECTORY_SLOT)
-        .copied()
-    {
-        Some(Slot::Int(value)) => Ok(value != 0),
-        _ => Err(Error::TypeMismatch {
-            expected: "Int",
-            got: "other",
-        }),
-    }
-}
-
-pub(crate) fn native_boot_archive_entry_name(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    _out: &mut dyn Write,
-    _control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let entry_ref = extract_ref_arg(args, 0)?;
-    let Some(slot @ Slot::Reference(Some(_))) = heap
-        .get(entry_ref)?
-        .fields
-        .get(BOOT_ARCHIVE_ENTRY_NAME_SLOT)
-        .copied()
-    else {
-        return Err(Error::NullPointerException);
-    };
-    Ok(Some(slot))
-}
-
-pub(crate) fn native_boot_archive_entry_is_directory(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    _out: &mut dyn Write,
-    _control: &mut NativeControl,
-) -> Result<Option<Slot>> {
-    let entry_ref = extract_ref_arg(args, 0)?;
-    Ok(Some(Slot::Int(i32::from(
-        boot_archive_entry_is_directory_flag(heap, entry_ref)?,
-    ))))
-}
-
-fn boot_archive_hashset_add_url(
-    set_ref: u64,
-    url_spec: String,
-    heap: &mut duke_gc::Heap,
-    out: &mut dyn Write,
-    control: &mut NativeControl,
-) -> Result<()> {
-    let url_ref = allocate_string_backed_object(heap, "java/net/URL", url_spec)?;
-    native_hashset_add(
-        &[
-            Slot::Reference(Some(set_ref)),
-            Slot::Reference(Some(url_ref)),
-        ],
-        heap,
-        out,
-        control,
-    )?;
-    Ok(())
-}
-
 fn allocate_boot_archive_entry(
     heap: &mut duke_gc::Heap,
     entry_name: &str,
@@ -9813,43 +9345,6 @@ fn patch_forwarded_ref_if_needed(heap: &duke_gc::Heap, reference: &mut u64) {
     }
 }
 
-pub(crate) fn native_boot_jar_file_archive_get_class_path_urls(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    out: &mut dyn Write,
-    control: &mut NativeControl,
-    ops: &mut dyn CallbackOps,
-) -> Result<Option<Slot>> {
-    let archive_ref = extract_ref_arg(args, 0)?;
-    let include_predicate_ref = extract_ref_arg(args, 1)?;
-    let _ = extract_ref_arg(args, 2)?;
-    let archive_file_ref = archive_file_ref_at(heap, archive_ref, 0)?;
-    let archive_path = file_path_from_ref(archive_file_ref, heap)?;
-    let reader = open_boot_archive_reader(&archive_path)?;
-    let mut entry_names: Vec<String> = reader.entry_names().map(ToOwned::to_owned).collect();
-    entry_names.sort_unstable();
-
-    let set_ref = heap.allocate("java/util/HashSet".to_string(), 1);
-    native_hashset_init(&[Slot::Reference(Some(set_ref))], heap, out, control)?;
-
-    for entry_name in entry_names {
-        let is_directory = entry_name.ends_with('/');
-        if boot_archive_predicate_accepts(
-            include_predicate_ref,
-            &entry_name,
-            is_directory,
-            heap,
-            out,
-            ops,
-        )? {
-            let url_spec = format!("jar:{}!/{}", path_to_file_url(&archive_path), entry_name);
-            boot_archive_hashset_add_url(set_ref, url_spec, heap, out, control)?;
-        }
-    }
-
-    Ok(Some(Slot::Reference(Some(set_ref))))
-}
-
 fn list_directory_children_sorted(path: &std::path::Path) -> Result<Vec<std::path::PathBuf>> {
     let iter = std::fs::read_dir(path).map_err(|_| Error::JavaException {
         class_name: "java/io/IOException".to_string(),
@@ -9883,66 +9378,6 @@ fn exploded_archive_relative_entry_name(
         relative.push('/');
     }
     relative
-}
-
-pub(crate) fn native_boot_exploded_archive_get_class_path_urls(
-    args: &[Slot],
-    heap: &mut duke_gc::Heap,
-    out: &mut dyn Write,
-    control: &mut NativeControl,
-    ops: &mut dyn CallbackOps,
-) -> Result<Option<Slot>> {
-    let archive_ref = extract_ref_arg(args, 0)?;
-    let include_predicate_ref = extract_ref_arg(args, 1)?;
-    let search_predicate_ref = extract_ref_arg(args, 2)?;
-    let root_directory_ref = archive_file_ref_at(heap, archive_ref, 0)?;
-    let root_path = file_path_from_ref(root_directory_ref, heap)?;
-
-    let set_ref = heap.allocate("java/util/HashSet".to_string(), 1);
-    native_hashset_init(&[Slot::Reference(Some(set_ref))], heap, out, control)?;
-
-    let mut pending: VecDeque<std::path::PathBuf> = list_directory_children_sorted(&root_path)?
-        .into_iter()
-        .collect();
-    while let Some(entry_path) = pending.pop_front() {
-        let is_directory = entry_path.is_dir();
-        let entry_name =
-            exploded_archive_relative_entry_name(&root_path, &entry_path, is_directory);
-        if is_directory
-            && boot_archive_predicate_accepts(
-                search_predicate_ref,
-                &entry_name,
-                true,
-                heap,
-                out,
-                ops,
-            )?
-        {
-            let children = list_directory_children_sorted(&entry_path)?;
-            for child in children.into_iter().rev() {
-                pending.push_front(child);
-            }
-        }
-
-        if boot_archive_predicate_accepts(
-            include_predicate_ref,
-            &entry_name,
-            is_directory,
-            heap,
-            out,
-            ops,
-        )? {
-            boot_archive_hashset_add_url(
-                set_ref,
-                path_to_file_url(&entry_path),
-                heap,
-                out,
-                control,
-            )?;
-        }
-    }
-
-    Ok(Some(Slot::Reference(Some(set_ref))))
 }
 
 pub(crate) fn native_boot_launched_class_loader_init(
@@ -37720,70 +37155,7 @@ mod havoc_string_indent_overflow {
     }
 }
 
-#[cfg(test)]
-mod tests_zip_coverage {
-    use super::*;
 
-    #[test]
-    fn zip_registry_error_coverage() {
-        // ID 999 doesn't exist
-        let err = zip_entry_count(999).unwrap_err();
-        assert!(matches!(err, Error::JavaException { .. }));
-
-        let err = zip_get_entry_info(999, "test").unwrap_err();
-        assert!(matches!(err, Error::JavaException { .. }));
-
-        let err = zip_read_entry(999, "test").unwrap_err();
-        assert!(matches!(err, Error::JavaException { .. }));
-
-        // Removing non-existent shouldn't panic
-        zip_close(999);
-    }
-}
-
-#[cfg(test)]
-mod tests_zip_open_coverage {
-    use super::*;
-
-    #[test]
-    fn zip_open_io_error() {
-        let err = zip_open(std::path::Path::new("/does/not/exist/ever/zip.zip")).unwrap_err();
-        assert!(matches!(err, Error::JavaException { ref class_name } if class_name == "java/io/FileNotFoundException"));
-    }
-
-    #[test]
-    fn zip_open_format_error() {
-        let temp_dir = std::env::temp_dir();
-        let path = temp_dir.join("bad_zip_format.zip");
-        std::fs::write(&path, b"not a zip file").unwrap();
-        let err = zip_open(&path).unwrap_err();
-        assert!(matches!(err, Error::JavaException { ref class_name } if class_name == "java/util/zip/ZipException"));
-        std::fs::remove_file(&path).unwrap();
-    }
-
-
-
-
-
-
-
-#[cfg(test)]
-mod havoc_coverage_tests {
-    use super::*;
-
-    #[test]
-    fn test_system_property_value_fallback() {
-        assert!(system_property_value_fallback("file.separator").is_some());
-        assert!(system_property_value_fallback("path.separator").is_some());
-        assert!(system_property_value_fallback("line.separator").is_some());
-        assert!(system_property_value_fallback("os.name").is_some());
-        assert!(system_property_value_fallback("unknown.property").is_none());
-        assert!(system_property_value_fallback("java.version").is_some());
-        assert!(system_property_value_fallback("user.dir").is_some());
-    }
-}
-
-}
 
 #[cfg(test)]
 mod havoc_string_repeat_oom {
@@ -37918,5 +37290,20 @@ mod native_helper_tests {
         let args = vec![];
         let res = extract_slot_arg(&args, 0);
         assert_eq!(res, Slot::Reference(None));
+    }
+}
+#[cfg(test)]
+mod havoc_coverage_tests {
+    use super::*;
+
+    #[test]
+    fn test_system_property_value_fallback() {
+        assert!(system_property_value_fallback("file.separator").is_some());
+        assert!(system_property_value_fallback("path.separator").is_some());
+        assert!(system_property_value_fallback("line.separator").is_some());
+        assert!(system_property_value_fallback("os.name").is_some());
+        assert!(system_property_value_fallback("unknown.property").is_none());
+        assert!(system_property_value_fallback("java.version").is_some());
+        assert!(system_property_value_fallback("user.dir").is_some());
     }
 }

--- a/crates/duke-interpreter/src/native_zip.rs
+++ b/crates/duke-interpreter/src/native_zip.rs
@@ -1,0 +1,608 @@
+
+fn zip_files() -> &'static RwLock<HashMap<i32, duke_loader::ZipReader>> {
+    static ZIP_FILES: OnceLock<RwLock<HashMap<i32, duke_loader::ZipReader>>> = OnceLock::new();
+    ZIP_FILES.get_or_init(|| RwLock::new(HashMap::new()))
+}
+static NEXT_ZIP_ID: AtomicI32 = AtomicI32::new(100_000_000);
+
+fn zip_open(path: &std::path::Path) -> Result<i32> {
+    let reader = duke_loader::ZipReader::open(path).map_err(|err| match err {
+        duke_loader::Error::Io { .. } => Error::JavaException {
+            class_name: "java/io/FileNotFoundException".to_string(),
+        },
+        _ => Error::JavaException {
+            class_name: "java/util/zip/ZipException".to_string(),
+        },
+    })?;
+    let id = NEXT_ZIP_ID.fetch_add(1, Ordering::Relaxed);
+    zip_files().write().unwrap_or_else(std::sync::PoisonError::into_inner).insert(id, reader);
+    Ok(id)
+}
+
+fn zip_entry_count(id: i32) -> Result<usize> {
+    let map = zip_files().read().unwrap_or_else(std::sync::PoisonError::into_inner);
+    map.get(&id).map_or_else(
+        || Err(Error::JavaException { class_name: "java/io/IOException".into() }),
+        |reader| Ok(reader.entry_count())
+    )
+}
+
+fn zip_get_entry_info(id: i32, name: &str) -> Result<Option<duke_loader::ZipEntryInfo>> {
+    let map = zip_files().read().unwrap_or_else(std::sync::PoisonError::into_inner);
+    map.get(&id).map_or_else(
+        || Err(Error::JavaException { class_name: "java/io/IOException".into() }),
+        |reader| Ok(reader.get_entry(name).cloned())
+    )
+}
+
+fn zip_read_entry(id: i32, name: &str) -> Result<Vec<u8>> {
+    let map = zip_files().read().unwrap_or_else(std::sync::PoisonError::into_inner);
+    map.get(&id).map_or_else(
+        || Err(Error::JavaException { class_name: "java/io/IOException".into() }),
+        |reader| reader.read_entry(name).map_err(|_| Error::JavaException { class_name: "java/util/zip/ZipException".into() })
+    )
+}
+
+fn zip_close(id: i32) {
+    zip_files().write().unwrap_or_else(std::sync::PoisonError::into_inner).remove(&id);
+}
+
+/// Native: `ZipFile.<init>(String)` — open and index a ZIP/JAR archive.
+pub(crate) fn native_zip_file_init(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let path_ref = extract_ref_arg(args, 1)?;
+    let path_str = heap
+        .get(path_ref)?
+        .string_value
+        .as_deref()
+        .ok_or(Error::NullPointerException)?
+        .to_string();
+    let fd = zip_open(std::path::Path::new(&path_str))?;
+    let obj = heap.get_mut(this_ref)?;
+    obj.fields[0] = Slot::Int(fd);
+    Ok(None)
+}
+
+/// Native: `JarFile.<init>(File)` — open and index a JAR archive from a File object.
+pub(crate) fn native_jar_file_init_from_file(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let file_ref = extract_ref_arg(args, 1)?;
+    let path = file_path_from_ref(file_ref, heap)?;
+    let fd = zip_open(&path)?;
+    let obj = heap.get_mut(this_ref)?;
+    obj.fields[0] = Slot::Int(fd);
+    Ok(None)
+}
+
+pub(crate) fn native_jar_file_init_with_mode_and_version(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    out: &mut dyn Write,
+    control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let forwarded_args = match args {
+        [this_slot, file_slot, ..] => [*this_slot, *file_slot],
+        _ => {
+            return Err(Error::TypeMismatch {
+                expected: "this,file",
+                got: "other",
+            });
+        }
+    };
+    native_jar_file_init_from_file(&forwarded_args, heap, out, control)
+}
+
+pub(crate) fn native_jar_file_get_manifest(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let fd = extract_io_fd(heap, this_ref)?;
+    let Ok(manifest_bytes) = zip_read_entry(fd, "META-INF/MANIFEST.MF") else {
+        return Ok(Some(Slot::Reference(None)));
+    };
+    let manifest_ref = allocate_manifest_from_bytes(heap, &manifest_bytes)?;
+    Ok(Some(Slot::Reference(Some(manifest_ref))))
+}
+
+pub(crate) fn native_boot_nested_jar_file_get_manifest(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    out: &mut dyn Write,
+    control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    native_jar_file_get_manifest(args, heap, out, control)
+}
+
+const BOOT_JAR_FILE_ARCHIVE_JAR_FILE_SLOT: usize = 1;
+const BOOT_EXPLODED_ARCHIVE_ROOT_DIRECTORY_SLOT: usize = 0;
+const BOOT_EXPLODED_ARCHIVE_MANIFEST_SLOT: usize = 2;
+
+pub(crate) fn native_boot_jar_file_archive_get_manifest(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    out: &mut dyn Write,
+    control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let jar_file_ref = match heap
+        .get(this_ref)?
+        .fields
+        .get(BOOT_JAR_FILE_ARCHIVE_JAR_FILE_SLOT)
+        .copied()
+    {
+        Some(Slot::Reference(Some(jar_file_ref))) => jar_file_ref,
+        Some(Slot::Reference(None)) | None => return Err(Error::NullPointerException),
+        Some(_) => {
+            return Err(Error::TypeMismatch {
+                expected: "reference",
+                got: "other",
+            });
+        }
+    };
+    native_jar_file_get_manifest(&[Slot::Reference(Some(jar_file_ref))], heap, out, control)
+}
+
+pub(crate) fn native_boot_archive_get_manifest(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    out: &mut dyn Write,
+    control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    match heap.get(this_ref)?.class_name.as_str() {
+        "org/springframework/boot/loader/launch/JarFileArchive" => {
+            native_boot_jar_file_archive_get_manifest(args, heap, out, control)
+        }
+        "org/springframework/boot/loader/launch/ExplodedArchive" => {
+            native_boot_exploded_archive_get_manifest(args, heap, out, control)
+        }
+        _ => Err(Error::MethodNotFound {
+            name: format!("{}.getManifest", heap.get(this_ref)?.class_name),
+            descriptor: "()Ljava/util/jar/Manifest;".to_string(),
+        }),
+    }
+}
+
+pub(crate) fn native_boot_exploded_archive_get_manifest(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    if let Some(slot @ Slot::Reference(Some(_))) = heap
+        .get(this_ref)?
+        .fields
+        .get(BOOT_EXPLODED_ARCHIVE_MANIFEST_SLOT)
+        .copied()
+    {
+        return Ok(Some(slot));
+    }
+
+    let root_directory_ref = match heap
+        .get(this_ref)?
+        .fields
+        .get(BOOT_EXPLODED_ARCHIVE_ROOT_DIRECTORY_SLOT)
+        .copied()
+    {
+        Some(Slot::Reference(Some(root_directory_ref))) => root_directory_ref,
+        Some(Slot::Reference(None)) | None => return Err(Error::NullPointerException),
+        Some(_) => {
+            return Err(Error::TypeMismatch {
+                expected: "reference",
+                got: "other",
+            });
+        }
+    };
+    let manifest_path = file_path_from_ref(root_directory_ref, heap)?.join("META-INF/MANIFEST.MF");
+    let manifest_bytes = match std::fs::read(&manifest_path) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Some(Slot::Reference(None)));
+        }
+        Err(_) => {
+            return Err(Error::JavaException {
+                class_name: "java/io/IOException".to_string(),
+            });
+        }
+    };
+    let manifest_ref = allocate_manifest_from_bytes(heap, &manifest_bytes)?;
+    heap.get_mut(this_ref)?.fields[BOOT_EXPLODED_ARCHIVE_MANIFEST_SLOT] =
+        Slot::Reference(Some(manifest_ref));
+    Ok(Some(Slot::Reference(Some(manifest_ref))))
+}
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+pub(crate) fn native_zip_file_get_entry(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let name_ref = extract_ref_arg(args, 1)?;
+    let fd = extract_io_fd(heap, this_ref)?;
+    let entry_name = heap
+        .get(name_ref)?
+        .string_value
+        .as_deref()
+        .ok_or(Error::NullPointerException)?
+        .to_string();
+    let info = zip_get_entry_info(fd, &entry_name)?;
+    let Some(info) = info else {
+        return Ok(Some(Slot::Reference(None)));
+    };
+    // Allocate a ZipEntry HeapObject with 6 fields.
+    let name_heap_ref = heap.allocate_string(info.name);
+    let entry_ref = heap.allocate("java/util/zip/ZipEntry".to_string(), 6);
+    let entry_obj = heap.get_mut(entry_ref)?;
+    entry_obj.fields[0] = Slot::Reference(Some(name_heap_ref));
+    entry_obj.fields[1] = Slot::Int(info.compressed_size as i32);
+    entry_obj.fields[2] = Slot::Int((info.compressed_size >> 32) as i32);
+    entry_obj.fields[3] = Slot::Int(info.uncompressed_size as i32);
+    entry_obj.fields[4] = Slot::Int((info.uncompressed_size >> 32) as i32);
+    entry_obj.fields[5] = Slot::Int(i32::from(info.compression_method));
+    Ok(Some(Slot::Reference(Some(entry_ref))))
+}
+
+/// Native: `ZipFile.getInputStream(ZipEntry) -> InputStream`
+pub(crate) fn native_zip_file_get_input_stream(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let entry_ref = extract_ref_arg(args, 1)?;
+    let fd = extract_io_fd(heap, this_ref)?;
+    // Get entry name from the ZipEntry object.
+    let name_slot_ref = match heap.get(entry_ref)?.fields.first() {
+        Some(Slot::Reference(Some(r))) => *r,
+        _ => return Err(Error::NullPointerException),
+    };
+    let entry_name = heap
+        .get(name_slot_ref)?
+        .string_value
+        .as_deref()
+        .ok_or(Error::NullPointerException)?
+        .to_string();
+    // Decompress the entry and wrap in a ByteBuffer.
+    let data = zip_read_entry(fd, &entry_name)?;
+    let buf_fd = heap.open_host_byte_buffer(data);
+    let is_ref = heap.allocate("duke/zip/ByteBufferInputStream".to_string(), 1);
+    let is_obj = heap.get_mut(is_ref)?;
+    is_obj.fields[0] = Slot::Int(buf_fd);
+    Ok(Some(Slot::Reference(Some(is_ref))))
+}
+
+/// Native: `ZipFile.close()`
+pub(crate) fn native_zip_file_close(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let fd = match heap.get(this_ref)?.fields.first() {
+        Some(Slot::Int(id)) => *id,
+        _ => return Ok(None),
+    };
+    zip_close(fd);
+    let obj = heap.get_mut(this_ref)?;
+    obj.fields[0] = Slot::Int(0);
+    Ok(None)
+}
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+pub(crate) fn native_zip_file_size(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let fd = extract_io_fd(heap, this_ref)?;
+    let count = zip_entry_count(fd)?;
+    Ok(Some(Slot::Int(count as i32)))
+}
+
+/// Native: `ZipEntry.getName() -> String`
+pub(crate) fn native_zip_entry_get_name(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    Ok(Some(heap.get(this_ref)?.fields[0]))
+}
+
+/// Native: `ZipEntry.getCompressedSize() -> long`
+pub(crate) fn native_zip_entry_get_compressed_size(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let fields = &heap.get(this_ref)?.fields;
+    let lo = match fields[1] {
+        Slot::Int(v) => v,
+        _ => 0,
+    };
+    let hi = match fields[2] {
+        Slot::Int(v) => v,
+        _ => 0,
+    };
+    let val = (i64::from(hi) << 32) | (i64::from(lo) & 0xFFFF_FFFF);
+    Ok(Some(Slot::Long(val)))
+}
+
+/// Native: `ZipEntry.getSize() -> long`
+pub(crate) fn native_zip_entry_get_size(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let fields = &heap.get(this_ref)?.fields;
+    let lo = match fields[3] {
+        Slot::Int(v) => v,
+        _ => 0,
+    };
+    let hi = match fields[4] {
+        Slot::Int(v) => v,
+        _ => 0,
+    };
+    let val = (i64::from(hi) << 32) | (i64::from(lo) & 0xFFFF_FFFF);
+    Ok(Some(Slot::Long(val)))
+}
+
+/// Native: `ZipEntry.getMethod() -> int`
+pub(crate) fn native_zip_entry_get_method(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    Ok(Some(heap.get(this_ref)?.fields[5]))
+}
+
+const BOOT_ARCHIVE_ENTRY_NAME_SLOT: usize = 0;
+const BOOT_ARCHIVE_ENTRY_DIRECTORY_SLOT: usize = 1;
+
+#[cfg(test)]
+fn boot_archive_entry_name(heap: &duke_gc::Heap, entry_ref: u64) -> Result<String> {
+    let Some(Slot::Reference(Some(name_ref))) = heap
+        .get(entry_ref)?
+        .fields
+        .get(BOOT_ARCHIVE_ENTRY_NAME_SLOT)
+        .copied()
+    else {
+        return Err(Error::NullPointerException);
+    };
+    string_value_from_ref(heap, name_ref)
+}
+
+fn boot_archive_entry_is_directory_flag(heap: &duke_gc::Heap, entry_ref: u64) -> Result<bool> {
+    match heap
+        .get(entry_ref)?
+        .fields
+        .get(BOOT_ARCHIVE_ENTRY_DIRECTORY_SLOT)
+        .copied()
+    {
+        Some(Slot::Int(value)) => Ok(value != 0),
+        _ => Err(Error::TypeMismatch {
+            expected: "Int",
+            got: "other",
+        }),
+    }
+}
+
+pub(crate) fn native_boot_archive_entry_name(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let entry_ref = extract_ref_arg(args, 0)?;
+    let Some(slot @ Slot::Reference(Some(_))) = heap
+        .get(entry_ref)?
+        .fields
+        .get(BOOT_ARCHIVE_ENTRY_NAME_SLOT)
+        .copied()
+    else {
+        return Err(Error::NullPointerException);
+    };
+    Ok(Some(slot))
+}
+
+pub(crate) fn native_boot_archive_entry_is_directory(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let entry_ref = extract_ref_arg(args, 0)?;
+    Ok(Some(Slot::Int(i32::from(
+        boot_archive_entry_is_directory_flag(heap, entry_ref)?,
+    ))))
+}
+
+fn boot_archive_hashset_add_url(
+    set_ref: u64,
+    url_spec: String,
+    heap: &mut duke_gc::Heap,
+    out: &mut dyn Write,
+    control: &mut NativeControl,
+) -> Result<()> {
+    let url_ref = allocate_string_backed_object(heap, "java/net/URL", url_spec)?;
+    native_hashset_add(
+        &[
+            Slot::Reference(Some(set_ref)),
+            Slot::Reference(Some(url_ref)),
+        ],
+        heap,
+        out,
+        control,
+    )?;
+    Ok(())
+}
+
+pub(crate) fn native_boot_jar_file_archive_get_class_path_urls(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    out: &mut dyn Write,
+    control: &mut NativeControl,
+    ops: &mut dyn CallbackOps,
+) -> Result<Option<Slot>> {
+    let archive_ref = extract_ref_arg(args, 0)?;
+    let include_predicate_ref = extract_ref_arg(args, 1)?;
+    let _ = extract_ref_arg(args, 2)?;
+    let archive_file_ref = archive_file_ref_at(heap, archive_ref, 0)?;
+    let archive_path = file_path_from_ref(archive_file_ref, heap)?;
+    let reader = open_boot_archive_reader(&archive_path)?;
+    let mut entry_names: Vec<String> = reader.entry_names().map(ToOwned::to_owned).collect();
+    entry_names.sort_unstable();
+
+    let set_ref = heap.allocate("java/util/HashSet".to_string(), 1);
+    native_hashset_init(&[Slot::Reference(Some(set_ref))], heap, out, control)?;
+
+    for entry_name in entry_names {
+        let is_directory = entry_name.ends_with('/');
+        if boot_archive_predicate_accepts(
+            include_predicate_ref,
+            &entry_name,
+            is_directory,
+            heap,
+            out,
+            ops,
+        )? {
+            let url_spec = format!("jar:{}!/{}", path_to_file_url(&archive_path), entry_name);
+            boot_archive_hashset_add_url(set_ref, url_spec, heap, out, control)?;
+        }
+    }
+
+    Ok(Some(Slot::Reference(Some(set_ref))))
+}
+
+pub(crate) fn native_boot_exploded_archive_get_class_path_urls(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    out: &mut dyn Write,
+    control: &mut NativeControl,
+    ops: &mut dyn CallbackOps,
+) -> Result<Option<Slot>> {
+    let archive_ref = extract_ref_arg(args, 0)?;
+    let include_predicate_ref = extract_ref_arg(args, 1)?;
+    let search_predicate_ref = extract_ref_arg(args, 2)?;
+    let root_directory_ref = archive_file_ref_at(heap, archive_ref, 0)?;
+    let root_path = file_path_from_ref(root_directory_ref, heap)?;
+
+    let set_ref = heap.allocate("java/util/HashSet".to_string(), 1);
+    native_hashset_init(&[Slot::Reference(Some(set_ref))], heap, out, control)?;
+
+    let mut pending: VecDeque<std::path::PathBuf> = list_directory_children_sorted(&root_path)?
+        .into_iter()
+        .collect();
+    while let Some(entry_path) = pending.pop_front() {
+        let is_directory = entry_path.is_dir();
+        let entry_name =
+            exploded_archive_relative_entry_name(&root_path, &entry_path, is_directory);
+        if is_directory
+            && boot_archive_predicate_accepts(
+                search_predicate_ref,
+                &entry_name,
+                true,
+                heap,
+                out,
+                ops,
+            )?
+        {
+            let children = list_directory_children_sorted(&entry_path)?;
+            for child in children.into_iter().rev() {
+                pending.push_front(child);
+            }
+        }
+
+        if boot_archive_predicate_accepts(
+            include_predicate_ref,
+            &entry_name,
+            is_directory,
+            heap,
+            out,
+            ops,
+        )? {
+            boot_archive_hashset_add_url(
+                set_ref,
+                path_to_file_url(&entry_path),
+                heap,
+                out,
+                control,
+            )?;
+        }
+    }
+
+    Ok(Some(Slot::Reference(Some(set_ref))))
+}
+#[cfg(test)]
+mod tests_zip_coverage {
+    use super::*;
+
+    #[test]
+    fn zip_registry_error_coverage() {
+        // ID 999 doesn't exist
+        let err = zip_entry_count(999).unwrap_err();
+        assert!(matches!(err, Error::JavaException { .. }));
+
+        let err = zip_get_entry_info(999, "test").unwrap_err();
+        assert!(matches!(err, Error::JavaException { .. }));
+
+        let err = zip_read_entry(999, "test").unwrap_err();
+        assert!(matches!(err, Error::JavaException { .. }));
+
+        // Removing non-existent shouldn't panic
+        zip_close(999);
+    }
+}
+#[cfg(test)]
+mod tests_zip_open_coverage {
+    use super::*;
+
+    #[test]
+    fn zip_open_io_error() {
+        let err = zip_open(std::path::Path::new("/does/not/exist/ever/zip.zip")).unwrap_err();
+        assert!(matches!(err, Error::JavaException { ref class_name } if class_name == "java/io/FileNotFoundException"));
+    }
+
+    #[test]
+    fn zip_open_format_error() {
+        let temp_dir = std::env::temp_dir();
+        let path = temp_dir.join("bad_zip_format.zip");
+        std::fs::write(&path, b"not a zip file").unwrap();
+        let err = zip_open(&path).unwrap_err();
+        assert!(matches!(err, Error::JavaException { ref class_name } if class_name == "java/util/zip/ZipException"));
+        std::fs::remove_file(&path).unwrap();
+    }
+
+
+
+
+
+
+
+
+}


### PR DESCRIPTION
**Tangle:** The `native.rs` file contains non-JNI zip file management mixed with native bridges, contributing to The Bloat. **Blueprint:** Extracted zip-related logic into `native_zip.rs` to enforce clearer boundaries. **Stability:** Reduced coupling, smaller file size. **Verification:** Tests pass.

---
*PR created automatically by Jules for task [795936755510177033](https://jules.google.com/task/795936755510177033) started by @madmax983*