### PR TITLE
🗺️ Atlas: explicit exports for duke-classfile

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -1,6 +1,3 @@
-**Standardize Workspace Error Types**
-**Tangle:** Each module defined its own duplicate aliases like `VmResult`, `LoadResult`, and `ParseError`, breaking standardized `Result<T, crate::Error>` rules.
-**Blueprint:** Removed domain-specific error aliases in favor of standard `Result` and `Error` types across all crates.
-**[Encapsulate Module Facades]
-**Tangle:** The `pub mod` declarations for internal sub-modules like `reachability` and `ser_helpers` were publicly exposed, violating encapsulation boundaries.
-**Blueprint:** Changed the visibilities to `pub(crate) mod` to encapsulate the modules, while re-exporting only the specific items like `find_shortest_path` where needed.
+## 2024-05-24 - Wildcard Exports in duke-classfile
+**Tangle:** The `duke-classfile` crate used wildcard exports (`pub use crate::attributes::*;`, etc.) in its public API facade, creating a 'Leaky Abstraction' that could unintentionally expose internal implementation details or cause namespace pollution.
+**Blueprint:** Replaced the wildcard exports with explicit, itemized re-exports (`pub use crate::attributes::{...};`) to strictly enforce the public API boundary as a concrete contract.

--- a/crates/duke-classfile/src/lib.rs
+++ b/crates/duke-classfile/src/lib.rs
@@ -24,9 +24,12 @@ pub(crate) mod parser;
 
 /// Compatibility module re-exporting the split type structures.
 pub mod types {
-    pub use crate::attributes::*;
-    pub use crate::class::*;
-    pub use crate::constant_pool::*;
+    pub use crate::attributes::{
+        Annotation, AttributeData, AttributeInfo, BootstrapMethodEntry, CodeAttribute,
+        ElementValue, ElementValuePair, ExceptionTableEntry, LineNumberEntry, LocalVariableEntry,
+    };
+    pub use crate::class::{ClassFile, FieldInfo, MethodInfo};
+    pub use crate::constant_pool::{CpEntry, CpIndex};
 }
 
 pub use access_flags::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};


### PR DESCRIPTION
🕸️ Tangle: The `duke-classfile` crate used wildcard exports (`pub use crate::module::*;`) in its public facade, creating a leaky abstraction that could expose internal implementation details.
📐 Blueprint: Replaced wildcard exports with explicit, itemized exports to strictly define the public API boundary.
🧱 Stability: Enforced strict encapsulation and reduced namespace pollution.
🔬 Verification: Verified with `cargo check` and `cargo test`.

---
*PR created automatically by Jules for task [5043764966666251915](https://jules.google.com/task/5043764966666251915) started by @madmax983*