### PR TITLE
🛡️ Sentry: [test coverage improvement] Add tests for boundary errors and EOF parsing

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -27,3 +27,6 @@
 ## 2024-05-24 - Testing Duke Telemetry Serde Map Emptiness
 **Learning:** `keyed_map` formatting utilities using `serialize_map` were missing tests to ensure empty HashMaps correctly serialize as `{}`.
 **Action:** Adding tests for `HashMap::new()` in serialization wrappers proves correct behavior.
+## 2024-05-25 - Testing EOF and Out-of-Bounds Error Arms
+**Learning:** Decoders and parsers often implicitly rely on boundary check logic deep inside their cursors/readers, leading to branches returning `UnexpectedEof` remaining untested. Furthermore, `DirectoryLoader` inside `duke-loader` did not have tests confirming that directly attempting to search for dots (e.g. `java.lang.Object`) correctly triggers the boundary abort early returning `NotFound`.
+**Action:** Adding explicit unit tests that construct undersized buffers or supply dot-separated strings forces evaluation of these error paths (`UnexpectedEof`, `NotFound`), closing coverage gaps inside `duke-bytecode`, `duke-classfile`, and `duke-loader`.

--- a/crates/duke-bytecode/src/decoder.rs
+++ b/crates/duke-bytecode/src/decoder.rs
@@ -1232,4 +1232,33 @@ mod tests {
         let mut cursor4 = Cursor::new(&[0xFF, 0xFF]);
         assert_eq!(cursor4.read_i16().unwrap(), -1);
     }
+
+    #[test]
+    fn should_return_unexpected_eof_for_cursor_reads() {
+        let mut cursor = Cursor::new(&[0x01]);
+        assert_eq!(cursor.read_u8().unwrap(), 0x01);
+
+        // Next u8 should fail
+        let err = cursor.read_u8().unwrap_err();
+        assert!(matches!(
+            err,
+            crate::Error::Decode(DecodeError::UnexpectedEof { pc: 1 })
+        ));
+
+        // Let's test u16 and u32 boundaries as well
+        let mut cursor2 = Cursor::new(&[0x01, 0x02, 0x03]);
+        cursor2.pos = 2; // only 1 byte remaining
+        let err = cursor2.read_u16().unwrap_err();
+        assert!(matches!(
+            err,
+            crate::Error::Decode(DecodeError::UnexpectedEof { pc: 2 })
+        ));
+
+        cursor2.pos = 0; // 3 bytes remaining
+        let err = cursor2.read_u32().unwrap_err();
+        assert!(matches!(
+            err,
+            crate::Error::Decode(DecodeError::UnexpectedEof { pc: 0 })
+        ));
+    }
 }

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -705,4 +705,20 @@ mod tests {
         };
         assert_eq!(values.len(), 2);
     }
+
+    #[test]
+    fn should_return_unexpected_eof_when_reading_out_of_bounds() {
+        let mut cursor = Cursor::new(&[0x01]);
+        assert_eq!(cursor.remaining(), 1);
+        let val = cursor.read_u8().unwrap();
+        assert_eq!(val, 0x01);
+        let err = cursor.read_u8().unwrap_err();
+        assert!(
+            matches!(err, Error::UnexpectedEof { offset: 1 }),
+            "Expected Error::UnexpectedEof, got {err:?}"
+        );
+
+        let err2 = cursor.read_bytes(1).unwrap_err();
+        assert!(matches!(err2, Error::UnexpectedEof { offset: 1 }));
+    }
 }

--- a/crates/duke-loader/src/directory.rs
+++ b/crates/duke-loader/src/directory.rs
@@ -195,4 +195,11 @@ mod tests {
         );
         assert!(resource.url.ends_with("sample.txt"));
     }
+
+    #[test]
+    fn directory_loader_find_class_with_dot_returns_not_found() {
+        let loader = DirectoryLoader::new(std::path::PathBuf::from("/tmp"));
+        let result = loader.find_class("java.lang.Object");
+        assert!(matches!(result, Err(Error::NotFound { .. })));
+    }
 }


### PR DESCRIPTION
This PR addresses missing coverage lines reported in `cobertura.xml` specifically inside cursor boundary/EOF logic across `duke-classfile` and `duke-bytecode`, as well as directory traversal/dot-path filtering inside `duke-loader::directory`.

Key changes:
- `duke-bytecode/src/decoder.rs`: added explicit OOB checks for `u8`, `u16`, and `u32` cursor offsets asserting `UnexpectedEof`.
- `duke-classfile/src/parser.rs`: added explicit bounds validations asserting `UnexpectedEof` for byte reading limits.
- `duke-loader/src/directory.rs`: added checks ensuring `.class` or dot notation paths gracefully return `NotFound` when requested against `DirectoryLoader`.
- Appended related learnings to `.jules/sentry.md`.

---
*PR created automatically by Jules for task [13034586254248938002](https://jules.google.com/task/13034586254248938002) started by @madmax983*