### PR TITLE
⚒️ Forge: refactor jar_diff formatting

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**Extracted Array/Formatting Logic**
+**Learning:** `dump_jar_diff` in `duke/src/jar_diff.rs` had duplicated loops to print added, removed, and modified items. This made the function unnecessarily long and repetitive.
+**Action:** Extract repetitive printing and formatting logic into helper functions (like `print_methods`) to condense God Functions and remove redundant code blocks.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(std::option::Option::as_ref)
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(std::option::Option::as_ref);
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")
@@ -100,37 +97,36 @@ pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
     println!();
 
     if !added.is_empty() {
-        println!("--- Top 10 Added Methods ---");
-        for m in added.iter().take(10) {
-            println!("  + {m}");
-        }
-        if added.len() > 10 {
-            println!("  ... and {} more", added.len() - 10);
-        }
-        println!();
+        print_methods("Added", &added);
     }
 
     if !removed.is_empty() {
-        println!("--- Top 10 Removed Methods ---");
-        for m in removed.iter().take(10) {
-            println!("  - {m}");
-        }
-        if removed.len() > 10 {
-            println!("  ... and {} more", removed.len() - 10);
-        }
-        println!();
+        print_methods("Removed", &removed);
     }
 
     if !modified.is_empty() {
-        println!("--- Top 10 Modified Methods ---");
-        for m in modified.iter().take(10) {
-            println!("  ~ {m}");
-        }
-        if modified.len() > 10 {
-            println!("  ... and {} more", modified.len() - 10);
-        }
-        println!();
+        print_methods("Modified", &modified);
     }
+}
+
+#[cfg(feature = "nova")]
+#[cfg(not(tarpaulin_include))]
+#[allow(unexpected_cfgs)]
+fn print_methods(label: &str, methods: &[String]) {
+    println!("--- Top 10 {label} Methods ---");
+    let prefix = match label {
+        "Added" => "+",
+        "Removed" => "-",
+        "Modified" => "~",
+        _ => " ",
+    };
+    for m in methods.iter().take(10) {
+        println!("  {prefix} {m}");
+    }
+    if methods.len() > 10 {
+        println!("  ... and {} more", methods.len() - 10);
+    }
+    println!();
 }
 
 #[cfg(feature = "nova")]


### PR DESCRIPTION
🚷 Smell: `dump_jar_diff` in `duke/src/jar_diff.rs` had duplicated loops and inline formatting logic to print added, removed, and modified methods, making it a repetitive 'God Function'.
✨ Solution: Extracted the repetitive printing logic into a strictly typed `print_methods` helper function. Fixed ambiguous type inferences and missing imports found during exploration.
🧼 Benefit: Reduces cognitive load and code duplication by DRYing up the array printing logic, flattening the primary function.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [4294513106375950451](https://jules.google.com/task/4294513106375950451) started by @madmax983*