### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,7 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+
+## 2024-05-25 - [Type Annotations & Struct Imports]
+**Confusion:** `rustc` complained about missing type annotations in closures within `and_then` when working with `Option<CpEntry>`. The path `duke_classfile::types::AttributeData` was invalid because core types are exported at the crate root, not via a `types` submodule.
+**Clarification:** Added explicit type annotations to closure parameters (e.g., `|slot: &Option<CpEntry>|`) to satisfy `rustc`. Fixed imports by directly importing core types from `duke_classfile` (e.g., `use duke_classfile::{AttributeData, CpEntry, CpIndex, parse}`).

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,3 @@
-🛡️ Sentry: [test coverage improvement]
+🎻 Bard: [documentation update]
 
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+Fixed missing type annotations and unresolved imports in `jar_diff.rs` causing compile errors during documentation builds. Additionally, resolved `missing_docs` lint in `havoc_classfile_proptest.rs` by adding module-level documentation. Added a journal entry detailing the import path fix for `duke_classfile` types.

--- a/crates/duke-classfile/tests/havoc_classfile_proptest.rs
+++ b/crates/duke-classfile/tests/havoc_classfile_proptest.rs
@@ -1,3 +1,9 @@
+//! Proptest suite for the `duke-classfile` parser.
+//!
+//! This module contains property-based tests that feed random byte sequences
+//! into the classfile parser to ensure it fails gracefully without panicking
+//! or crashing, enforcing the parser's robustness against malformed input.
+
 use proptest::prelude::*;
 
 proptest! {

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,4 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
-
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
-
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
-
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+📖 Chapter: The `jar_diff` module and test documentation lints.
+🔦 Insight: `rustc` needed explicit type annotations (`&Option<CpEntry>`) when dealing with `and_then` on options to compile correctly. Additionally, `duke_classfile` types needed to be imported directly from the crate root (`use duke_classfile::{AttributeData, CpEntry, CpIndex}`) instead of a non-existent `types` submodule. Finally, resolved missing documentation lints in `havoc_classfile_proptest.rs` with proper module-level `//!` comments instead of suppressing the lint.
+🧪 Example: N/A - Fixes were type hints, imports, and docs.
+🖼️ Preview: N/A


### PR DESCRIPTION
📖 Chapter: The `jar_diff` module and test documentation lints.\n🔦 Insight: `rustc` needed explicit type annotations (`&Option<CpEntry>`) when dealing with `and_then` on options to compile correctly. Additionally, `duke_classfile` types needed to be imported directly from the crate root (`use duke_classfile::{AttributeData, CpEntry, CpIndex}`) instead of a non-existent `types` submodule. Finally, resolved missing documentation lints in `havoc_classfile_proptest.rs` with proper module-level `//!` comments instead of suppressing the lint.\n🧪 Example: N/A - Fixes were type hints, imports, and docs.\n🖼️ Preview: N/A

---
*PR created automatically by Jules for task [7574802455728420598](https://jules.google.com/task/7574802455728420598) started by @madmax983*