### PR TITLE
⚒️ Forge: Extract receiver peek logic into helper functions

### DIFF
--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -63,6 +63,26 @@ use crate::*;
     clippy::items_after_statements,
     clippy::used_underscore_binding
 )]
+
+/// Helper to extract the receiver slot (the `this` reference) without popping it.
+fn peek_receiver_slot(frame: &Frame, arg_count: usize) -> Result<Slot> {
+    let stack_len = frame.stack_len();
+    if stack_len > arg_count {
+        frame.peek_at(stack_len - arg_count - 1)
+    } else {
+        Err(Error::StackUnderflow)
+    }
+}
+
+/// Helper to get the class name of the receiver.
+fn peek_receiver_class(frame: &Frame, heap: &duke_gc::Heap, arg_count: usize) -> Option<String> {
+    if let Ok(Slot::Reference(Some(r))) = peek_receiver_slot(frame, arg_count) {
+        heap.get(r).ok().map(|o| o.class_name.clone())
+    } else {
+        None
+    }
+}
+
 pub fn run_execution(
     state: &mut ExecutionState,
     registry: &mut ClassRegistry,
@@ -1521,17 +1541,7 @@ pub fn run_execution(
                 let virtual_start: Option<String> =
                     if matches!(instr, Instruction::Invokevirtual(_)) {
                         let arg_count = parse_arg_count(&callee_desc);
-                        let stack_len = frame.stack_len();
-                        if stack_len > arg_count {
-                            let this_pos = stack_len - arg_count - 1;
-                            if let Ok(Slot::Reference(Some(r))) = frame.peek_at(this_pos) {
-                                heap.get(r).ok().map(|o| o.class_name.clone())
-                            } else {
-                                None
-                            }
-                        } else {
-                            None
-                        }
+                        peek_receiver_class(frame, heap, arg_count)
                     } else {
                         None
                     };
@@ -1540,9 +1550,8 @@ pub fn run_execution(
                     && annotation_proxy_type(runtime_class).is_some()
                 {
                     let arg_count = parse_arg_count(&callee_desc);
-                    let stack_len = frame.stack_len();
-                    let this_pos = stack_len - arg_count - 1;
-                    let Slot::Reference(Some(receiver_ref)) = frame.peek_at(this_pos)? else {
+                    let Slot::Reference(Some(receiver_ref)) = peek_receiver_slot(frame, arg_count)?
+                    else {
                         return Err(Error::NullPointerException);
                     };
                     if let Some(result) = annotation_proxy_element_slot(
@@ -2648,23 +2657,12 @@ pub fn run_execution(
                 // Peek at `this` (sits below the args) to determine the actual
                 // runtime class without consuming the stack yet.  Each dispatch
                 // path (native / lambda / bytecode) pops what it needs itself.
-                let stack_len = frame.stack_len();
-                let actual_class = if stack_len > arg_count {
-                    let this_pos = stack_len - arg_count - 1;
-                    if let Ok(Slot::Reference(Some(r))) = frame.peek_at(this_pos) {
-                        heap.get(r).ok().map(|o| o.class_name.clone())
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-                .unwrap_or_else(|| callee_class.clone());
+                let actual_class = peek_receiver_class(frame, heap, arg_count)
+                    .unwrap_or_else(|| callee_class.clone());
 
                 if annotation_proxy_type(&actual_class).is_some() {
-                    let stack_len = frame.stack_len();
-                    let this_pos = stack_len - arg_count - 1;
-                    let Slot::Reference(Some(receiver_ref)) = frame.peek_at(this_pos)? else {
+                    let Slot::Reference(Some(receiver_ref)) = peek_receiver_slot(frame, arg_count)?
+                    else {
                         return Err(Error::NullPointerException);
                     };
                     if let Some(result) = annotation_proxy_element_slot(

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/pr_details.txt
+++ b/pr_details.txt
@@ -1,6 +1,6 @@
-Title: 🛡️ Sentry: [test coverage improvement]
-Body:
-🎯 Target: `duke_loader::ZipReader::read_entry_info`, `duke_loader::parse_central_directory`, and `duke_telemetry::ser_helpers`.
-💣 Risk: Edge cases where zip central directories have truncated entries or mismatched local header offsets, and missing telemetry map empty paths could panic or fail implicitly if refactored.
-🧪 Strategy: Added specific inline tests inside `crates/duke-loader/src/zip.rs` to reach missing branches of Zip Format errors (e.g. truncated `filename_len`, exceeded `uncompressed_size`). Added tests in `crates/duke-telemetry/src/helpers.rs` for empty map serialization. Added an empty check for `print_report`.
-🔭 Verification: `cargo test -p duke-loader` and `cargo test -p duke-telemetry`
+Title: ⚒️ Forge: Extract receiver peek logic into helper functions
+Description:
+🚮 Smell: The logic for determining the receiver object's class by peeking into the frame stack based on argument count was duplicated multiple times in the `run_execution` function. This created boilerplate, repetitive bounds-checking, and deeper nesting logic than necessary. In addition, there were some type-inference issues in `jar_diff.rs` where an `Option` was assumed but needed to be explicit.
+✨ Solution: Extracted the stack inspection and bounds checking logic into `peek_receiver_slot` and `peek_receiver_class` helper functions, and updated all duplicated instances to use them. Fixed type annotations in `jar_diff.rs`.
+🧼 Benefit: Reduces cognitive load when parsing the `run_execution` match arms by flattening the logic. Makes the interpreter execution loop less bulky and more expressive regarding its intent.
+🛡️ Verification: Tests passed. No logic changed.


### PR DESCRIPTION
🚮 Smell: The logic for determining the receiver object's class by peeking into the frame stack based on argument count was duplicated multiple times in the `run_execution` function. This created boilerplate, repetitive bounds-checking, and deeper nesting logic than necessary. In addition, there were some type-inference issues in `jar_diff.rs` where an `Option` was assumed but needed to be explicit.
✨ Solution: Extracted the stack inspection and bounds checking logic into `peek_receiver_slot` and `peek_receiver_class` helper functions, and updated all duplicated instances to use them. Fixed type annotations in `jar_diff.rs`.
🧼 Benefit: Reduces cognitive load when parsing the `run_execution` match arms by flattening the logic. Makes the interpreter execution loop less bulky and more expressive regarding its intent.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [756532981778433234](https://jules.google.com/task/756532981778433234) started by @madmax983*