### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -25,3 +25,7 @@
 ## 2024-05-23 - [Test Files Missing Docs]
 **Confusion:** Proptest and loom test binaries generated missing documentation warnings, which shouldn't require full crate documentation blocks.
 **Clarification:** Suppressed warnings in `havoc_jimage_proptest.rs`, `havoc_zip_proptest.rs`, and `havoc_zip_files_loom.rs` using `#![allow(missing_docs)]`. Added `//!` crate documentation to `duke-interpreter` to clarify its core orchestration role.
+
+## 2024-05-24 - [Clippy Doc Markdown Lint]
+**Confusion:** Clippy was throwing `clippy::doc-markdown` warnings on capitalized names in documentation (like `ClassLoader`, `JImage`, `OpenJDK`).
+**Clarification:** Replaced bare occurrences of these system or format names with backtick-enclosed code block formatting (e.g., `` `ClassLoader` ``) to satisfy documentation style lints.

--- a/crates/duke-bytecode/src/reachability.rs
+++ b/crates/duke-bytecode/src/reachability.rs
@@ -1,9 +1,15 @@
 //! Basic block reachability and pathfinding.
 //!
 //! This module provides algorithms for analyzing control flow reachability
-//! within a method's basic blocks. It includes utilities to determine basic
-//! block successors, identify dead (unreachable) blocks, and find the shortest
-//! execution paths between blocks.
+//! within a method's basic blocks. A method's bytecode is not just a linear sequence
+//! of instructions; it is a complex web of jumps, branches, and returns. By grouping
+//! these instructions into `BasicBlock`s, we can traverse this web to answer critical questions:
+//! - What can execute next? (`get_successors`)
+//! - Is there code that can never be reached? (`find_dead_blocks`)
+//! - How do we get from point A to point B? (`find_shortest_path`)
+//!
+//! These utilities are essential for generating control flow graphs, optimizing bytecode,
+//! and analyzing execution paths during debugging or testing.
 
 #[cfg(feature = "nova")]
 use crate::basic_block::BasicBlock;

--- a/crates/duke-classfile/src/access_flags.rs
+++ b/crates/duke-classfile/src/access_flags.rs
@@ -1,4 +1,9 @@
 //! `duke-classfile::access_flags` — Class, field, and method access flags
+//!
+//! The JVM relies on a compact set of bitflags to encode the visibility, state, and properties
+//! of classes, fields, and methods. These 16-bit masks determine if a method is `public`, if a
+//! field is `static`, or if a class is actually an `interface`. This module defines strongly-typed
+//! representations of these flags, allowing safe, readable bitwise operations instead of raw `u16` masking.
 
 use bitflags::bitflags;
 

--- a/crates/duke-loader/src/directory.rs
+++ b/crates/duke-loader/src/directory.rs
@@ -1,4 +1,8 @@
 //! `duke-loader::directory` - Loads classes and resources from directories.
+//!
+//! The `DirectoryLoader` is the simplest form of a `ClassLoader`. It maps a JVM internal class name
+//! (like `java/lang/Object`) directly to a file path on the local filesystem (like `java/lang/Object.class`).
+//! It enforces strict bounds-checking to prevent directory traversal attacks (e.g., rejecting paths with `..` or absolute paths).
 
 use std::path::{Path, PathBuf};
 

--- a/crates/duke-loader/src/jimage.rs
+++ b/crates/duke-loader/src/jimage.rs
@@ -74,6 +74,10 @@ const ATTR_UNCOMPRESSED: u8 = 7;
 /// assert_eq!(info.uncompressed, 1024);
 /// ```
 #[derive(Debug, Clone)]
+/// Metadata detailing the location and compression state of a resource inside the `JImage`.
+///
+/// A resource can be uncompressed (raw bytes) or compressed. This metadata is extracted
+/// from the locations table and guides the decompression logic.
 pub struct ResourceInfo {
     /// Byte offset into the data section.
     pub offset: u64,
@@ -98,6 +102,12 @@ pub struct ResourceInfo {
 /// let reader = JImageReader::open(Path::new("/usr/lib/jvm/java-21-openjdk/lib/modules")).unwrap();
 /// println!("Found {} resources", reader.resource_count());
 /// ```
+/// A reader for the `OpenJDK` 9+ `modules` file format (`jimage`).
+///
+/// Modern JVMs bundle all system classes (like `java.lang.Object`) into a highly optimized
+/// binary container instead of hundreds of individual JAR files. The `JImageReader` memory-maps
+/// this container, scans its perfect-hash directory structure, and allows fast O(1) lookups
+/// for any system resource or class.
 pub struct JImageReader {
     data: Vec<u8>,
     resource_count: u32,


### PR DESCRIPTION
- **The "Missing" Link**: Added structural documentation to several modules and structs that lacked descriptive narratives.
- `duke-bytecode::reachability`: Framed the control flow analysis as navigating a complex web of bytecode paths.
- `duke-classfile::access_flags`: Explained the necessity of safe bitflags to represent JVM state attributes.
- `duke-loader::directory`: Described the `DirectoryLoader`'s bounds-checking and role as a primitive file-system mapper.
- `duke-loader::jimage`: Added comprehensive `ResourceInfo` and `JImageReader` comments to elucidate OpenJDK 9+ module reading.
- Satisfied `clippy::doc-markdown` warnings by ensuring capitalized external format names (like `JImage` and `OpenJDK`) are properly escaped with backticks.

---
*PR created automatically by Jules for task [4098541720620498759](https://jules.google.com/task/4098541720620498759) started by @madmax983*