### PR TITLE
⚒️ Forge: Refactor pyramid of doom in JAR analysis modules

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**Flattening pyramids of doom in JAR analysis modules**
+**Learning:** Using `let else { continue }` inside loops flattens deep `if let` nesting (Pyramid of Doom), drastically improving readability.
+**Action:** Always prefer guard clauses (early returns or continues) over nested `if let` blocks, especially when parsing nested attributes like `AttributeData::Code`.

--- a/duke/src/audit.rs
+++ b/duke/src/audit.rs
@@ -100,7 +100,9 @@ pub fn dump_jar_audit(jar_path: &str) {
 
     for entry_name in class_entries {
         let class_name_internal = &entry_name[..entry_name.len() - 6];
-        let Ok(bytes) = loader.find_class(class_name_internal) else { continue };
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
         let Ok(cf) = parse(&bytes) else { continue };
 
         let this_class = resolve_class_name(&cf, cf.this_class);
@@ -110,8 +112,12 @@ pub fn dump_jar_audit(jar_path: &str) {
             let full_name = format!("{this_class}::{name_str}{desc_str}");
 
             for attr in &method.attributes {
-                let AttributeData::Code(code) = &attr.data else { continue };
-                let Ok(instructions) = decode(&code.code) else { continue };
+                let AttributeData::Code(code) = &attr.data else {
+                    continue;
+                };
+                let Ok(instructions) = decode(&code.code) else {
+                    continue;
+                };
 
                 for (pc, instr) in instructions {
                     let method_ref_idx = match instr {
@@ -123,21 +129,20 @@ pub fn dump_jar_audit(jar_path: &str) {
                     };
 
                     let Some(idx) = method_ref_idx else { continue };
-                    let Some((target_class, target_method)) =
-                        resolve_method_ref(&cf, idx) else { continue };
+                    let Some((target_class, target_method)) = resolve_method_ref(&cf, idx) else {
+                        continue;
+                    };
 
-                    if target_class == "java/lang/System"
-                        && target_method == "exit"
-                    {
+                    if target_class == "java/lang/System" && target_method == "exit" {
                         findings.push(format!("  [!] System.exit() called in {full_name} @ {pc}"));
-                    } else if target_class == "java/lang/Runtime"
-                        && target_method == "exec"
-                    {
+                    } else if target_class == "java/lang/Runtime" && target_method == "exec" {
                         findings.push(format!("  [!] Runtime.exec() called in {full_name} @ {pc}"));
                     } else if target_class == "java/lang/reflect/Method"
                         && target_method == "invoke"
                     {
-                        findings.push(format!("  [!] Method.invoke() (Reflection) used in {full_name} @ {pc}"));
+                        findings.push(format!(
+                            "  [!] Method.invoke() (Reflection) used in {full_name} @ {pc}"
+                        ));
                     }
                 }
             }

--- a/duke/src/audit.rs
+++ b/duke/src/audit.rs
@@ -78,7 +78,7 @@ fn resolve_method_ref(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<(S
 }
 
 #[cfg(feature = "nova")]
-#[allow(clippy::print_stdout, clippy::collapsible_if, clippy::use_debug)]
+#[allow(clippy::print_stdout, clippy::use_debug)]
 pub fn dump_jar_audit(jar_path: &str) {
     let loader = ZipLoader::open(Path::new(jar_path)).unwrap_or_else(|e| {
         eprintln!("duke: failed to open JAR '{jar_path}': {e}");
@@ -100,48 +100,44 @@ pub fn dump_jar_audit(jar_path: &str) {
 
     for entry_name in class_entries {
         let class_name_internal = &entry_name[..entry_name.len() - 6];
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            if let Ok(cf) = parse(&bytes) {
-                let this_class = resolve_class_name(&cf, cf.this_class);
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{this_class}::{name_str}{desc_str}");
+        let Ok(bytes) = loader.find_class(class_name_internal) else { continue };
+        let Ok(cf) = parse(&bytes) else { continue };
 
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            if let Ok(instructions) = decode(&code.code) {
-                                for (pc, instr) in instructions {
-                                    let method_ref_idx = match instr {
-                                        Instruction::Invokevirtual(idx)
-                                        | Instruction::Invokespecial(idx)
-                                        | Instruction::Invokestatic(idx) => Some(idx),
-                                        Instruction::Invokeinterface { index, .. } => Some(index),
-                                        _ => None,
-                                    };
+        let this_class = resolve_class_name(&cf, cf.this_class);
+        for method in &cf.methods {
+            let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+            let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+            let full_name = format!("{this_class}::{name_str}{desc_str}");
 
-                                    if let Some(idx) = method_ref_idx {
-                                        if let Some((target_class, target_method)) =
-                                            resolve_method_ref(&cf, idx)
-                                        {
-                                            if target_class == "java/lang/System"
-                                                && target_method == "exit"
-                                            {
-                                                findings.push(format!("  [!] System.exit() called in {full_name} @ {pc}"));
-                                            } else if target_class == "java/lang/Runtime"
-                                                && target_method == "exec"
-                                            {
-                                                findings.push(format!("  [!] Runtime.exec() called in {full_name} @ {pc}"));
-                                            } else if target_class == "java/lang/reflect/Method"
-                                                && target_method == "invoke"
-                                            {
-                                                findings.push(format!("  [!] Method.invoke() (Reflection) used in {full_name} @ {pc}"));
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+            for attr in &method.attributes {
+                let AttributeData::Code(code) = &attr.data else { continue };
+                let Ok(instructions) = decode(&code.code) else { continue };
+
+                for (pc, instr) in instructions {
+                    let method_ref_idx = match instr {
+                        Instruction::Invokevirtual(idx)
+                        | Instruction::Invokespecial(idx)
+                        | Instruction::Invokestatic(idx) => Some(idx),
+                        Instruction::Invokeinterface { index, .. } => Some(index),
+                        _ => None,
+                    };
+
+                    let Some(idx) = method_ref_idx else { continue };
+                    let Some((target_class, target_method)) =
+                        resolve_method_ref(&cf, idx) else { continue };
+
+                    if target_class == "java/lang/System"
+                        && target_method == "exit"
+                    {
+                        findings.push(format!("  [!] System.exit() called in {full_name} @ {pc}"));
+                    } else if target_class == "java/lang/Runtime"
+                        && target_method == "exec"
+                    {
+                        findings.push(format!("  [!] Runtime.exec() called in {full_name} @ {pc}"));
+                    } else if target_class == "java/lang/reflect/Method"
+                        && target_method == "invoke"
+                    {
+                        findings.push(format!("  [!] Method.invoke() (Reflection) used in {full_name} @ {pc}"));
                     }
                 }
             }

--- a/duke/src/dead_code.rs
+++ b/duke/src/dead_code.rs
@@ -76,7 +76,6 @@ fn extract_method_ref(cf: &ClassFile, idx: CpIndex) -> Option<(String, String, S
 #[cfg(not(tarpaulin_include))]
 #[allow(
     unexpected_cfgs,
-    clippy::collapsible_if,
     clippy::items_after_statements
 )]
 pub fn dump_dead_code(cf: &ClassFile) {
@@ -97,29 +96,26 @@ pub fn dump_dead_code(cf: &ClassFile) {
         }
 
         for attr in &method.attributes {
-            if let AttributeData::Code(code) = &attr.data {
-                if let Ok(instructions) = decode(&code.code) {
-                    for (_, instr) in instructions {
-                        let target_idx = match instr {
-                            Instruction::Invokevirtual(idx)
-                            | Instruction::Invokespecial(idx)
-                            | Instruction::Invokestatic(idx)
-                            | Instruction::Invokeinterface { index: idx, .. } => Some(idx),
-                            _ => None,
-                        };
+            let AttributeData::Code(code) = &attr.data else { continue };
+            let Ok(instructions) = decode(&code.code) else { continue };
 
-                        if let Some(idx) = target_idx {
-                            if let Some((target_class, target_method, target_descriptor)) =
-                                extract_method_ref(cf, idx)
-                            {
-                                if target_class == class_name {
-                                    called_methods.insert(format!(
-                                        "{target_class}::{target_method}{target_descriptor}"
-                                    ));
-                                }
-                            }
-                        }
-                    }
+            for (_, instr) in instructions {
+                let target_idx = match instr {
+                    Instruction::Invokevirtual(idx)
+                    | Instruction::Invokespecial(idx)
+                    | Instruction::Invokestatic(idx)
+                    | Instruction::Invokeinterface { index: idx, .. } => Some(idx),
+                    _ => None,
+                };
+
+                let Some(idx) = target_idx else { continue };
+                let Some((target_class, target_method, target_descriptor)) =
+                    extract_method_ref(cf, idx) else { continue };
+
+                if target_class == class_name {
+                    called_methods.insert(format!(
+                        "{target_class}::{target_method}{target_descriptor}"
+                    ));
                 }
             }
         }
@@ -148,7 +144,6 @@ pub fn dump_dead_code(cf: &ClassFile) {
 #[allow(
     unexpected_cfgs,
     clippy::cast_precision_loss,
-    clippy::collapsible_if,
     clippy::case_sensitive_file_extension_comparisons,
     clippy::items_after_statements
 )]
@@ -170,52 +165,48 @@ pub fn dump_jar_dead_code(jar_path: &str) {
             continue;
         }
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            if let Ok(cf) = duke_classfile::parse(&bytes) {
-                total_classes += 1;
-                let class_name = resolve_class_name(&cf, cf.this_class);
+        let Ok(bytes) = loader.find_class(class_name_internal) else { continue };
+        let Ok(cf) = duke_classfile::parse(&bytes) else { continue };
 
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{class_name}::{name_str}{desc_str}");
+        total_classes += 1;
+        let class_name = resolve_class_name(&cf, cf.this_class);
 
-                    defined_methods.insert(full_name.clone());
+        for method in &cf.methods {
+            let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+            let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+            let full_name = format!("{class_name}::{name_str}{desc_str}");
 
-                    if name_str == "main" || name_str == "<clinit>" || name_str == "<init>" {
-                        called_methods.insert(full_name);
-                    }
+            defined_methods.insert(full_name.clone());
 
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            if let Ok(instructions) = decode(&code.code) {
-                                for (_, instr) in instructions {
-                                    let target_idx = match instr {
-                                        Instruction::Invokevirtual(idx)
-                                        | Instruction::Invokespecial(idx)
-                                        | Instruction::Invokestatic(idx)
-                                        | Instruction::Invokeinterface { index: idx, .. } => {
-                                            Some(idx)
-                                        }
-                                        _ => None,
-                                    };
+            if name_str == "main" || name_str == "<clinit>" || name_str == "<init>" {
+                called_methods.insert(full_name);
+            }
 
-                                    if let Some(idx) = target_idx {
-                                        if let Some((
-                                            target_class,
-                                            target_method,
-                                            target_descriptor,
-                                        )) = extract_method_ref(&cf, idx)
-                                        {
-                                            called_methods.insert(format!(
-                                                "{target_class}::{target_method}{target_descriptor}"
-                                            ));
-                                        }
-                                    }
-                                }
-                            }
+            for attr in &method.attributes {
+                let AttributeData::Code(code) = &attr.data else { continue };
+                let Ok(instructions) = decode(&code.code) else { continue };
+
+                for (_, instr) in instructions {
+                    let target_idx = match instr {
+                        Instruction::Invokevirtual(idx)
+                        | Instruction::Invokespecial(idx)
+                        | Instruction::Invokestatic(idx)
+                        | Instruction::Invokeinterface { index: idx, .. } => {
+                            Some(idx)
                         }
-                    }
+                        _ => None,
+                    };
+
+                    let Some(idx) = target_idx else { continue };
+                    let Some((
+                        target_class,
+                        target_method,
+                        target_descriptor,
+                    )) = extract_method_ref(&cf, idx) else { continue };
+
+                    called_methods.insert(format!(
+                        "{target_class}::{target_method}{target_descriptor}"
+                    ));
                 }
             }
         }

--- a/duke/src/dead_code.rs
+++ b/duke/src/dead_code.rs
@@ -74,10 +74,7 @@ fn extract_method_ref(cf: &ClassFile, idx: CpIndex) -> Option<(String, String, S
 
 #[cfg(feature = "nova")]
 #[cfg(not(tarpaulin_include))]
-#[allow(
-    unexpected_cfgs,
-    clippy::items_after_statements
-)]
+#[allow(unexpected_cfgs, clippy::items_after_statements)]
 pub fn dump_dead_code(cf: &ClassFile) {
     let mut defined_methods = HashSet::new();
     let mut called_methods = HashSet::new();
@@ -96,8 +93,12 @@ pub fn dump_dead_code(cf: &ClassFile) {
         }
 
         for attr in &method.attributes {
-            let AttributeData::Code(code) = &attr.data else { continue };
-            let Ok(instructions) = decode(&code.code) else { continue };
+            let AttributeData::Code(code) = &attr.data else {
+                continue;
+            };
+            let Ok(instructions) = decode(&code.code) else {
+                continue;
+            };
 
             for (_, instr) in instructions {
                 let target_idx = match instr {
@@ -110,7 +111,10 @@ pub fn dump_dead_code(cf: &ClassFile) {
 
                 let Some(idx) = target_idx else { continue };
                 let Some((target_class, target_method, target_descriptor)) =
-                    extract_method_ref(cf, idx) else { continue };
+                    extract_method_ref(cf, idx)
+                else {
+                    continue;
+                };
 
                 if target_class == class_name {
                     called_methods.insert(format!(
@@ -165,8 +169,12 @@ pub fn dump_jar_dead_code(jar_path: &str) {
             continue;
         }
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        let Ok(bytes) = loader.find_class(class_name_internal) else { continue };
-        let Ok(cf) = duke_classfile::parse(&bytes) else { continue };
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
+        let Ok(cf) = duke_classfile::parse(&bytes) else {
+            continue;
+        };
 
         total_classes += 1;
         let class_name = resolve_class_name(&cf, cf.this_class);
@@ -183,26 +191,28 @@ pub fn dump_jar_dead_code(jar_path: &str) {
             }
 
             for attr in &method.attributes {
-                let AttributeData::Code(code) = &attr.data else { continue };
-                let Ok(instructions) = decode(&code.code) else { continue };
+                let AttributeData::Code(code) = &attr.data else {
+                    continue;
+                };
+                let Ok(instructions) = decode(&code.code) else {
+                    continue;
+                };
 
                 for (_, instr) in instructions {
                     let target_idx = match instr {
                         Instruction::Invokevirtual(idx)
                         | Instruction::Invokespecial(idx)
                         | Instruction::Invokestatic(idx)
-                        | Instruction::Invokeinterface { index: idx, .. } => {
-                            Some(idx)
-                        }
+                        | Instruction::Invokeinterface { index: idx, .. } => Some(idx),
                         _ => None,
                     };
 
                     let Some(idx) = target_idx else { continue };
-                    let Some((
-                        target_class,
-                        target_method,
-                        target_descriptor,
-                    )) = extract_method_ref(&cf, idx) else { continue };
+                    let Some((target_class, target_method, target_descriptor)) =
+                        extract_method_ref(&cf, idx)
+                    else {
+                        continue;
+                    };
 
                     called_methods.insert(format!(
                         "{target_class}::{target_method}{target_descriptor}"

--- a/duke/src/inspect.rs
+++ b/duke/src/inspect.rs
@@ -3,7 +3,7 @@ use duke_classfile::{parse, AttributeData};
 use duke_loader::ZipReader;
 use std::fs;
 
-#[allow(clippy::cast_precision_loss, clippy::case_sensitive_file_extension_comparisons, clippy::collapsible_if)]
+#[allow(clippy::cast_precision_loss, clippy::case_sensitive_file_extension_comparisons)]
 /// Prints a static analysis report of a JAR file to standard output.
 ///
 /// **Why it exists:** Provides developers with a high-level overview of a JAR's
@@ -38,44 +38,43 @@ pub fn inspect_jar(path: &str) {
     names.sort_unstable(); // For deterministic parsing in tests
 
     for name in names {
-        if name.ends_with(".class") {
-            if let Ok(class_bytes) = zip.read_entry(name) {
-                if let Ok(cf) = parse(&class_bytes) {
-                    total_classes += 1;
-                    total_fields += cf.fields.len();
-                    total_methods += cf.methods.len();
+        if !name.ends_with(".class") {
+            continue;
+        }
+        let Ok(class_bytes) = zip.read_entry(name) else { continue };
+        let Ok(cf) = parse(&class_bytes) else { continue };
 
-                    let class_name = name.replace(".class", "").replace('/', ".");
+        total_classes += 1;
+        total_fields += cf.fields.len();
+        total_methods += cf.methods.len();
 
-                    for method in &cf.methods {
-                        let method_name = cf
-                            .constant_pool
-                            .get(method.name_index.0 as usize)
-                            .and_then(|e| e.as_ref())
-                            .and_then(|e| {
-                                if let duke_classfile::CpEntry::Utf8(s) = e {
-                                    Some(s)
-                                } else {
-                                    None
-                                }
-                            })
-                            .map_or("<unknown>", std::string::String::as_str);
+        let class_name = name.replace(".class", "").replace('/', ".");
 
-                        for attr in &method.attributes {
-                            if let AttributeData::Code(code) = &attr.data {
-                                if let Ok(instructions) = decode(&code.code) {
-                                    total_instructions += instructions.len();
-                                    let comp = cyclomatic_complexity(&instructions);
-                                    total_complexity += comp;
-
-                                    if comp > max_complexity {
-                                        max_complexity = comp;
-                                        max_complex_method = format!("{class_name}::{method_name}");
-                                    }
-                                }
-                            }
-                        }
+        for method in &cf.methods {
+            let method_name = cf
+                .constant_pool
+                .get(method.name_index.0 as usize)
+                .and_then(|e| e.as_ref())
+                .and_then(|e| {
+                    if let duke_classfile::CpEntry::Utf8(s) = e {
+                        Some(s)
+                    } else {
+                        None
                     }
+                })
+                .map_or("<unknown>", std::string::String::as_str);
+
+            for attr in &method.attributes {
+                let AttributeData::Code(code) = &attr.data else { continue };
+                let Ok(instructions) = decode(&code.code) else { continue };
+
+                total_instructions += instructions.len();
+                let comp = cyclomatic_complexity(&instructions);
+                total_complexity += comp;
+
+                if comp > max_complexity {
+                    max_complexity = comp;
+                    max_complex_method = format!("{class_name}::{method_name}");
                 }
             }
         }

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    AttributeData, CpEntry, CpIndex,
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
⚒️ Forge: Refactor pyramid of doom in JAR analysis modules
      
      🛁 Smell: Deeply nested 'if let' statements (pyramid of doom) in 'inspect_jar', 'dump_jar_audit', and 'dump_jar_dead_code'.
      ✨ Solution: Extracted logic using guard clauses ('let else { continue }') to flatten the nesting.
      🧼 Benefit: Significantly reduces cognitive load by bringing the main execution path to the top level of the loop.
      🛡️ Verification: Ran tests. All tests passed. No logic was changed.

---
*PR created automatically by Jules for task [12192297182880047613](https://jules.google.com/task/12192297182880047613) started by @madmax983*