### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,7 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+
+## 2024-05-14 - Inner attributes compile error
+**Confusion:** Getting compile errors when adding `#![allow(...)]` inside files that already have standard module-level comments or other attributes. Also experienced `unresolved import duke_classfile::types` and `type annotations needed` for closure arguments on `Option<T>` references.
+**Clarification:** Module-level inner attributes (`#!`) must be placed at the very top of the file, before any other items or outer attributes (`#`). Also, `AttributeData`, `CpEntry`, etc., are exported directly at the root of `duke_classfile`, not under a `types` module. When calling `.and_then(|x| x.as_ref())` on collections of `Option<T>`, the closure argument needs explicit type annotation `|x: &Option<T>|` to avoid compiler inference errors.

--- a/crates/duke-classfile/tests/havoc_classfile_proptest.rs
+++ b/crates/duke-classfile/tests/havoc_classfile_proptest.rs
@@ -1,3 +1,4 @@
+//! Fuzzing tests for the `duke-classfile` crate using `proptest`.
 use proptest::prelude::*;
 
 proptest! {

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
📖 Chapter: `duke_classfile` tests and `jar_diff` compilation.
🔦 Insight: Resolved a missing top-level module documentation attribute in `havoc_classfile_proptest.rs`. Fixed an invalid import path and a tricky compiler type inference issue regarding `.and_then` closure arguments for `Option` references. Added critical learnings to `.jules/bard.md`.
🧪 Example: Successfully passed the `RUSTDOCFLAGS="-W missing_docs"` lints which were previously failing.
🖼️ Preview: Documentation builds smoothly and codebase compiling is completely restored.

---
*PR created automatically by Jules for task [7664588183991775877](https://jules.google.com/task/7664588183991775877) started by @madmax983*