### PR TITLE
🗺️ Atlas: [Explicit API boundaries]

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -4,3 +4,6 @@
 **[Encapsulate Module Facades]
 **Tangle:** The `pub mod` declarations for internal sub-modules like `reachability` and `ser_helpers` were publicly exposed, violating encapsulation boundaries.
 **Blueprint:** Changed the visibilities to `pub(crate) mod` to encapsulate the modules, while re-exporting only the specific items like `find_shortest_path` where needed.
+**[Replacing Wildcard Exports with Explicit Exports]
+**Tangle:** Several crates (`duke-interpreter`, `duke-telemetry`) were using wildcard exports (`pub use module::*`) in their `lib.rs`, which leaks internal implementation details and creates unclear public API boundaries.
+**Blueprint:** Replaced the wildcard exports with explicit exports (e.g., `pub use context::{ClassContext, ...};`) to enforce strict API boundaries and reduce potential coupling issues.

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -26,8 +26,13 @@ pub(crate) mod registry;
 pub(crate) mod stdlib;
 pub(crate) mod threading;
 
-pub use context::*;
-pub use registry::*;
+pub use context::{ClassContext, ClassLoadSource, ExceptionEntry, FieldEntry, MethodEntry};
+pub use registry::{
+    CallbackNativeHandler, CallbackOps, ClassRegistry, HandlerKind, LambdaInfo, NativeControl,
+    NativeHandler, NativeRegistry, NativeStackFrame, NativeThreadAction, ReflectedAnnotation,
+    ReflectedAnnotationConst, ReflectedAnnotationElement, ReflectedAnnotationValue,
+    ReflectedClassInfo, ReflectedFieldInfo, ReflectedMethodInfo,
+};
 pub use stdlib::bootstrap_stdlib;
 pub use threading::{SharedOutput, ThreadPause, ThreadRecord, ThreadRuntime};
 

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -38,17 +38,17 @@
 pub(crate) mod helpers;
 
 pub(crate) mod bytecode_cost;
-pub use bytecode_cost::*;
+pub use bytecode_cost::{BytecodeCostStore, OpcodeStat};
 pub(crate) mod object_lineage;
-pub use object_lineage::*;
+pub use object_lineage::{AllocationSite, ObjectLineageStore};
 pub(crate) mod class_init_dag;
-pub use class_init_dag::*;
+pub use class_init_dag::{ClassInitDagStore, ClinitEvent};
 pub(crate) mod exception_flow;
-pub use exception_flow::*;
+pub use exception_flow::{ExceptionEvent, ExceptionFlowStore};
 pub(crate) mod dispatch_resolution;
-pub use dispatch_resolution::*;
+pub use dispatch_resolution::{DispatchResolutionStore, DispatchStat};
 pub(crate) mod native_boundary;
-pub use native_boundary::*;
+pub use native_boundary::{NativeBoundaryStore, NativeStat};
 
 // -- TelemetryStore --------------------------------------------------------------
 


### PR DESCRIPTION
Replaces wildcard exports (`pub use module::*`) in `duke-interpreter` and `duke-telemetry` with explicit, typed item exports. This architectural change ensures clean, explicit public API boundaries, avoiding the accidental exposure of private types and enforcing high cohesion and low coupling. I also recorded this learning in `.jules/atlas.md`.

---
*PR created automatically by Jules for task [1106249360289255391](https://jules.google.com/task/1106249360289255391) started by @madmax983*