### PR TITLE
🔭 Vantage: Spec for SecurityManager Compatibility

### DIFF
--- a/docs/specs/vantage-spec-security-manager.md
+++ b/docs/specs/vantage-spec-security-manager.md
@@ -1,0 +1,20 @@
+# Product Specification: SecurityManager Compatibility
+
+## 👤 User Story
+"As an Application Developer, I want my SLF4J logging framework to initialize successfully on Duke JVM, so that I can capture application telemetry and debug issues without hitting JVM panics."
+
+## ❓ So What? (Business Value)
+Implementing the security manager unlocks the first OSS library integration (`slf4j-simple`). It bridges the gap between Duke JVM and third-party real-world software, providing a path to widespread application support.
+
+## 📏 Metric Definition
+Success = The `slf4j-simple` test execution progresses beyond the current native invocation block without triggering an `Unsupported native` panic for `getSecurityManager`.
+
+## ✅ Acceptance Criteria
+- `java.lang.System.getSecurityManager()Ljava/lang/SecurityManager;` must be supported by the interpreter.
+- The `slf4j-simple` smoke test must progress past the currently blocked native method `getSecurityManager`.
+
+## 🚫 Out of Scope
+- Implementation details like Structs and Enums (Engineering's job).
+
+## 🔍 Gap Analysis
+Duke throws an `Unsupported native` error for `java.lang.System.getSecurityManager()Ljava/lang/SecurityManager;`. We need to bridge this gap to allow OSS jars like `slf4j-simple` to run.


### PR DESCRIPTION
* 👤 **User Story:** "As an Application Developer, I want my SLF4J logging framework to initialize successfully on Duke JVM, so that I can capture application telemetry and debug issues without hitting JVM panics."
* ❓ **So What? (Business Value):** Implementing the security manager unlocks the first OSS library integration (`slf4j-simple`).
* 📏 **Metric Definition:** Success = The `slf4j-simple` test execution progresses beyond the current native invocation block without triggering an `Unsupported native` panic for `getSecurityManager`.
* ✅ **Acceptance Criteria:**
  - `java.lang.System.getSecurityManager()Ljava/lang/SecurityManager;` must be supported by the interpreter.
  - The `slf4j-simple` smoke test must progress past the currently blocked native method `getSecurityManager`.
* 🚫 **Out of Scope:** Implementation details like Structs and Enums (Engineering's job).
* 🔍 **Gap Analysis:** Duke throws an `Unsupported native` error for `java.lang.System.getSecurityManager()Ljava/lang/SecurityManager;`. We need to bridge this gap to allow OSS jars like `slf4j-simple` to run.

---
*PR created automatically by Jules for task [4094109094121511215](https://jules.google.com/task/4094109094121511215) started by @madmax983*