### PR TITLE
🗺️ Atlas: explicit exports to prevent leaky abstractions

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -4,3 +4,7 @@
 **[Encapsulate Module Facades]
 **Tangle:** The `pub mod` declarations for internal sub-modules like `reachability` and `ser_helpers` were publicly exposed, violating encapsulation boundaries.
 **Blueprint:** Changed the visibilities to `pub(crate) mod` to encapsulate the modules, while re-exporting only the specific items like `find_shortest_path` where needed.
+
+**[Explicit Exports]
+**Tangle:** The codebase used wildcard exports (`pub use module::*`) in several crates, which exposed internal implementation details and created leaky abstractions.
+**Blueprint:** Replaced all wildcard exports with explicit item exports (e.g., `pub use context::{ClassContext, ...};`).

--- a/crates/duke-classfile/src/lib.rs
+++ b/crates/duke-classfile/src/lib.rs
@@ -24,9 +24,9 @@ pub(crate) mod parser;
 
 /// Compatibility module re-exporting the split type structures.
 pub mod types {
-    pub use crate::attributes::*;
-    pub use crate::class::*;
-    pub use crate::constant_pool::*;
+    pub use crate::attributes::{Annotation, AttributeData, AttributeInfo, BootstrapMethodEntry, CodeAttribute, ElementValue, ElementValuePair, ExceptionTableEntry, LineNumberEntry, LocalVariableEntry};
+    pub use crate::class::{ClassFile, FieldInfo, MethodInfo};
+    pub use crate::constant_pool::{CpEntry, CpIndex};
 }
 
 pub use access_flags::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};

--- a/crates/duke-classfile/src/lib.rs
+++ b/crates/duke-classfile/src/lib.rs
@@ -24,7 +24,10 @@ pub(crate) mod parser;
 
 /// Compatibility module re-exporting the split type structures.
 pub mod types {
-    pub use crate::attributes::{Annotation, AttributeData, AttributeInfo, BootstrapMethodEntry, CodeAttribute, ElementValue, ElementValuePair, ExceptionTableEntry, LineNumberEntry, LocalVariableEntry};
+    pub use crate::attributes::{
+        Annotation, AttributeData, AttributeInfo, BootstrapMethodEntry, CodeAttribute,
+        ElementValue, ElementValuePair, ExceptionTableEntry, LineNumberEntry, LocalVariableEntry,
+    };
     pub use crate::class::{ClassFile, FieldInfo, MethodInfo};
     pub use crate::constant_pool::{CpEntry, CpIndex};
 }

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -26,8 +26,8 @@ pub(crate) mod registry;
 pub(crate) mod stdlib;
 pub(crate) mod threading;
 
-pub use context::*;
-pub use registry::*;
+pub use context::{ClassContext, ClassLoadSource, ExceptionEntry, FieldEntry, MethodEntry};
+pub use registry::{CallbackNativeHandler, CallbackOps, ClassRegistry, HandlerKind, LambdaInfo, NativeControl, NativeHandler, NativeRegistry, NativeStackFrame, NativeThreadAction, ReflectedAnnotation, ReflectedAnnotationConst, ReflectedAnnotationElement, ReflectedAnnotationValue, ReflectedClassInfo, ReflectedFieldInfo, ReflectedMethodInfo};
 pub use stdlib::bootstrap_stdlib;
 pub use threading::{SharedOutput, ThreadPause, ThreadRecord, ThreadRuntime};
 

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -27,7 +27,12 @@ pub(crate) mod stdlib;
 pub(crate) mod threading;
 
 pub use context::{ClassContext, ClassLoadSource, ExceptionEntry, FieldEntry, MethodEntry};
-pub use registry::{CallbackNativeHandler, CallbackOps, ClassRegistry, HandlerKind, LambdaInfo, NativeControl, NativeHandler, NativeRegistry, NativeStackFrame, NativeThreadAction, ReflectedAnnotation, ReflectedAnnotationConst, ReflectedAnnotationElement, ReflectedAnnotationValue, ReflectedClassInfo, ReflectedFieldInfo, ReflectedMethodInfo};
+pub use registry::{
+    CallbackNativeHandler, CallbackOps, ClassRegistry, HandlerKind, LambdaInfo, NativeControl,
+    NativeHandler, NativeRegistry, NativeStackFrame, NativeThreadAction, ReflectedAnnotation,
+    ReflectedAnnotationConst, ReflectedAnnotationElement, ReflectedAnnotationValue,
+    ReflectedClassInfo, ReflectedFieldInfo, ReflectedMethodInfo,
+};
 pub use stdlib::bootstrap_stdlib;
 pub use threading::{SharedOutput, ThreadPause, ThreadRecord, ThreadRuntime};
 

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -38,17 +38,17 @@
 pub(crate) mod helpers;
 
 pub(crate) mod bytecode_cost;
-pub use bytecode_cost::*;
+pub use bytecode_cost::{BytecodeCostStore, OpcodeStat};
 pub(crate) mod object_lineage;
-pub use object_lineage::*;
+pub use object_lineage::{AllocationSite, ObjectLineageStore};
 pub(crate) mod class_init_dag;
-pub use class_init_dag::*;
+pub use class_init_dag::{ClassInitDagStore, ClinitEvent};
 pub(crate) mod exception_flow;
-pub use exception_flow::*;
+pub use exception_flow::{ExceptionEvent, ExceptionFlowStore};
 pub(crate) mod dispatch_resolution;
-pub use dispatch_resolution::*;
+pub use dispatch_resolution::{DispatchResolutionStore, DispatchStat};
 pub(crate) mod native_boundary;
-pub use native_boundary::*;
+pub use native_boundary::{NativeBoundaryStore, NativeStat};
 
 // -- TelemetryStore --------------------------------------------------------------
 

--- a/plan.md
+++ b/plan.md
@@ -1,7 +1,19 @@
-1. **Understand the problem:** The problem requires fixing missing documentation warnings that `cargo clippy --all-targets --all-features -- -W missing-docs` reports.
-2. **Current state:** We had missing docs for test binaries `crates/duke-loader/tests/havoc_jimage_proptest.rs`, `crates/duke-loader/tests/havoc_zip_proptest.rs`, `crates/duke-interpreter/tests/havoc_zip_files_loom.rs`.
-3. **Execution:** We already fixed this by adding `#![allow(missing_docs)]` to these test files, which makes sense for test binaries that don't need crate-level documentation to satisfy the warning.
-4. **Fixing other module:** We had an issue with `duke-interpreter` missing the crate documentation block. I updated `crates/duke-interpreter/src/lib.rs` to have a nice `//!` description that documents the crate-level module.
-5. **Validation:** `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` completes successfully, and `cargo clippy --all-targets --all-features -- -W missing_docs` doesn't produce missing_docs warnings, and tests pass.
-6. **Pre-commit step**: Execute tests and run pre commit step.
-7. **Submit**: Create PR.
+1. Modify `crates/duke-interpreter/src/lib.rs`
+   - Remove wildcard exports `pub use context::*;` and `pub use registry::*;`
+   - Replace them with explicit exports for `MethodEntry`, `FieldEntry`, `ExceptionEntry`, `ClassLoadSource`, `ClassContext` from `context` and `LambdaInfo`, `NativeThreadAction`, `NativeStackFrame`, `NativeControl`, `ReflectedMethodInfo`, `ReflectedFieldInfo`, `ReflectedAnnotation`, `ReflectedAnnotationElement`, `ReflectedAnnotationValue`, `ReflectedAnnotationConst`, `ReflectedClassInfo`, `ClassRegistry`, `NativeHandler`, `CallbackOps`, `CallbackNativeHandler`, `HandlerKind`, `NativeRegistry` from `registry`.
+
+2. Modify `crates/duke-telemetry/src/lib.rs`
+   - Remove wildcard exports `pub use bytecode_cost::*;`, `pub use object_lineage::*;`, `pub use class_init_dag::*;`, `pub use exception_flow::*;`, `pub use dispatch_resolution::*;`, `pub use native_boundary::*;`
+   - Replace them with explicit exports for `OpcodeStat`, `BytecodeCostStore` from `bytecode_cost`; `AllocationSite`, `ObjectLineageStore` from `object_lineage`; `ClinitEvent`, `ClassInitDagStore` from `class_init_dag`; `ExceptionEvent`, `ExceptionFlowStore` from `exception_flow`; `DispatchStat`, `DispatchResolutionStore` from `dispatch_resolution`; `NativeStat`, `NativeBoundaryStore` from `native_boundary`.
+
+3. Ensure no regressions
+   - Run tests for all crates `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings`.
+
+4. Journal Learning
+   - Add journal entry to `.jules/atlas.md` about wildcard exports causing leaky abstractions and breaking API boundaries.
+
+5. Pre-commit
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+
+6. Submit
+   - Commit and submit.


### PR DESCRIPTION
🗺️ Atlas: explicit exports to prevent leaky abstractions

🕸️ Tangle: The codebase used wildcard exports (`pub use module::*`) in `duke-interpreter`, `duke-telemetry` and `duke-classfile`, which exposed internal implementation details and created leaky abstractions.
📐 Blueprint: Replaced all wildcard exports with explicit item exports (e.g., `pub use context::{ClassContext, ...};`).
🧱 Stability: Strict public API boundaries enforced, preventing internal module changes from unintentionally leaking to the public API.
🔬 Verification: The workspace test suite passes successfully and the changes adhere to `cargo clippy` without warnings.

---
*PR created automatically by Jules for task [4179129997970833594](https://jules.google.com/task/4179129997970833594) started by @madmax983*