### PR TITLE
🗺️ Atlas: [architectural change] explicitly export module items and remove wildcard exports

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -4,3 +4,6 @@
 **[Encapsulate Module Facades]
 **Tangle:** The `pub mod` declarations for internal sub-modules like `reachability` and `ser_helpers` were publicly exposed, violating encapsulation boundaries.
 **Blueprint:** Changed the visibilities to `pub(crate) mod` to encapsulate the modules, while re-exporting only the specific items like `find_shortest_path` where needed.
+**[Explicit Exports over Wildcards]**
+**Tangle:** The `lib.rs` files across modules like `duke-telemetry`, `duke-interpreter`, and `duke-classfile` used wildcard exports (`pub use module::*`). This created leaky abstractions, potentially exposing internal implementation details and cluttering the module's public interface, which violated clear domain boundary principles.
+**Blueprint:** Replaced all `pub use module::*` statements with exact item exports (`pub use module::{SpecificType1, SpecificType2};`), enforcing strict and intentional public APIs that only expose what is necessary.

--- a/crates/duke-classfile/src/lib.rs
+++ b/crates/duke-classfile/src/lib.rs
@@ -24,9 +24,12 @@ pub(crate) mod parser;
 
 /// Compatibility module re-exporting the split type structures.
 pub mod types {
-    pub use crate::attributes::*;
-    pub use crate::class::*;
-    pub use crate::constant_pool::*;
+    pub use crate::attributes::{
+        Annotation, AttributeData, AttributeInfo, BootstrapMethodEntry, CodeAttribute,
+        ElementValue, ElementValuePair, ExceptionTableEntry, LineNumberEntry, LocalVariableEntry,
+    };
+    pub use crate::class::{ClassFile, FieldInfo, MethodInfo};
+    pub use crate::constant_pool::{CpEntry, CpIndex};
 }
 
 pub use access_flags::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -26,8 +26,13 @@ pub(crate) mod registry;
 pub(crate) mod stdlib;
 pub(crate) mod threading;
 
-pub use context::*;
-pub use registry::*;
+pub use context::{ClassContext, ClassLoadSource, ExceptionEntry, FieldEntry, MethodEntry};
+pub use registry::{
+    CallbackNativeHandler, CallbackOps, ClassRegistry, HandlerKind, LambdaInfo, NativeControl,
+    NativeHandler, NativeRegistry, NativeStackFrame, NativeThreadAction, ReflectedAnnotation,
+    ReflectedAnnotationConst, ReflectedAnnotationElement, ReflectedAnnotationValue,
+    ReflectedClassInfo, ReflectedFieldInfo, ReflectedMethodInfo,
+};
 pub use stdlib::bootstrap_stdlib;
 pub use threading::{SharedOutput, ThreadPause, ThreadRecord, ThreadRuntime};
 

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -38,17 +38,17 @@
 pub(crate) mod helpers;
 
 pub(crate) mod bytecode_cost;
-pub use bytecode_cost::*;
+pub use bytecode_cost::{BytecodeCostStore, OpcodeStat};
 pub(crate) mod object_lineage;
-pub use object_lineage::*;
+pub use object_lineage::{AllocationSite, ObjectLineageStore};
 pub(crate) mod class_init_dag;
-pub use class_init_dag::*;
+pub use class_init_dag::{ClassInitDagStore, ClinitEvent};
 pub(crate) mod exception_flow;
-pub use exception_flow::*;
+pub use exception_flow::{ExceptionEvent, ExceptionFlowStore};
 pub(crate) mod dispatch_resolution;
-pub use dispatch_resolution::*;
+pub use dispatch_resolution::{DispatchResolutionStore, DispatchStat};
 pub(crate) mod native_boundary;
-pub use native_boundary::*;
+pub use native_boundary::{NativeBoundaryStore, NativeStat};
 
 // -- TelemetryStore --------------------------------------------------------------
 


### PR DESCRIPTION
Replaced all wildcard exports (`pub use module::*`) with explicit item exports (`pub use module::{Item1, Item2};`) across the `duke-telemetry`, `duke-interpreter`, and `duke-classfile` crates.

🕸️ Tangle: Wildcard exports created leaky abstractions and made the public API boundaries unclear.
📐 Blueprint: Enforced clear, specific domain boundaries by explicitly listing exported items.
🧱 Stability: Reduced the risk of accidental API exposure and name collisions.
🔬 Verification: Passed strict clippy checks, tests, and standard formatting.

---
*PR created automatically by Jules for task [7794394329993391658](https://jules.google.com/task/7794394329993391658) started by @madmax983*