### PR TITLE
🗺️ Atlas: [architectural change] explicitly export duke-telemetry API

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -7,3 +7,6 @@
 **[Encapsulate `duke_classfile` Facade]**
 **Tangle:** The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types, and `duke-telemetry` exposed internal serialization helpers via `pub mod ser_helpers`. This creates confusing, leaky abstractions and redundant paths.
 **Blueprint:** Encapsulated both modules. In `duke_classfile`, replaced `pub mod types` with direct `pub use` statements at the crate root, eliminating the `types` namespace from the public API entirely. In `duke_telemetry`, reduced `ser_helpers` visibility to `pub(crate)`.
+**2024-05-11 - Telemetry API Leak**
+**Tangle:** The `duke-telemetry` crate utilized wildcard exports (`pub use module::*`), which can inadvertently expose private implementation details and create leaky abstractions. This resulted in a lack of explicit boundary enforcement.
+**Blueprint:** Replaced wildcard exports with explicit item exports (e.g., `pub use bytecode_cost::{BytecodeCostStore, OpcodeStat};`) for `BytecodeCostStore`, `ObjectLineageStore`, and other core telemetry structures. This enforces strict public API boundaries, ensuring higher cohesion and preventing internal leakage.

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -38,17 +38,17 @@
 pub(crate) mod helpers;
 
 pub(crate) mod bytecode_cost;
-pub use bytecode_cost::*;
+pub use bytecode_cost::{BytecodeCostStore, OpcodeStat};
 pub(crate) mod object_lineage;
-pub use object_lineage::*;
+pub use object_lineage::{AllocationSite, ObjectLineageStore};
 pub(crate) mod class_init_dag;
-pub use class_init_dag::*;
+pub use class_init_dag::{ClassInitDagStore, ClinitEvent};
 pub(crate) mod exception_flow;
-pub use exception_flow::*;
+pub use exception_flow::{ExceptionEvent, ExceptionFlowStore};
 pub(crate) mod dispatch_resolution;
-pub use dispatch_resolution::*;
+pub use dispatch_resolution::{DispatchResolutionStore, DispatchStat};
 pub(crate) mod native_boundary;
-pub use native_boundary::*;
+pub use native_boundary::{NativeBoundaryStore, NativeStat};
 
 // -- TelemetryStore --------------------------------------------------------------
 

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
🗺️ Atlas: [architectural change] explicitly export duke-telemetry API
     
🕸️ Tangle: The duke-telemetry crate utilized wildcard exports (`pub use module::*`), which can inadvertently expose private implementation details, creating leaky abstractions.
📐 Blueprint: Replaced wildcard exports with explicit item exports for `BytecodeCostStore`, `ObjectLineageStore`, and other core telemetry structures.
🧱 Stability: Enforced strict public API boundaries, ensuring higher cohesion and preventing internal leakage.
🔬 Verification: Full workspace test suite passes, `cargo clippy` and `cargo fmt` clean.

---
*PR created automatically by Jules for task [7599031495032581781](https://jules.google.com/task/7599031495032581781) started by @madmax983*