### PR TITLE
👺 Havoc: Prevent Stack Overflow from malicious annotations

### DIFF
--- a/crates/duke-classfile/src/error.rs
+++ b/crates/duke-classfile/src/error.rs
@@ -129,6 +129,11 @@ pub enum Error {
         /// Raw tag byte.
         tag: u8,
     },
+
+    /// The annotation recursion depth limit was exceeded.
+    #[error("annotation recursion depth exceeded")]
+    AnnotationDepthExceeded,
+
 }
 
 /// Convenience alias.

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -433,7 +433,7 @@ fn decode_known_attribute(name: &str, raw: &[u8]) -> Result<AttributeData> {
         "RuntimeVisibleAnnotations" => {
             AttributeData::RuntimeVisibleAnnotations(decode_runtime_visible_annotations(&mut c)?)
         }
-        "AnnotationDefault" => AttributeData::AnnotationDefault(decode_element_value(&mut c)?),
+        "AnnotationDefault" => AttributeData::AnnotationDefault(decode_element_value(&mut c, 0)?),
         _ => AttributeData::Raw(raw.to_vec()),
     };
     Ok(data)
@@ -505,19 +505,22 @@ fn decode_runtime_visible_annotations(c: &mut Cursor<'_>) -> Result<Vec<Annotati
     let num_annotations = c.read_u16()? as usize;
     let mut annotations = Vec::with_capacity(num_annotations.min(c.remaining() / 4));
     for _ in 0..num_annotations {
-        annotations.push(decode_annotation(c)?);
+        annotations.push(decode_annotation(c, 0)?);
     }
     Ok(annotations)
 }
 
-fn decode_annotation(c: &mut Cursor<'_>) -> Result<Annotation> {
+fn decode_annotation(c: &mut Cursor<'_>, depth: usize) -> Result<Annotation> {
+    if depth > 256 {
+        return Err(Error::AnnotationDepthExceeded);
+    }
     let type_index = c.read_cp_index()?;
     let num_pairs = c.read_u16()? as usize;
     let mut element_value_pairs = Vec::with_capacity(num_pairs.min(c.remaining() / 3));
     for _ in 0..num_pairs {
         element_value_pairs.push(ElementValuePair {
             element_name_index: c.read_cp_index()?,
-            value: decode_element_value(c)?,
+            value: decode_element_value(c, depth + 1)?,
         });
     }
     Ok(Annotation {
@@ -526,7 +529,10 @@ fn decode_annotation(c: &mut Cursor<'_>) -> Result<Annotation> {
     })
 }
 
-fn decode_element_value(c: &mut Cursor<'_>) -> Result<ElementValue> {
+fn decode_element_value(c: &mut Cursor<'_>, depth: usize) -> Result<ElementValue> {
+    if depth > 256 {
+        return Err(Error::AnnotationDepthExceeded);
+    }
     let tag = c.read_u8()?;
     match tag {
         b'B' | b'C' | b'D' | b'F' | b'I' | b'J' | b'S' | b'Z' | b's' => {
@@ -537,12 +543,12 @@ fn decode_element_value(c: &mut Cursor<'_>) -> Result<ElementValue> {
             const_name_index: c.read_cp_index()?,
         }),
         b'c' => Ok(ElementValue::ClassInfoIndex(c.read_cp_index()?)),
-        b'@' => Ok(ElementValue::AnnotationValue(decode_annotation(c)?)),
+        b'@' => Ok(ElementValue::AnnotationValue(decode_annotation(c, depth + 1)?)),
         b'[' => {
             let num_values = c.read_u16()? as usize;
             let mut values = Vec::with_capacity(num_values.min(c.remaining() / 3));
             for _ in 0..num_values {
-                values.push(decode_element_value(c)?);
+                values.push(decode_element_value(c, depth + 1)?);
             }
             Ok(ElementValue::ArrayValue(values))
         }

--- a/crates/duke-classfile/tests/havoc_annotation_overflow.rs
+++ b/crates/duke-classfile/tests/havoc_annotation_overflow.rs
@@ -1,0 +1,52 @@
+#![allow(missing_docs)]
+#![allow(clippy::cast_possible_truncation)]
+use std::thread;
+
+#[test]
+fn test_annotation_stack_overflow() {
+    let depth = 50000;
+    let mut raw = Vec::new();
+
+    // Classfile Header
+    raw.extend_from_slice(&[0xca, 0xfe, 0xba, 0xbe]); // Magic
+    raw.extend_from_slice(&[0x00, 0x00, 0x00, 0x34]); // Version
+    raw.extend_from_slice(&[0x00, 0x02]); // CP Count = 2
+    raw.extend_from_slice(&[0x01, 0x00, 0x19]); // CP[1]: Utf8 "RuntimeVisibleAnnotations"
+    raw.extend_from_slice(b"RuntimeVisibleAnnotations");
+    raw.extend_from_slice(&[0x00, 0x00]); // Access Flags
+    raw.extend_from_slice(&[0x00, 0x00]); // This Class
+    raw.extend_from_slice(&[0x00, 0x00]); // Super Class
+    raw.extend_from_slice(&[0x00, 0x00]); // Interfaces Count
+    raw.extend_from_slice(&[0x00, 0x00]); // Fields Count
+    raw.extend_from_slice(&[0x00, 0x00]); // Methods Count
+    raw.extend_from_slice(&[0x00, 0x01]); // Attributes Count
+    raw.extend_from_slice(&[0x00, 0x01]); // attr_name_index = 1 ("RuntimeVisibleAnnotations")
+
+    let attr_len = (6_usize + depth * 7) as u32;
+    raw.extend_from_slice(&attr_len.to_be_bytes());
+
+    raw.extend_from_slice(&1_u16.to_be_bytes()); // num_annotations = 1
+
+    for _ in 0..depth {
+        raw.extend_from_slice(&1_u16.to_be_bytes()); // type_index
+        raw.extend_from_slice(&1_u16.to_be_bytes()); // num_pairs = 1
+        raw.extend_from_slice(&1_u16.to_be_bytes()); // element_name_index
+        raw.push(b'@'); // tag
+    }
+
+    raw.extend_from_slice(&1_u16.to_be_bytes());
+    raw.extend_from_slice(&0_u16.to_be_bytes());
+
+    let handle = thread::Builder::new()
+        .stack_size(2 * 1024 * 1024)
+        .spawn(move || {
+            let res = duke_classfile::parse(&raw);
+            assert!(res.is_err());
+            // It will fail during lazy parsing? No, lazy parsing was removed or what?
+            // Actually `decode_runtime_visible_annotations` is called within `parse_class_file` -> `decode_known_attribute`!
+            assert!(res.unwrap_err().to_string().contains("annotation recursion depth exceeded"));
+        })
+        .unwrap();
+
+    handle.join().unwrap();
+}


### PR DESCRIPTION
👺 Havoc: Prevent Stack Overflow from malicious annotations

🧨 **The Trigger:** A `.class` file can contain an `AnnotationDefault` or `RuntimeVisibleAnnotations` attribute containing an annotation value that recursively nests other annotations (via the `@` tag) or arrays (via the `[` tag) to an arbitrary depth.
📉 **The Stack Trace:** thread has overflowed its stack
🧪 **Reproduction:** Construct a raw attribute value containing 100,000 nested `@` or `[` tags, and call `attribute.decode()`.
😈 **Comment:** "You assumed recursion had limits. The stack had other plans."

---
*PR created automatically by Jules for task [18282035936128610652](https://jules.google.com/task/18282035936128610652) started by @madmax983*