### PR TITLE
🗺️ Atlas: [architectural change]

### DIFF
--- a/crates/duke-classfile/src/lib.rs
+++ b/crates/duke-classfile/src/lib.rs
@@ -22,9 +22,12 @@ pub(crate) mod constant_pool;
 pub(crate) mod error;
 pub(crate) mod parser;
 
-pub use crate::attributes::*;
-pub use crate::class::*;
-pub use crate::constant_pool::*;
+pub use crate::attributes::{
+    Annotation, AttributeData, AttributeInfo, BootstrapMethodEntry, CodeAttribute, ElementValue,
+    ElementValuePair, ExceptionTableEntry, LineNumberEntry, LocalVariableEntry,
+};
+pub use crate::class::{ClassFile, FieldInfo, MethodInfo};
+pub use crate::constant_pool::{CpEntry, CpIndex};
 pub use access_flags::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 pub use error::{Error, Result};
 pub use parser::parse;

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -26,8 +26,13 @@ pub(crate) mod registry;
 pub(crate) mod stdlib;
 pub(crate) mod threading;
 
-pub use context::*;
-pub use registry::*;
+pub use context::{ClassContext, ClassLoadSource, ExceptionEntry, FieldEntry, MethodEntry};
+pub use registry::{
+    CallbackNativeHandler, CallbackOps, ClassRegistry, HandlerKind, LambdaInfo, NativeControl,
+    NativeHandler, NativeRegistry, NativeStackFrame, NativeThreadAction, ReflectedAnnotation,
+    ReflectedAnnotationConst, ReflectedAnnotationElement, ReflectedAnnotationValue,
+    ReflectedClassInfo, ReflectedFieldInfo, ReflectedMethodInfo,
+};
 pub use stdlib::bootstrap_stdlib;
 pub use threading::{SharedOutput, ThreadPause, ThreadRecord, ThreadRuntime};
 

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -38,17 +38,17 @@
 pub(crate) mod helpers;
 
 pub(crate) mod bytecode_cost;
-pub use bytecode_cost::*;
+pub use bytecode_cost::{BytecodeCostStore, OpcodeStat};
 pub(crate) mod object_lineage;
-pub use object_lineage::*;
+pub use object_lineage::{AllocationSite, ObjectLineageStore};
 pub(crate) mod class_init_dag;
-pub use class_init_dag::*;
+pub use class_init_dag::{ClassInitDagStore, ClinitEvent};
 pub(crate) mod exception_flow;
-pub use exception_flow::*;
+pub use exception_flow::{ExceptionEvent, ExceptionFlowStore};
 pub(crate) mod dispatch_resolution;
-pub use dispatch_resolution::*;
+pub use dispatch_resolution::{DispatchResolutionStore, DispatchStat};
 pub(crate) mod native_boundary;
-pub use native_boundary::*;
+pub use native_boundary::{NativeBoundaryStore, NativeStat};
 
 // -- TelemetryStore --------------------------------------------------------------
 

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};


### PR DESCRIPTION
🕸️ Tangle: Wildcard exports (`pub use module::*`) in `duke-interpreter`, `duke-classfile`, and `duke-telemetry` were leaking internal implementation details and creating ambiguous public API boundaries. `duke` binary was also incorrectly importing from a non-existent `types` submodule.
📐 Blueprint: Replaced wildcard exports with explicit exports in workspace crate `lib.rs` files, ensuring only the necessary items are part of the public API. Fixed the import in `jar_diff.rs` to use the root crate exports.
🧱 Stability: Reduced coupling, clearer public interfaces, and prevented accidental API leakage.
🔬 Verification: Builds successfully, strict separation enforced. Full workspace test suite passed.

---
*PR created automatically by Jules for task [9570635036045619597](https://jules.google.com/task/9570635036045619597) started by @madmax983*