### PR TITLE
🌟 Nova: Cyclomatic Complexity Analysis for JARs

### DIFF
--- a/duke/src/jar_complexity.rs
+++ b/duke/src/jar_complexity.rs
@@ -1,0 +1,139 @@
+#[cfg(feature = "nova")]
+use duke_bytecode::{cyclomatic_complexity, decode};
+#[cfg(feature = "nova")]
+use duke_classfile::{
+    parse,
+    types::{AttributeData, CpEntry, CpIndex},
+};
+#[cfg(feature = "nova")]
+use duke_loader::{ClassLoader, ZipLoader};
+use std::path::Path;
+use std::process;
+
+#[cfg(feature = "nova")]
+#[cfg(not(tarpaulin_include))]
+#[allow(unexpected_cfgs, dead_code)]
+fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
+    cf.constant_pool
+        .get(idx.0 as usize)
+        .and_then(|slot| slot.as_ref())
+        .and_then(|entry| {
+            if let CpEntry::Utf8(s) = entry {
+                Some(s.as_str())
+            } else {
+                None
+            }
+        })
+}
+
+#[cfg(feature = "nova")]
+#[cfg(not(tarpaulin_include))]
+#[allow(unexpected_cfgs, dead_code)]
+fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
+    if idx.0 == 0 {
+        return "<none>".to_string();
+    }
+    let class_entry = cf
+        .constant_pool
+        .get(idx.0 as usize)
+        .and_then(|s| s.as_ref());
+    if let Some(CpEntry::Class { name_index }) = class_entry {
+        cp_str(cf, *name_index)
+            .unwrap_or("<invalid utf8>")
+            .to_string()
+    } else {
+        "<not a class ref>".to_string()
+    }
+}
+
+/// Computes cyclomatic complexity for all methods in a JAR.
+///
+/// **Why it exists:** Provides insight into the maintainability and testing
+/// burden of code by calculating `McCabe`'s Cyclomatic Complexity per method.
+#[cfg(feature = "nova")]
+#[allow(clippy::print_stdout, clippy::collapsible_if, clippy::use_debug, clippy::doc_markdown, clippy::cast_precision_loss, clippy::cast_lossless)]
+pub fn dump_jar_complexity(jar_path: &str) {
+    let loader = ZipLoader::open(Path::new(jar_path)).unwrap_or_else(|e| {
+        eprintln!("duke: failed to open JAR '{jar_path}': {e}");
+        process::exit(1);
+    });
+
+    let reader = loader.reader();
+    let class_entries: Vec<String> = reader
+        .entry_names()
+        .filter(|name| {
+            std::path::Path::new(name)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("class"))
+        })
+        .map(std::string::ToString::to_string)
+        .collect();
+
+    let mut complexities = Vec::new();
+    let mut total_complexity = 0;
+    let mut method_count = 0;
+
+    for entry_name in class_entries {
+        let class_name_internal = &entry_name[..entry_name.len() - 6];
+        if let Ok(bytes) = loader.find_class(class_name_internal) {
+            if let Ok(cf) = parse(&bytes) {
+                let this_class = resolve_class_name(&cf, cf.this_class);
+                for method in &cf.methods {
+                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+                    let full_name = format!("{this_class}::{name_str}{desc_str}");
+
+                    for attr in &method.attributes {
+                        if let AttributeData::Code(code) = &attr.data {
+                            if let Ok(instructions) = decode(&code.code) {
+                                let c = cyclomatic_complexity(&instructions);
+                                complexities.push((full_name.clone(), c));
+                                total_complexity += c;
+                                method_count += 1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    complexities.sort_by(|a, b| b.1.cmp(&a.1));
+
+    println!("======================================");
+    println!(" JAR Cyclomatic Complexity Analysis");
+    println!("======================================");
+    println!("File:                 {jar_path}");
+    if method_count > 0 {
+        println!("Average Complexity:   {:.2}", (total_complexity as f64) / f64::from(method_count));
+    } else {
+        println!("Average Complexity:   N/A");
+    }
+    println!();
+
+    let top_n = std::cmp::min(10, complexities.len());
+    if top_n > 0 {
+        println!("Top {top_n} most complex methods:");
+        for (name, score) in complexities.iter().take(top_n) {
+            let bar: String = "█".repeat(*score);
+            println!("{score:>5} | {name} {bar}");
+        }
+    } else {
+        println!("No methods found.");
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "nova")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dump_jar_complexity() {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../tests/fixtures/hello.jar");
+        let path_str = path.to_str().unwrap();
+
+        dump_jar_complexity(path_str);
+    }
+}

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -17,6 +17,8 @@ mod histogram;
 mod html;
 #[cfg(feature = "nova")]
 mod html_jar;
+#[cfg(feature = "nova")]
+mod jar_complexity;
 mod jar_analyze;
 #[cfg(feature = "nova")]
 mod jar_search;
@@ -306,6 +308,8 @@ fn main() {
         #[cfg(feature = "nova")]
         eprintln!("       duke cycle-detect <file.jar>");
         #[cfg(feature = "nova")]
+        #[cfg(feature = "nova")]
+        eprintln!("       duke jar-complexity <file.jar>");
         eprintln!("       duke audit <file.jar>");
         eprintln!("       duke deps-graph <classfile.class>");
         #[cfg(feature = "nova")]
@@ -480,6 +484,12 @@ fn main() {
 
     if args.len() >= 3 && args[1] == "scan" {
         scan::dump_scan(&args[2]);
+        return;
+    }
+
+    #[cfg(feature = "nova")]
+    if args.len() >= 3 && args[1] == "jar-complexity" {
+        jar_complexity::dump_jar_complexity(&args[2]);
         return;
     }
 

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,4 @@
+💡 **The Spark:** "Codebases can quickly become unmaintainable if methods grow too large. I noticed we have bytecode parsing and CFG generation in `duke-bytecode` and archive reading in `duke-loader`, but no way to quickly evaluate the complexity of an entire JAR file at a glance."
+🚀 **The Feature:** "Implemented a `jar-complexity` analysis tool that parses all `.class` files in a `.jar`, decodes their bytecode, calculates McCabe's Cyclomatic Complexity per method using our existing CFG logic, and outputs an overall average alongside a visual histogram of the top 10 most complex methods."
+🔮 **The Potential:** "Could be used in CI/CD pipelines to block PRs that introduce overly complex methods, or as an audit tool for investigating third-party library bloat before adopting them into the JVM."
+⚠️ **Risk:** "Low. Isolated to a new CLI subcommand in `duke/src/jar_complexity.rs` and safely guarded by the `#[cfg(feature = "nova")]` feature flag."


### PR DESCRIPTION
💡 **The Spark:** "Codebases can quickly become unmaintainable if methods grow too large. I noticed we have bytecode parsing and CFG generation in `duke-bytecode` and archive reading in `duke-loader`, but no way to quickly evaluate the complexity of an entire JAR file at a glance."
🚀 **The Feature:** "Implemented a `jar-complexity` analysis tool that parses all `.class` files in a `.jar`, decodes their bytecode, calculates McCabe's Cyclomatic Complexity per method using our existing CFG logic, and outputs an overall average alongside a visual histogram of the top 10 most complex methods."
🔮 **The Potential:** "Could be used in CI/CD pipelines to block PRs that introduce overly complex methods, or as an audit tool for investigating third-party library bloat before adopting them into the JVM."
⚠️ **Risk:** "Low. Isolated to a new CLI subcommand in `duke/src/jar_complexity.rs` and safely guarded by the `#[cfg(feature = "nova")]` feature flag."

---
*PR created automatically by Jules for task [4750634953708369920](https://jules.google.com/task/4750634953708369920) started by @madmax983*