### PR TITLE
👺 Havoc: ClassFile parser stack overflow on deeply nested annotations

### DIFF
--- a/crates/duke-classfile/src/error.rs
+++ b/crates/duke-classfile/src/error.rs
@@ -129,6 +129,10 @@ pub enum Error {
         /// Raw tag byte.
         tag: u8,
     },
+
+    /// Annotation nesting is too deep.
+    #[error("annotation nesting is too deep")]
+    AnnotationNestingTooDeep,
 }
 
 /// Convenience alias.

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -433,7 +433,7 @@ fn decode_known_attribute(name: &str, raw: &[u8]) -> Result<AttributeData> {
         "RuntimeVisibleAnnotations" => {
             AttributeData::RuntimeVisibleAnnotations(decode_runtime_visible_annotations(&mut c)?)
         }
-        "AnnotationDefault" => AttributeData::AnnotationDefault(decode_element_value(&mut c)?),
+        "AnnotationDefault" => AttributeData::AnnotationDefault(decode_element_value(&mut c, 0)?),
         _ => AttributeData::Raw(raw.to_vec()),
     };
     Ok(data)
@@ -505,19 +505,22 @@ fn decode_runtime_visible_annotations(c: &mut Cursor<'_>) -> Result<Vec<Annotati
     let num_annotations = c.read_u16()? as usize;
     let mut annotations = Vec::with_capacity(num_annotations.min(c.remaining() / 4));
     for _ in 0..num_annotations {
-        annotations.push(decode_annotation(c)?);
+        annotations.push(decode_annotation(c, 0)?);
     }
     Ok(annotations)
 }
 
-fn decode_annotation(c: &mut Cursor<'_>) -> Result<Annotation> {
+fn decode_annotation(c: &mut Cursor<'_>, depth: usize) -> Result<Annotation> {
+    if depth > 256 {
+        return Err(Error::AnnotationNestingTooDeep);
+    }
     let type_index = c.read_cp_index()?;
     let num_pairs = c.read_u16()? as usize;
     let mut element_value_pairs = Vec::with_capacity(num_pairs.min(c.remaining() / 3));
     for _ in 0..num_pairs {
         element_value_pairs.push(ElementValuePair {
             element_name_index: c.read_cp_index()?,
-            value: decode_element_value(c)?,
+            value: decode_element_value(c, depth + 1)?,
         });
     }
     Ok(Annotation {
@@ -526,7 +529,10 @@ fn decode_annotation(c: &mut Cursor<'_>) -> Result<Annotation> {
     })
 }
 
-fn decode_element_value(c: &mut Cursor<'_>) -> Result<ElementValue> {
+fn decode_element_value(c: &mut Cursor<'_>, depth: usize) -> Result<ElementValue> {
+    if depth > 256 {
+        return Err(Error::AnnotationNestingTooDeep);
+    }
     let tag = c.read_u8()?;
     match tag {
         b'B' | b'C' | b'D' | b'F' | b'I' | b'J' | b'S' | b'Z' | b's' => {
@@ -537,12 +543,12 @@ fn decode_element_value(c: &mut Cursor<'_>) -> Result<ElementValue> {
             const_name_index: c.read_cp_index()?,
         }),
         b'c' => Ok(ElementValue::ClassInfoIndex(c.read_cp_index()?)),
-        b'@' => Ok(ElementValue::AnnotationValue(decode_annotation(c)?)),
+        b'@' => Ok(ElementValue::AnnotationValue(decode_annotation(c, depth + 1)?)),
         b'[' => {
             let num_values = c.read_u16()? as usize;
             let mut values = Vec::with_capacity(num_values.min(c.remaining() / 3));
             for _ in 0..num_values {
-                values.push(decode_element_value(c)?);
+                values.push(decode_element_value(c, depth + 1)?);
             }
             Ok(ElementValue::ArrayValue(values))
         }

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -543,7 +543,10 @@ fn decode_element_value(c: &mut Cursor<'_>, depth: usize) -> Result<ElementValue
             const_name_index: c.read_cp_index()?,
         }),
         b'c' => Ok(ElementValue::ClassInfoIndex(c.read_cp_index()?)),
-        b'@' => Ok(ElementValue::AnnotationValue(decode_annotation(c, depth + 1)?)),
+        b'@' => Ok(ElementValue::AnnotationValue(decode_annotation(
+            c,
+            depth + 1,
+        )?)),
         b'[' => {
             let num_values = c.read_u16()? as usize;
             let mut values = Vec::with_capacity(num_values.min(c.remaining() / 3));

--- a/crates/duke-classfile/tests/havoc_classfile_stackoverflow.rs
+++ b/crates/duke-classfile/tests/havoc_classfile_stackoverflow.rs
@@ -16,7 +16,7 @@ fn test_annotation_stack_overflow() {
     let attr_name = b"RuntimeVisibleAnnotations";
     bytes.push(1); // tag Utf8
     bytes.push(0);
-    bytes.push(attr_name.len() as u8);
+    bytes.push(u8::try_from(attr_name.len()).unwrap());
     bytes.extend_from_slice(attr_name);
 
     // access_flags, this_class, super_class
@@ -62,11 +62,11 @@ fn test_annotation_stack_overflow() {
     bytes.push(b'B'); // base value
     bytes.extend_from_slice(&[0x00, 0x01]); // const_value_index
 
-    let attr_len = (bytes.len() - attr_start) as u32;
-    bytes[attr_len_idx] = (attr_len >> 24) as u8;
-    bytes[attr_len_idx + 1] = (attr_len >> 16) as u8;
-    bytes[attr_len_idx + 2] = (attr_len >> 8) as u8;
-    bytes[attr_len_idx + 3] = attr_len as u8;
+    let attr_len = u32::try_from(bytes.len() - attr_start).unwrap();
+    bytes[attr_len_idx] = u8::try_from(attr_len >> 24).unwrap();
+    bytes[attr_len_idx + 1] = u8::try_from(attr_len >> 16).unwrap();
+    bytes[attr_len_idx + 2] = u8::try_from(attr_len >> 8).unwrap();
+    bytes[attr_len_idx + 3] = u8::try_from(attr_len & 0xFF).unwrap();
 
     let _ = parse(&bytes);
 }

--- a/crates/duke-classfile/tests/havoc_classfile_stackoverflow.rs
+++ b/crates/duke-classfile/tests/havoc_classfile_stackoverflow.rs
@@ -1,0 +1,72 @@
+use duke_classfile::parse;
+
+#[test]
+fn test_annotation_stack_overflow() {
+    // Construct a malicious classfile with deeply nested annotations.
+    let mut bytes = vec![
+        0xCA, 0xFE, 0xBA, 0xBE, // magic
+        0x00, 0x00, 0x00, 0x41, // version
+    ];
+
+    // Constant pool count: 2 (indices 1)
+    bytes.push(0x00);
+    bytes.push(0x02);
+
+    // CP 1: Utf8 "RuntimeVisibleAnnotations"
+    let attr_name = b"RuntimeVisibleAnnotations";
+    bytes.push(1); // tag Utf8
+    bytes.push(0);
+    bytes.push(attr_name.len() as u8);
+    bytes.extend_from_slice(attr_name);
+
+    // access_flags, this_class, super_class
+    bytes.extend_from_slice(&[0x00, 0x00, 0x00, 0x01, 0x00, 0x01]);
+
+    // interfaces count
+    bytes.extend_from_slice(&[0x00, 0x00]);
+
+    // fields count
+    bytes.extend_from_slice(&[0x00, 0x00]);
+
+    // methods count
+    bytes.extend_from_slice(&[0x00, 0x00]);
+
+    // attributes count: 1
+    bytes.extend_from_slice(&[0x00, 0x01]);
+
+    // Attribute: RuntimeVisibleAnnotations
+    bytes.extend_from_slice(&[0x00, 0x01]); // name_index
+
+    // Attribute length: we will fill this later
+    let attr_len_idx = bytes.len();
+    bytes.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+
+    let attr_start = bytes.len();
+
+    // num_annotations: 1
+    bytes.extend_from_slice(&[0x00, 0x01]);
+
+    // Let's create deeply nested arrays
+    let depth = 10000; // Deeply nested to cause stack overflow
+
+    // start annotation
+    bytes.extend_from_slice(&[0x00, 0x01]); // type_index
+    bytes.extend_from_slice(&[0x00, 0x01]); // num_pairs
+    bytes.extend_from_slice(&[0x00, 0x01]); // element_name_index
+
+    for _ in 0..depth {
+        bytes.push(b'['); // array
+        bytes.extend_from_slice(&[0x00, 0x01]); // num_values: 1
+    }
+
+    bytes.push(b'B'); // base value
+    bytes.extend_from_slice(&[0x00, 0x01]); // const_value_index
+
+    let attr_len = (bytes.len() - attr_start) as u32;
+    bytes[attr_len_idx] = (attr_len >> 24) as u8;
+    bytes[attr_len_idx + 1] = (attr_len >> 16) as u8;
+    bytes[attr_len_idx + 2] = (attr_len >> 8) as u8;
+    bytes[attr_len_idx + 3] = attr_len as u8;
+
+    let _ = parse(&bytes);
+}


### PR DESCRIPTION
🧨 **The Trigger:** A malicious `.class` file with a `RuntimeVisibleAnnotations` attribute containing arrays nested 10,000 levels deep.
📉 **The Stack Trace:** `fatal runtime error: stack overflow, aborting`
🧪 **Reproduction:** Run `cargo test -p duke-classfile --test havoc_classfile_stackoverflow` before this commit.
😈 **Comment:** You assumed the JVM would never feed you an annotation deeper than a kiddie pool. You were wrong. Added a strict recursion depth limit of 256.

---
*PR created automatically by Jules for task [8323791991107100813](https://jules.google.com/task/8323791991107100813) started by @madmax983*