### PR TITLE
⚒️ Forge: Fix broken imports in jar_diff.rs

### DIFF
--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -3,8 +3,7 @@
 
 #[cfg(feature = "nova")]
 use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    parse, AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +17,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +37,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
⚒️ Forge: Fix broken imports in jar_diff.rs

🚮 Smell: The `duke/src/jar_diff.rs` file was attempting to import types like `AttributeData` through a private `types::` module instead of directly from the `duke_classfile` root.
✨ Solution: Corrected the `use` statements to import types directly from `duke_classfile` and updated closure types to fix compilation errors.
🧼 Benefit: Resolves compilation errors.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [2977759008604079354](https://jules.google.com/task/2977759008604079354) started by @madmax983*