### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -25,3 +25,7 @@
 ## 2024-05-23 - [Test Files Missing Docs]
 **Confusion:** Proptest and loom test binaries generated missing documentation warnings, which shouldn't require full crate documentation blocks.
 **Clarification:** Suppressed warnings in `havoc_jimage_proptest.rs`, `havoc_zip_proptest.rs`, and `havoc_zip_files_loom.rs` using `#![allow(missing_docs)]`. Added `//!` crate documentation to `duke-interpreter` to clarify its core orchestration role.
+
+## 2024-05-06 - [Test Files Missing Documentation]
+**Confusion:** The integration test file for oss_jar_smoke triggered missing documentation warnings, which are explicitly mandated by strict linting rules.
+**Clarification:** Added module-level `//!` documentation to the `oss_jar_smoke.rs` integration test to address the warning.

--- a/crates/duke-interpreter/tests/oss_jar_smoke.rs
+++ b/crates/duke-interpreter/tests/oss_jar_smoke.rs
@@ -1,3 +1,5 @@
+//! OSS JAR Smoke tests.
+//!
 use std::path::{Path, PathBuf};
 
 use duke_gc::Heap;

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -173,37 +173,45 @@ impl TelemetryStore {
     }
 
     fn print_class_init_dag(&self, w: &mut dyn std::io::Write) -> std::io::Result<()> {
-        writeln!(
-            w,
-            "\n-- class_init_dag ({} clinit events) --",
-            self.class_init_dag.events.len()
-        )?;
-        for ev in &self.class_init_dag.events {
+        if self.class_init_dag.events.is_empty() {
+            writeln!(w, "\n-- class_init_dag --\n  No class initialization events recorded.")?;
+        } else {
             writeln!(
                 w,
-                "  {} (triggered by: {}, {}ns)",
-                ev.class, ev.triggered_by, ev.duration_ns
+                "\n-- class_init_dag ({} clinit events) --",
+                self.class_init_dag.events.len()
             )?;
+            for ev in &self.class_init_dag.events {
+                writeln!(
+                    w,
+                    "  {} (triggered by: {}, {}ns)",
+                    ev.class, ev.triggered_by, ev.duration_ns
+                )?;
+            }
         }
         Ok(())
     }
 
     fn print_exception_flow(&self, w: &mut dyn std::io::Write) -> std::io::Result<()> {
-        writeln!(
-            w,
-            "\n-- exception_flow ({} throw events) --",
-            self.exception_flow.events.len()
-        )?;
-        for ev in &self.exception_flow.events {
-            let catch = ev.catch_site.as_ref().map_or_else(
-                || "uncaught".to_string(),
-                |(c, m, pc)| format!("{c}::{m} @{pc}"),
-            );
+        if self.exception_flow.events.is_empty() {
+            writeln!(w, "\n-- exception_flow --\n  No exception flow events recorded.")?;
+        } else {
             writeln!(
                 w,
-                "  {} thrown at {:?} caught at {}",
-                ev.exception_class, ev.throw_site, catch
+                "\n-- exception_flow ({} throw events) --",
+                self.exception_flow.events.len()
             )?;
+            for ev in &self.exception_flow.events {
+                let catch = ev.catch_site.as_ref().map_or_else(
+                    || "uncaught".to_string(),
+                    |(c, m, pc)| format!("{c}::{m} @{pc}"),
+                );
+                writeln!(
+                    w,
+                    "  {} thrown at {:?} caught at {}",
+                    ev.exception_class, ev.throw_site, catch
+                )?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
📖 Chapter: The `oss_jar_smoke.rs` tests.
🔦 Insight: The integration test file for oss_jar_smoke triggered missing documentation warnings, which are explicitly mandated by strict linting rules. Added module-level `//!` documentation to address the warning. Tests need documentation just like regular modules! Also fixed the failing `test_print_report_empty` telemetry test by allowing telemetry formatting to gracefully handle printing empty class init DAGs and exception flows, without panicking on assertion.
🧪 Example: Run `cargo clippy --workspace --all-targets --all-features -- -W missing_docs -W clippy::missing_errors_doc -W clippy::missing_panics_doc`
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [216498583815344651](https://jules.google.com/task/216498583815344651) started by @madmax983*