### PR TITLE
👺 Havoc: Annotation Stack Overflow

### DIFF
--- a/crates/duke-classfile/src/error.rs
+++ b/crates/duke-classfile/src/error.rs
@@ -36,7 +36,6 @@ use thiserror::Error;
 /// ```
 #[derive(Debug, Error)]
 pub enum Error {
-
     /// A recursive structure (like nested annotations) exceeded the maximum depth limit.
     #[error("recursion limit exceeded while parsing class file")]
     RecursionLimitExceeded,

--- a/crates/duke-classfile/src/error.rs
+++ b/crates/duke-classfile/src/error.rs
@@ -36,6 +36,11 @@ use thiserror::Error;
 /// ```
 #[derive(Debug, Error)]
 pub enum Error {
+
+    /// A recursive structure (like nested annotations) exceeded the maximum depth limit.
+    #[error("recursion limit exceeded while parsing class file")]
+    RecursionLimitExceeded,
+
     /// Expected more bytes to parse but reached the end of the file.
     #[error("unexpected end of input at offset {offset}")]
     UnexpectedEof {

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -433,7 +433,7 @@ fn decode_known_attribute(name: &str, raw: &[u8]) -> Result<AttributeData> {
         "RuntimeVisibleAnnotations" => {
             AttributeData::RuntimeVisibleAnnotations(decode_runtime_visible_annotations(&mut c)?)
         }
-        "AnnotationDefault" => AttributeData::AnnotationDefault(decode_element_value(&mut c)?),
+        "AnnotationDefault" => AttributeData::AnnotationDefault(decode_element_value(&mut c, 0)?),
         _ => AttributeData::Raw(raw.to_vec()),
     };
     Ok(data)
@@ -505,19 +505,22 @@ fn decode_runtime_visible_annotations(c: &mut Cursor<'_>) -> Result<Vec<Annotati
     let num_annotations = c.read_u16()? as usize;
     let mut annotations = Vec::with_capacity(num_annotations.min(c.remaining() / 4));
     for _ in 0..num_annotations {
-        annotations.push(decode_annotation(c)?);
+        annotations.push(decode_annotation(c, 0)?);
     }
     Ok(annotations)
 }
 
-fn decode_annotation(c: &mut Cursor<'_>) -> Result<Annotation> {
+fn decode_annotation(c: &mut Cursor<'_>, depth: u16) -> Result<Annotation> {
+    if depth > 256 {
+        return Err(Error::RecursionLimitExceeded);
+    }
     let type_index = c.read_cp_index()?;
     let num_pairs = c.read_u16()? as usize;
     let mut element_value_pairs = Vec::with_capacity(num_pairs.min(c.remaining() / 3));
     for _ in 0..num_pairs {
         element_value_pairs.push(ElementValuePair {
             element_name_index: c.read_cp_index()?,
-            value: decode_element_value(c)?,
+            value: decode_element_value(c, depth + 1)?,
         });
     }
     Ok(Annotation {
@@ -526,7 +529,10 @@ fn decode_annotation(c: &mut Cursor<'_>) -> Result<Annotation> {
     })
 }
 
-fn decode_element_value(c: &mut Cursor<'_>) -> Result<ElementValue> {
+fn decode_element_value(c: &mut Cursor<'_>, depth: u16) -> Result<ElementValue> {
+    if depth > 256 {
+        return Err(Error::RecursionLimitExceeded);
+    }
     let tag = c.read_u8()?;
     match tag {
         b'B' | b'C' | b'D' | b'F' | b'I' | b'J' | b'S' | b'Z' | b's' => {
@@ -537,12 +543,12 @@ fn decode_element_value(c: &mut Cursor<'_>) -> Result<ElementValue> {
             const_name_index: c.read_cp_index()?,
         }),
         b'c' => Ok(ElementValue::ClassInfoIndex(c.read_cp_index()?)),
-        b'@' => Ok(ElementValue::AnnotationValue(decode_annotation(c)?)),
+        b'@' => Ok(ElementValue::AnnotationValue(decode_annotation(c, depth + 1)?)),
         b'[' => {
             let num_values = c.read_u16()? as usize;
             let mut values = Vec::with_capacity(num_values.min(c.remaining() / 3));
             for _ in 0..num_values {
-                values.push(decode_element_value(c)?);
+                values.push(decode_element_value(c, depth + 1)?);
             }
             Ok(ElementValue::ArrayValue(values))
         }

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -543,7 +543,10 @@ fn decode_element_value(c: &mut Cursor<'_>, depth: u16) -> Result<ElementValue> 
             const_name_index: c.read_cp_index()?,
         }),
         b'c' => Ok(ElementValue::ClassInfoIndex(c.read_cp_index()?)),
-        b'@' => Ok(ElementValue::AnnotationValue(decode_annotation(c, depth + 1)?)),
+        b'@' => Ok(ElementValue::AnnotationValue(decode_annotation(
+            c,
+            depth + 1,
+        )?)),
         b'[' => {
             let num_values = c.read_u16()? as usize;
             let mut values = Vec::with_capacity(num_values.min(c.remaining() / 3));

--- a/crates/duke-classfile/tests/havoc_annotation_overflow.rs
+++ b/crates/duke-classfile/tests/havoc_annotation_overflow.rs
@@ -1,30 +1,25 @@
 #![allow(clippy::cast_possible_truncation)]
-use duke_classfile::{parse, Error};
+use duke_classfile::{Error, parse};
 
 #[test]
 fn test_annotation_stack_overflow() {
     let mut class_bytes = vec![
         0xCA, 0xFE, 0xBA, 0xBE, // magic
-        0x00, 0x00,             // minor
-        0x00, 0x41,             // major (65)
-        0x00, 0x04,             // constant pool count (4)
+        0x00, 0x00, // minor
+        0x00, 0x41, // major (65)
+        0x00, 0x04, // constant pool count (4)
         // 1: Utf8 "RuntimeVisibleAnnotations"
-        0x01, 0x00, 0x19, b'R', b'u', b'n', b't', b'i', b'm', b'e', b'V', b'i', b's', b'i', b'b', b'l', b'e', b'A', b'n', b'n', b'o', b't', b'a', b't', b'i', b'o', b'n', b's',
+        0x01, 0x00, 0x19, b'R', b'u', b'n', b't', b'i', b'm', b'e', b'V', b'i', b's', b'i', b'b',
+        b'l', b'e', b'A', b'n', b'n', b'o', b't', b'a', b't', b'i', b'o', b'n', b's',
         // 2: Utf8 "Lfoo;"
-        0x01, 0x00, 0x05, b'L', b'f', b'o', b'o', b';',
-        // 3: Utf8 "value"
+        0x01, 0x00, 0x05, b'L', b'f', b'o', b'o', b';', // 3: Utf8 "value"
         0x01, 0x00, 0x05, b'v', b'a', b'l', b'u', b'e',
         // Access flags, this_class, super_class
-        0x00, 0x01, 0x00, 0x02, 0x00, 0x02,
-        // Interfaces count
-        0x00, 0x00,
-        // Fields count
-        0x00, 0x00,
-        // Methods count
-        0x00, 0x00,
-        // Attributes count
-        0x00, 0x01,
-        // Attribute 1: RuntimeVisibleAnnotations
+        0x00, 0x01, 0x00, 0x02, 0x00, 0x02, // Interfaces count
+        0x00, 0x00, // Fields count
+        0x00, 0x00, // Methods count
+        0x00, 0x00, // Attributes count
+        0x00, 0x01, // Attribute 1: RuntimeVisibleAnnotations
         0x00, 0x01, // name_index = 1
         0x00, 0x00, 0x00, 0x00, // attr_length (will patch later)
         // num_annotations
@@ -43,7 +38,7 @@ fn test_annotation_stack_overflow() {
             0x00, 0x02, // type_index = 2
             0x00, 0x01, // num_element_value_pairs = 1
             0x00, 0x03, // element_name_index = 3
-            b'@',       // ElementValue tag = annotation
+            b'@', // ElementValue tag = annotation
         ]);
     }
 
@@ -61,5 +56,8 @@ fn test_annotation_stack_overflow() {
     class_bytes[attr_length_offset + 3] = u8::try_from(attr_length & 0xFF).unwrap();
 
     let result = parse(&class_bytes);
-    assert!(matches!(result, Err(Error::RecursionLimitExceeded)), "Expected RecursionLimitExceeded, got {:?}", result);
+    assert!(
+        matches!(result, Err(Error::RecursionLimitExceeded)),
+        "Expected RecursionLimitExceeded, got {result:?}"
+    );
 }

--- a/crates/duke-classfile/tests/havoc_annotation_overflow.rs
+++ b/crates/duke-classfile/tests/havoc_annotation_overflow.rs
@@ -1,0 +1,65 @@
+#![allow(clippy::cast_possible_truncation)]
+use duke_classfile::{parse, Error};
+
+#[test]
+fn test_annotation_stack_overflow() {
+    let mut class_bytes = vec![
+        0xCA, 0xFE, 0xBA, 0xBE, // magic
+        0x00, 0x00,             // minor
+        0x00, 0x41,             // major (65)
+        0x00, 0x04,             // constant pool count (4)
+        // 1: Utf8 "RuntimeVisibleAnnotations"
+        0x01, 0x00, 0x19, b'R', b'u', b'n', b't', b'i', b'm', b'e', b'V', b'i', b's', b'i', b'b', b'l', b'e', b'A', b'n', b'n', b'o', b't', b'a', b't', b'i', b'o', b'n', b's',
+        // 2: Utf8 "Lfoo;"
+        0x01, 0x00, 0x05, b'L', b'f', b'o', b'o', b';',
+        // 3: Utf8 "value"
+        0x01, 0x00, 0x05, b'v', b'a', b'l', b'u', b'e',
+        // Access flags, this_class, super_class
+        0x00, 0x01, 0x00, 0x02, 0x00, 0x02,
+        // Interfaces count
+        0x00, 0x00,
+        // Fields count
+        0x00, 0x00,
+        // Methods count
+        0x00, 0x00,
+        // Attributes count
+        0x00, 0x01,
+        // Attribute 1: RuntimeVisibleAnnotations
+        0x00, 0x01, // name_index = 1
+        0x00, 0x00, 0x00, 0x00, // attr_length (will patch later)
+        // num_annotations
+        0x00, 0x01,
+    ];
+
+    // We appended 6 bytes for the attribute: 2 for name_index, 4 for attr_length.
+    // Wait, the bytes above added name_index (2) + attr_length (4) + num_annotations (2) = 8 bytes.
+    // The attr_length field is at index: class_bytes.len() - 6
+    let attr_length_offset = class_bytes.len() - 6;
+    let attr_start = class_bytes.len() - 2; // the start of the data inside the attribute
+
+    let depth = 500_000;
+    for _ in 0..depth {
+        class_bytes.extend_from_slice(&[
+            0x00, 0x02, // type_index = 2
+            0x00, 0x01, // num_element_value_pairs = 1
+            0x00, 0x03, // element_name_index = 3
+            b'@',       // ElementValue tag = annotation
+        ]);
+    }
+
+    // Bottom of recursion
+    class_bytes.extend_from_slice(&[
+        0x00, 0x02, // type_index = 2
+        0x00, 0x00, // num_element_value_pairs = 0
+    ]);
+
+    let attr_end = class_bytes.len();
+    let attr_length = u32::try_from(attr_end - attr_start).unwrap();
+    class_bytes[attr_length_offset] = u8::try_from(attr_length >> 24).unwrap();
+    class_bytes[attr_length_offset + 1] = u8::try_from((attr_length >> 16) & 0xFF).unwrap();
+    class_bytes[attr_length_offset + 2] = u8::try_from((attr_length >> 8) & 0xFF).unwrap();
+    class_bytes[attr_length_offset + 3] = u8::try_from(attr_length & 0xFF).unwrap();
+
+    let result = parse(&class_bytes);
+    assert!(matches!(result, Err(Error::RecursionLimitExceeded)), "Expected RecursionLimitExceeded, got {:?}", result);
+}


### PR DESCRIPTION
Added a hard limit to the recursion depth when decoding annotations inside the `duke-classfile` crate. Fails gracefully with `Error::RecursionLimitExceeded` to prevent Stack Overflow attacks via malicious class files. Included a chaos fuzzing test harness.

---
*PR created automatically by Jules for task [17997564364326130042](https://jules.google.com/task/17997564364326130042) started by @madmax983*