### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/crates/duke-classfile/tests/havoc_classfile_proptest.rs
+++ b/crates/duke-classfile/tests/havoc_classfile_proptest.rs
@@ -1,3 +1,4 @@
+//! Tests for random classfile fuzzing
 use proptest::prelude::*;
 
 proptest! {

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
🎻 Bard: [documentation update]

📖 Chapter: Fixed broken builds and missing docs in `jar_diff.rs` and tests.
🔦 Insight: `types` was removed from the API boundary of `duke-classfile`. Added missing explicit typing for `CpEntry`.
🧪 Example: N/A - Only fixes to broken tests.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [13206646584459472951](https://jules.google.com/task/13206646584459472951) started by @madmax983*