### PR TITLE
🎸 Bard: [documentation update] Enforce missing_docs and fix jar_diff

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,6 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+## 2024-05-24 - [Enforce Missing Docs Globally]
+**Confusion:** Missing documentation was creeping back into the codebase despite previous efforts because `#![deny(missing_docs)]` wasn't enforced at the crate level across the workspace.
+**Clarification:** Added `#![deny(missing_docs)]` to the top of all `src/lib.rs` and `src/main.rs` files across the workspace. Also fixed some intra-doc link typos in `cfg.rs` and `basic_block.rs`, and resolved type inference errors in `jar_diff.rs` that were masking missing doc errors.

--- a/crates/duke-bytecode/src/cfg.rs
+++ b/crates/duke-bytecode/src/cfg.rs
@@ -9,7 +9,7 @@ use std::fmt::Write;
 
 use crate::Instruction;
 
-/// Generates a Mermaid control flow graph (CFG) from a list of decoded instructions.
+/// Generates a Mermaid control flow graph (CFG) from a list of decoded [`Instruction`]s.
 ///
 /// This is used for visualising the structure of a Java method. It outputs
 /// Mermaid.js compatible syntax (using `graph TD`). Each instruction becomes a node,
@@ -348,7 +348,7 @@ mod complexity_tests {
     }
 }
 
-/// Generates a Mermaid control flow graph (CFG) from a list of basic blocks.
+/// Generates a Mermaid control flow graph (CFG) from a list of [`crate::basic_block::BasicBlock`]s.
 ///
 /// This is used to visualise the structure of a Java method in terms of basic blocks.
 /// It outputs Mermaid.js compatible syntax (using `graph TD`). Each basic block becomes a node,

--- a/crates/duke-bytecode/src/lib.rs
+++ b/crates/duke-bytecode/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! `duke-bytecode` — JVM bytecode definitions, decoder, and structural verifier.
 //!
 //! # Modules

--- a/crates/duke-bytecode/src/reachability.rs
+++ b/crates/duke-bytecode/src/reachability.rs
@@ -49,7 +49,7 @@ pub fn get_successors(block: &BasicBlock) -> Vec<usize> {
     }
 }
 
-/// Finds all dead (unreachable) basic blocks starting from the given entry PC.
+/// Finds all dead (unreachable) [`BasicBlock`]s starting from the given entry PC.
 ///
 /// A basic block is considered "dead" if there is no valid control flow path from the entry
 /// point to that block. Dead code can occur from unoptimized compilation, such as blocks
@@ -119,7 +119,7 @@ pub fn find_dead_blocks(blocks: &[BasicBlock], entry_pc: usize) -> Vec<usize> {
         .collect()
 }
 
-/// Finds the shortest execution path (in terms of basic block transitions)
+/// Finds the shortest execution path (in terms of [`BasicBlock`] transitions)
 /// from the entry block to a target block.
 ///
 /// This uses Breadth-First Search (BFS) to traverse the control flow graph.

--- a/crates/duke-classfile/src/lib.rs
+++ b/crates/duke-classfile/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! `duke-classfile` — JVM `.class` file parser.
 //!
 //! Parses `.class` files conforming to JVM SE 21 (class file version 65).

--- a/crates/duke-classfile/tests/havoc_classfile_proptest.rs
+++ b/crates/duke-classfile/tests/havoc_classfile_proptest.rs
@@ -1,3 +1,7 @@
+//! Fuzzing and property tests for the `duke-classfile` parser.
+//!
+//! This module contains tests using `proptest` to ensure the parser does not panic on arbitrary or malformed input.
+
 use proptest::prelude::*;
 
 proptest! {

--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Generational mark-sweep GC for the Duke JVM (Phase 25).
 //!
 //! **Young generation** — bump-pointer allocation (Eden-style). Minor GC uses

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! `duke-interpreter` — The execution engine of the JVM.
 //!
 //! This crate orchestrates the flow of the application by interpreting decoded

--- a/crates/duke-loader/src/lib.rs
+++ b/crates/duke-loader/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! `duke-loader` — Class file loaders and container formats.
 //!
 //! # Modules

--- a/crates/duke-runtime/src/lib.rs
+++ b/crates/duke-runtime/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! `duke-runtime` — Execution state primitives for the Duke JVM.
 //!
 //! This crate provides the foundational data structures required for JVM execution:

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Duke VM Telemetry subsystem.
 //!
 //! This module provides the [`TelemetryStore`] and its constituent channels for

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    {AttributeData, CpEntry, CpIndex},
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")
@@ -50,6 +50,11 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
 
 #[cfg(feature = "nova")]
 #[cfg(not(tarpaulin_include))]
+/// Dumps a diff of the methods contained in two JAR files.
+///
+/// # Panics
+///
+/// Panics if a method's name or descriptor index cannot be resolved from the constant pool.
 #[allow(
     unexpected_cfgs,
     clippy::print_stdout,

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Main entry point for the Duke JVM executable.
 //!
 //! Handles command-line argument parsing, environment initialization,


### PR DESCRIPTION
🎸 Bard: [documentation update]

📖 Chapter: The Missing Docs Enforcer
🔦 Insight: Enforced `#![deny(missing_docs)]` globally to prevent regressions and fixed type inference bugs in `duke/src/jar_diff.rs` masking doc issues. Added missing docs for `havoc_classfile_proptest.rs`.
🧪 Example: Clean `cargo doc` output with no missing doc warnings across crates.
🖼️ Preview: All crates are fully covered with proper module docs.

---
*PR created automatically by Jules for task [10406355035886381998](https://jules.google.com/task/10406355035886381998) started by @madmax983*