### PR TITLE
🗺️ Atlas: [architectural change]

### DIFF
--- a/crates/duke-classfile/src/lib.rs
+++ b/crates/duke-classfile/src/lib.rs
@@ -24,9 +24,9 @@ pub(crate) mod parser;
 
 /// Compatibility module re-exporting the split type structures.
 pub mod types {
-    pub use crate::attributes::*;
-    pub use crate::class::*;
-    pub use crate::constant_pool::*;
+    pub use crate::attributes::{Annotation, AttributeData, AttributeInfo, BootstrapMethodEntry, CodeAttribute, ElementValue, ElementValuePair, ExceptionTableEntry, LineNumberEntry, LocalVariableEntry};
+    pub use crate::class::{ClassFile, FieldInfo, MethodInfo};
+    pub use crate::constant_pool::{CpEntry, CpIndex};
 }
 
 pub use access_flags::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};

--- a/crates/duke-classfile/src/lib.rs
+++ b/crates/duke-classfile/src/lib.rs
@@ -24,7 +24,10 @@ pub(crate) mod parser;
 
 /// Compatibility module re-exporting the split type structures.
 pub mod types {
-    pub use crate::attributes::{Annotation, AttributeData, AttributeInfo, BootstrapMethodEntry, CodeAttribute, ElementValue, ElementValuePair, ExceptionTableEntry, LineNumberEntry, LocalVariableEntry};
+    pub use crate::attributes::{
+        Annotation, AttributeData, AttributeInfo, BootstrapMethodEntry, CodeAttribute,
+        ElementValue, ElementValuePair, ExceptionTableEntry, LineNumberEntry, LocalVariableEntry,
+    };
     pub use crate::class::{ClassFile, FieldInfo, MethodInfo};
     pub use crate::constant_pool::{CpEntry, CpIndex};
 }

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -26,8 +26,8 @@ pub(crate) mod registry;
 pub(crate) mod stdlib;
 pub(crate) mod threading;
 
-pub use context::*;
-pub use registry::*;
+pub use context::{ClassContext, ClassLoadSource, ExceptionEntry, FieldEntry, MethodEntry};
+pub use registry::{CallbackNativeHandler, CallbackOps, ClassRegistry, HandlerKind, LambdaInfo, NativeControl, NativeHandler, NativeRegistry, NativeStackFrame, NativeThreadAction, ReflectedAnnotation, ReflectedAnnotationConst, ReflectedAnnotationElement, ReflectedAnnotationValue, ReflectedClassInfo, ReflectedFieldInfo, ReflectedMethodInfo};
 pub use stdlib::bootstrap_stdlib;
 pub use threading::{SharedOutput, ThreadPause, ThreadRecord, ThreadRuntime};
 

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -27,7 +27,12 @@ pub(crate) mod stdlib;
 pub(crate) mod threading;
 
 pub use context::{ClassContext, ClassLoadSource, ExceptionEntry, FieldEntry, MethodEntry};
-pub use registry::{CallbackNativeHandler, CallbackOps, ClassRegistry, HandlerKind, LambdaInfo, NativeControl, NativeHandler, NativeRegistry, NativeStackFrame, NativeThreadAction, ReflectedAnnotation, ReflectedAnnotationConst, ReflectedAnnotationElement, ReflectedAnnotationValue, ReflectedClassInfo, ReflectedFieldInfo, ReflectedMethodInfo};
+pub use registry::{
+    CallbackNativeHandler, CallbackOps, ClassRegistry, HandlerKind, LambdaInfo, NativeControl,
+    NativeHandler, NativeRegistry, NativeStackFrame, NativeThreadAction, ReflectedAnnotation,
+    ReflectedAnnotationConst, ReflectedAnnotationElement, ReflectedAnnotationValue,
+    ReflectedClassInfo, ReflectedFieldInfo, ReflectedMethodInfo,
+};
 pub use stdlib::bootstrap_stdlib;
 pub use threading::{SharedOutput, ThreadPause, ThreadRecord, ThreadRuntime};
 

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -38,17 +38,17 @@
 pub(crate) mod helpers;
 
 pub(crate) mod bytecode_cost;
-pub use bytecode_cost::*;
+pub use bytecode_cost::{BytecodeCostStore, OpcodeStat};
 pub(crate) mod object_lineage;
-pub use object_lineage::*;
+pub use object_lineage::{AllocationSite, ObjectLineageStore};
 pub(crate) mod class_init_dag;
-pub use class_init_dag::*;
+pub use class_init_dag::{ClassInitDagStore, ClinitEvent};
 pub(crate) mod exception_flow;
-pub use exception_flow::*;
+pub use exception_flow::{ExceptionEvent, ExceptionFlowStore};
 pub(crate) mod dispatch_resolution;
-pub use dispatch_resolution::*;
+pub use dispatch_resolution::{DispatchResolutionStore, DispatchStat};
 pub(crate) mod native_boundary;
-pub use native_boundary::*;
+pub use native_boundary::{NativeBoundaryStore, NativeStat};
 
 // -- TelemetryStore --------------------------------------------------------------
 


### PR DESCRIPTION
🕸️ Tangle: Wildcard exports (`pub use module::*`) in workspace crates were exposing internal implementation details and creating leaky abstractions.
📐 Blueprint: Replaced all wildcard exports in `duke-classfile`, `duke-interpreter`, and `duke-telemetry` with explicit, itemized exports.
🧱 Stability: Reduced coupling, stricter public API boundaries, and less namespace pollution.
🔬 Verification: Builds successfully, strict separation enforced via explicit exports.

---
*PR created automatically by Jules for task [14846886316596841376](https://jules.google.com/task/14846886316596841376) started by @madmax983*