### PR TITLE
⚒️ Forge: Extract Reference Field Boilerplate

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -68,3 +68,6 @@
 **Extract Control Flow Graph Edges**
 **Learning:** `generate_mermaid_cfg`, `generate_basic_block_cfg`, and `cyclomatic_complexity` in `crates/duke-bytecode/src/cfg.rs` shared complex, duplicated matching logic to determine the control flow edges of instructions (using `is_return()`, `unconditional_jump_target()`, `conditional_branch_target()`, `switch_targets()`).
 **Action:** Created `Instruction::control_flow_edges` to centralize this logic, returning a generic list of `(target_pc, Option<label>)` tuples. This massively simplified all three functions by replacing their redundant if-else chains with a simple loop over the extracted edges.
+**Extract Reference Boilerplate**
+**Learning:** `native.rs` had dozens of repetitions of `match obj.fields.first() { Some(Slot::Reference(Some(r))) => *r, _ => return Err(Error::NullPointerException) }`. This repeated inline pattern matching clutters logic and hides the simple intent of extracting an object reference field.
+**Action:** Created `extract_first_ref_field` and `extract_ref_from_slot` helper functions to compress the boilerplate into a single line with `?` error propagation.

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -134,6 +134,24 @@ fn extract_first_field_arg(heap: &duke_gc::Heap, obj_ref: u64) -> Result<Slot> {
 }
 
 #[inline]
+fn extract_first_ref_field(heap: &duke_gc::Heap, obj_ref: u64) -> Result<u64> {
+    match heap.get(obj_ref)?.fields.first() {
+        Some(Slot::Reference(Some(r))) => Ok(*r),
+        _ => Err(Error::NullPointerException),
+    }
+}
+
+#[inline]
+const fn extract_ref_from_slot(slot: Option<&Slot>) -> Result<u64> {
+    match slot {
+        Some(Slot::Reference(Some(r))) => Ok(*r),
+        _ => Err(Error::NullPointerException),
+    }
+}
+
+
+
+#[inline]
 fn extract_io_fd(heap: &duke_gc::Heap, obj_ref: u64) -> Result<i32> {
     match heap.get(obj_ref)?.fields.first() {
         Some(Slot::Int(id)) => Ok(*id),
@@ -2468,10 +2486,7 @@ mod charset_codec_tests {
 }
 
 fn file_path_from_ref(file_ref: u64, heap: &duke_gc::Heap) -> Result<std::path::PathBuf> {
-    let path_ref = match heap.get(file_ref)?.fields.first() {
-        Some(Slot::Reference(Some(r))) => *r,
-        _ => return Err(Error::NullPointerException),
-    };
+    let path_ref = extract_first_ref_field(heap, file_ref)?;
     Ok(std::path::PathBuf::from(string_value_from_ref(
         heap, path_ref,
     )?))
@@ -3246,10 +3261,7 @@ pub(crate) fn native_zip_file_get_input_stream(
     let entry_ref = extract_ref_arg(args, 1)?;
     let fd = extract_io_fd(heap, this_ref)?;
     // Get entry name from the ZipEntry object.
-    let name_slot_ref = match heap.get(entry_ref)?.fields.first() {
-        Some(Slot::Reference(Some(r))) => *r,
-        _ => return Err(Error::NullPointerException),
-    };
+    let name_slot_ref = extract_first_ref_field(heap, entry_ref)?;
     let entry_name = heap
         .get(name_slot_ref)?
         .string_value
@@ -24923,10 +24935,7 @@ fn instantiate_service_provider(
                 });
             }
         };
-        let provider_name_ref = match iter.fields.get(SERVICE_ITER_PROVIDERS_START + index) {
-            Some(Slot::Reference(Some(reference))) => *reference,
-            _ => return Err(Error::NullPointerException),
-        };
+        let provider_name_ref = extract_ref_from_slot(iter.fields.get(SERVICE_ITER_PROVIDERS_START + index))?;
         (loader_ref, provider_name_ref)
     };
     let provider_binary_name = string_value_from_ref(heap, provider_name_ref)?;
@@ -25105,10 +25114,7 @@ pub(crate) fn native_arraylist_iter_next(
     let this_ref = extract_ref_arg(args, 0)?;
     let (list_ref, cursor) = {
         let iter_obj = heap.get(this_ref)?;
-        let lr = match iter_obj.fields.first() {
-            Some(Slot::Reference(Some(r))) => *r,
-            _ => return Err(Error::NullPointerException),
-        };
+        let lr = extract_ref_from_slot(iter_obj.fields.first())?;
         let c = match iter_obj.fields.get(1) {
             Some(Slot::Int(i)) => *i,
             _ => 0,
@@ -25143,10 +25149,7 @@ pub(crate) fn native_arraylist_iter_remove(
     let this_ref = extract_ref_arg(args, 0)?;
     let (list_ref, last, cursor) = {
         let iter_obj = heap.get(this_ref)?;
-        let lr = match iter_obj.fields.first() {
-            Some(Slot::Reference(Some(r))) => *r,
-            _ => return Err(Error::NullPointerException),
-        };
+        let lr = extract_ref_from_slot(iter_obj.fields.first())?;
         let last = match iter_obj.fields.get(2) {
             Some(Slot::Int(i)) => *i,
             _ => -1,
@@ -30954,10 +30957,7 @@ pub(crate) fn native_hashset_iter_next(
     let this_ref = extract_ref_arg(args, 0)?;
     let (set_ref, cursor) = {
         let iter_obj = heap.get(this_ref)?;
-        let sr = match iter_obj.fields.first() {
-            Some(Slot::Reference(Some(r))) => *r,
-            _ => return Err(Error::NullPointerException),
-        };
+        let sr = extract_ref_from_slot(iter_obj.fields.first())?;
         let c = match iter_obj.fields.get(1) {
             Some(Slot::Int(i)) => *i,
             _ => 0,


### PR DESCRIPTION
🚬 Smell: Repeated inline `match obj.fields.first() { Some(Slot::Reference(Some(r))) => *r, _ => return Err(Error::NullPointerException) }` boilerplate created visual noise and deep nesting.
✨ Solution: Extracted `extract_first_ref_field` and `extract_ref_from_slot` helper functions and used them to flatten logic.
🧼 Benefit: Reduces cognitive load and DRYs up reference extraction.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [16473682735206918628](https://jules.google.com/task/16473682735206918628) started by @madmax983*