### PR TITLE
🗺️ Atlas: [architectural change] explicitly export public APIs to fix leaky facades

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -1,6 +1,3 @@
-**Standardize Workspace Error Types**
-**Tangle:** Each module defined its own duplicate aliases like `VmResult`, `LoadResult`, and `ParseError`, breaking standardized `Result<T, crate::Error>` rules.
-**Blueprint:** Removed domain-specific error aliases in favor of standard `Result` and `Error` types across all crates.
-**[Encapsulate Module Facades]
-**Tangle:** The `pub mod` declarations for internal sub-modules like `reachability` and `ser_helpers` were publicly exposed, violating encapsulation boundaries.
-**Blueprint:** Changed the visibilities to `pub(crate) mod` to encapsulate the modules, while re-exporting only the specific items like `find_shortest_path` where needed.
+## 2024-05-08 - Explicit Facade Exports
+**Tangle:** The `duke-classfile`, `duke-interpreter`, and `duke-telemetry` crates used wildcard re-exports (`pub use module::*`) at their `lib.rs` boundaries. This is a "Leaky Abstraction" smell, as it unintentionally pollutes the public API namespace with private, internal, or implementation-detail types from submodules, making the architectural boundary unclear and prone to accidental coupling by consumers.
+**Blueprint:** Replaced all wildcard exports with explicit, named exports of only the intended public domain structures. This establishes a strict, intentional contract at the crate boundaries, ensuring the facade pattern properly hides internal sub-modules from external callers and maintains a clean, understandable API.

--- a/crates/duke-classfile/src/lib.rs
+++ b/crates/duke-classfile/src/lib.rs
@@ -24,9 +24,12 @@ pub(crate) mod parser;
 
 /// Compatibility module re-exporting the split type structures.
 pub mod types {
-    pub use crate::attributes::*;
-    pub use crate::class::*;
-    pub use crate::constant_pool::*;
+    pub use crate::attributes::{
+        Annotation, AttributeData, AttributeInfo, BootstrapMethodEntry, CodeAttribute,
+        ElementValue, ElementValuePair, ExceptionTableEntry, LineNumberEntry, LocalVariableEntry,
+    };
+    pub use crate::class::{ClassFile, FieldInfo, MethodInfo};
+    pub use crate::constant_pool::{CpEntry, CpIndex};
 }
 
 pub use access_flags::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -26,8 +26,13 @@ pub(crate) mod registry;
 pub(crate) mod stdlib;
 pub(crate) mod threading;
 
-pub use context::*;
-pub use registry::*;
+pub use context::{ClassContext, ClassLoadSource, ExceptionEntry, FieldEntry, MethodEntry};
+pub use registry::{
+    CallbackNativeHandler, CallbackOps, ClassRegistry, HandlerKind, LambdaInfo, NativeControl,
+    NativeHandler, NativeRegistry, NativeStackFrame, NativeThreadAction, ReflectedAnnotation,
+    ReflectedAnnotationConst, ReflectedAnnotationElement, ReflectedAnnotationValue,
+    ReflectedClassInfo, ReflectedFieldInfo, ReflectedMethodInfo,
+};
 pub use stdlib::bootstrap_stdlib;
 pub use threading::{SharedOutput, ThreadPause, ThreadRecord, ThreadRuntime};
 

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -38,17 +38,17 @@
 pub(crate) mod helpers;
 
 pub(crate) mod bytecode_cost;
-pub use bytecode_cost::*;
+pub use bytecode_cost::{BytecodeCostStore, OpcodeStat};
 pub(crate) mod object_lineage;
-pub use object_lineage::*;
+pub use object_lineage::{AllocationSite, ObjectLineageStore};
 pub(crate) mod class_init_dag;
-pub use class_init_dag::*;
+pub use class_init_dag::{ClassInitDagStore, ClinitEvent};
 pub(crate) mod exception_flow;
-pub use exception_flow::*;
+pub use exception_flow::{ExceptionEvent, ExceptionFlowStore};
 pub(crate) mod dispatch_resolution;
-pub use dispatch_resolution::*;
+pub use dispatch_resolution::{DispatchResolutionStore, DispatchStat};
 pub(crate) mod native_boundary;
-pub use native_boundary::*;
+pub use native_boundary::{NativeBoundaryStore, NativeStat};
 
 // -- TelemetryStore --------------------------------------------------------------
 


### PR DESCRIPTION
🕸️ Tangle: The codebase was using wildcard exports (`pub use module::*`) in the root `lib.rs` files of several core crates (`duke-classfile`, `duke-interpreter`, `duke-telemetry`). This is an architectural smell ("The Leaky Abstraction") as it unintentionally pollutes the public API namespace with whatever happens to be inside those sub-modules, weakening the intended public contract.

📐 Blueprint: Replaced all wildcard exports with explicitly named type exports. This acts as a strict Facade, guaranteeing that only intentionally public types are exposed outside the crate boundaries.

🧱 Stability: Enforces strict encapsulation, reducing the risk of accidental tight coupling to internal details by downstream crates.

🔬 Verification: Builds successfully, all workspace tests pass, and `cargo clippy` confirms no warnings or structural regressions were introduced. Added learning journal to `.jules/atlas.md`.

---
*PR created automatically by Jules for task [11712631609455385005](https://jules.google.com/task/11712631609455385005) started by @madmax983*