### PR TITLE
⚒️ Forge: refactor string argument extraction

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -68,3 +68,6 @@
 **Extract Control Flow Graph Edges**
 **Learning:** `generate_mermaid_cfg`, `generate_basic_block_cfg`, and `cyclomatic_complexity` in `crates/duke-bytecode/src/cfg.rs` shared complex, duplicated matching logic to determine the control flow edges of instructions (using `is_return()`, `unconditional_jump_target()`, `conditional_branch_target()`, `switch_targets()`).
 **Action:** Created `Instruction::control_flow_edges` to centralize this logic, returning a generic list of `(target_pc, Option<label>)` tuples. This massively simplified all three functions by replacing their redundant if-else chains with a simple loop over the extracted edges.
+**[Replacing Match Blocks Safely]**
+**Learning:** Replacing deeply nested `match` boilerplate with strictly-typed helper functions can easily introduce runtime regressions if the exact fallback semantics (e.g., returning `None` vs `String::new()` vs throwing `Error::TypeMismatch`) are not perfectly preserved.
+**Action:** Always create distinct, tailored helper functions that match the original code's specific fallback behavior before performing a bulk find-and-replace, rather than forcing a single generic error-throwing helper onto all call sites.

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -255,18 +255,9 @@ pub(crate) fn native_println_string(
     out: &mut dyn Write,
     _control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
-    let string_ref = match args.get(1) {
-        Some(Slot::Reference(Some(r))) => *r,
-        Some(Slot::Reference(None)) => {
-            writeln!(out, "null").ok();
-            return Ok(None);
-        }
-        _ => {
-            return Err(Error::TypeMismatch {
-                expected: "Reference",
-                got: "other",
-            });
-        }
+    let Some(string_ref) = extract_string_ref(args, 1)? else {
+        writeln!(out, "null").ok();
+        return Ok(None);
     };
     let obj = heap.get(string_ref)?;
     let text = obj.string_value.as_deref().unwrap_or("null");
@@ -3786,10 +3777,7 @@ pub(crate) fn native_throwable_init_string(
     control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let msg = match args.get(1) {
-        Some(Slot::Reference(Some(r))) => heap.get(*r)?.string_value.clone(),
-        _ => None,
-    };
+    let msg = extract_string_opt(heap, args, 1)?;
     heap.get_mut(this_ref)?.string_value = msg;
     fill_throwable_stack_trace_from_control(heap, this_ref, control)?;
     Ok(None)
@@ -3803,10 +3791,7 @@ pub(crate) fn native_throwable_init_string_cause(
     control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let msg = match args.get(1) {
-        Some(Slot::Reference(Some(r))) => heap.get(*r)?.string_value.clone(),
-        _ => None,
-    };
+    let msg = extract_string_opt(heap, args, 1)?;
     heap.get_mut(this_ref)?.string_value = msg;
     // Store cause in fields[0] (Throwable.cause field)
     if let Some(&cause_slot) = args.get(2)
@@ -7027,14 +7012,7 @@ pub(crate) fn native_collectors_joining_full(
     _control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
     let read_str = |heap: &duke_gc::Heap, idx: usize| -> String {
-        match args.get(idx) {
-            Some(Slot::Reference(Some(r))) => heap
-                .get(*r)
-                .ok()
-                .and_then(|o| o.string_value.clone())
-                .unwrap_or_default(),
-            _ => String::new(),
-        }
+        extract_string_or_empty(heap, args, idx).unwrap_or_default()
     };
     let delim = read_str(heap, 0);
     let prefix = read_str(heap, 1);
@@ -11088,18 +11066,9 @@ pub(crate) fn native_print_string(
     out: &mut dyn Write,
     _control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
-    let string_ref = match args.get(1) {
-        Some(Slot::Reference(Some(r))) => *r,
-        Some(Slot::Reference(None)) => {
-            write!(out, "null").ok();
-            return Ok(None);
-        }
-        _ => {
-            return Err(Error::TypeMismatch {
-                expected: "Reference",
-                got: "other",
-            });
-        }
+    let Some(string_ref) = extract_string_ref(args, 1)? else {
+        write!(out, "null").ok();
+        return Ok(None);
     };
     let obj = heap.get(string_ref)?;
     let text = obj.string_value.as_deref().unwrap_or("null");
@@ -17731,6 +17700,47 @@ fn extract_string_arg_value(args: &[Slot], index: usize, heap: &duke_gc::Heap) -
     Ok(heap.get(str_ref)?.string_value.clone().unwrap_or_default())
 }
 
+#[inline]
+fn extract_string_opt(heap: &duke_gc::Heap, args: &[Slot], idx: usize) -> Result<Option<String>> {
+    match args.get(idx) {
+        Some(Slot::Reference(Some(r))) => Ok(heap.get(*r)?.string_value.clone()),
+        _ => Ok(None),
+    }
+}
+
+#[inline]
+fn extract_string_or_null(heap: &duke_gc::Heap, args: &[Slot], idx: usize) -> Result<String> {
+    match args.get(idx) {
+        Some(Slot::Reference(Some(r))) => Ok(heap.get(*r)?.string_value.clone().unwrap_or_default()),
+        Some(Slot::Reference(None)) | None => Ok("null".to_string()),
+        _ => Err(Error::TypeMismatch {
+            expected: "String",
+            got: "other",
+        }),
+    }
+}
+
+#[inline]
+fn extract_string_or_empty(heap: &duke_gc::Heap, args: &[Slot], idx: usize) -> Result<String> {
+    match args.get(idx) {
+        Some(Slot::Reference(Some(r))) => Ok(heap.get(*r)?.string_value.clone().unwrap_or_default()),
+        _ => Ok(String::new()),
+    }
+}
+
+#[inline]
+fn extract_string_ref(args: &[Slot], idx: usize) -> Result<Option<u64>> {
+    match args.get(idx) {
+        Some(Slot::Reference(Some(r))) => Ok(Some(*r)),
+        Some(Slot::Reference(None)) => Ok(None),
+        _ => Err(Error::TypeMismatch {
+            expected: "Reference",
+            got: "other",
+        }),
+    }
+}
+
+
 fn extract_parse_radix_arg(args: &[Slot], index: usize) -> Result<u32> {
     let radix = extract_int_arg(args, index)?;
     if !(2..=36).contains(&radix) {
@@ -23825,10 +23835,7 @@ pub(crate) fn native_sb_init_string(
     _control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let init_str = match args.get(1) {
-        Some(Slot::Reference(Some(r))) => heap.get(*r)?.string_value.clone().unwrap_or_default(),
-        _ => String::new(),
-    };
+    let init_str = extract_string_or_empty(heap, args, 1)?;
     let obj = heap.get_mut(this_ref)?;
     obj.string_value = Some(init_str);
     Ok(None)
@@ -23979,16 +23986,7 @@ pub(crate) fn native_sb_insert_string(
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
     let offset = extract_int_arg(args, 1)?;
-    let s = match args.get(2) {
-        Some(Slot::Reference(Some(r))) => heap.get(*r)?.string_value.clone().unwrap_or_default(),
-        Some(Slot::Reference(None)) | None => "null".to_string(),
-        _ => {
-            return Err(Error::TypeMismatch {
-                expected: "String",
-                got: "other",
-            });
-        }
-    };
+    let s = extract_string_or_null(heap, args, 2)?;
     let buf = heap
         .get_mut(this_ref)?
         .string_value
@@ -28739,10 +28737,7 @@ pub(crate) fn native_stringbuffer_init_string(
     _control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let s = match args.get(1).copied() {
-        Some(Slot::Reference(Some(r))) => heap.get(r)?.string_value.clone().unwrap_or_default(),
-        _ => String::new(),
-    };
+    let s = extract_string_or_empty(heap, args, 1)?;
     heap.get_mut(this_ref)?.string_value = Some(s);
     Ok(None)
 }

--- a/plan.md
+++ b/plan.md
@@ -1,7 +1,5 @@
-1. **Understand the problem:** The problem requires fixing missing documentation warnings that `cargo clippy --all-targets --all-features -- -W missing-docs` reports.
-2. **Current state:** We had missing docs for test binaries `crates/duke-loader/tests/havoc_jimage_proptest.rs`, `crates/duke-loader/tests/havoc_zip_proptest.rs`, `crates/duke-interpreter/tests/havoc_zip_files_loom.rs`.
-3. **Execution:** We already fixed this by adding `#![allow(missing_docs)]` to these test files, which makes sense for test binaries that don't need crate-level documentation to satisfy the warning.
-4. **Fixing other module:** We had an issue with `duke-interpreter` missing the crate documentation block. I updated `crates/duke-interpreter/src/lib.rs` to have a nice `//!` description that documents the crate-level module.
-5. **Validation:** `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` completes successfully, and `cargo clippy --all-targets --all-features -- -W missing_docs` doesn't produce missing_docs warnings, and tests pass.
-6. **Pre-commit step**: Execute tests and run pre commit step.
-7. **Submit**: Create PR.
+1. Add new string extraction helper functions that match the *exact* semantics of the existing code, to avoid runtime errors or behavioral changes. The original matches often return `String::new()` or `None` on failure, instead of `Error::TypeMismatch`.
+2. Use python to safely substitute only matching boilerplate blocks.
+3. Validate by tests.
+4. Clean up any python scripts left in the workspace.
+5. Code review and submit.


### PR DESCRIPTION
⚒️ Forge: refactor string argument extraction

🚮 Smell: `native.rs` had repetitive, deeply nested `match args.get(idx) { ... }` blocks used to extract strings from interpreter arguments, resulting in "Pyramid of Doom" style boilerplate.
✨ Solution: Extracted the repetitive string extraction logic into strictly typed helper functions (`extract_string_opt`, `extract_string_or_null`, `extract_string_or_empty`, and `extract_string_ref`) that perfectly preserve original fallback behaviors and error semantics. Replaced all occurrences using a targeted patch script.
🧼 Benefit: Reduces cognitive load and structural nesting in `native.rs`, improving readability while enforcing idiomatic Rust bounds.
🛡️ Verification: Tests passed. No logic changed. All previous fallbacks preserved.

---
*PR created automatically by Jules for task [17058911474373560155](https://jules.google.com/task/17058911474373560155) started by @madmax983*