### PR TITLE
⚒️ Forge: Refactor jar_diff.rs and fix imports

### DIFF
--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -20,11 +17,8 @@ fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
         .get(idx.0 as usize)
         .and_then(|slot| slot.as_ref())
         .and_then(|entry| {
-            if let CpEntry::Utf8(s) = entry {
-                Some(s.as_str())
-            } else {
-                None
-            }
+            let CpEntry::Utf8(s) = entry else { return None };
+            Some(s.as_str())
         })
 }
 
@@ -39,13 +33,12 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
         .constant_pool
         .get(idx.0 as usize)
         .and_then(|s| s.as_ref());
-    if let Some(CpEntry::Class { name_index }) = class_entry {
-        cp_str(cf, *name_index)
-            .unwrap_or("<invalid utf8>")
-            .to_string()
-    } else {
-        "<not a class ref>".to_string()
-    }
+    let Some(CpEntry::Class { name_index }) = class_entry else {
+        return "<not a class ref>".to_string();
+    };
+    cp_str(cf, *name_index)
+        .unwrap_or("<invalid utf8>")
+        .to_string()
 }
 
 #[cfg(feature = "nova")]
@@ -151,25 +144,26 @@ fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
 
     for entry_name in class_entries {
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            #[allow(clippy::collapsible_if)]
-            if let Ok(cf) = parse(&bytes) {
-                let class_name = resolve_class_name(&cf, cf.this_class);
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
+        let Ok(cf) = parse(&bytes) else {
+            continue;
+        };
+        let class_name = resolve_class_name(&cf, cf.this_class);
 
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{class_name}::{name_str}{desc_str}");
+        for method in &cf.methods {
+            let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+            let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+            let full_name = format!("{class_name}::{name_str}{desc_str}");
 
-                    let mut hasher = DefaultHasher::new();
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            code.code.hash(&mut hasher);
-                        }
-                    }
-                    method_hashes.insert(full_name, hasher.finish());
+            let mut hasher = DefaultHasher::new();
+            for attr in &method.attributes {
+                if let AttributeData::Code(code) = &attr.data {
+                    code.code.hash(&mut hasher);
                 }
             }
+            method_hashes.insert(full_name, hasher.finish());
         }
     }
     method_hashes


### PR DESCRIPTION
⚒️ Forge: Refactor jar_diff.rs and fix imports

🚬 Smell: 
- `duke/src/jar_diff.rs` had incorrect imports of `duke_classfile::types::{AttributeData, CpEntry, CpIndex}`.
- `load_jar_methods` had deeply nested `if let` blocks (Pyramid of Doom).
- `resolve_class_name` and `cp_str` used standard `if let` instead of `else` guards.

✨ Solution: 
- Removed `types::` from the import path as these types are exported directly from `duke_classfile`.
- Refactored `load_jar_methods` using `let Ok(...) = ... else { continue; };` guard clauses.
- Refactored `resolve_class_name` using `let Some(...) = ... else { return ... };`.
- Refactored `cp_str` to use `let CpEntry::Utf8(...) = ... else { return None; };`.

🧼 Benefit: 
- Reduces cognitive load by flattening structure.
- Fixes compilation error due to broken import.
- Strictly adheres to Rust idioms and Forge's philosophy.

🛡️ Verification: 
Tests passed. No logic changed.

---
*PR created automatically by Jules for task [5781403812895278894](https://jules.google.com/task/5781403812895278894) started by @madmax983*