### PR TITLE
👺 Havoc: Add fuzzing tests for binary parsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "duke-classfile",
  "flate2",
  "proptest",
+ "tempfile",
  "thiserror",
 ]
 

--- a/crates/duke-bytecode/tests/havoc_bytecode_fuzz.rs
+++ b/crates/duke-bytecode/tests/havoc_bytecode_fuzz.rs
@@ -1,0 +1,12 @@
+#![allow(missing_docs)]
+
+use duke_bytecode::decode;
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(5000))]
+    #[test]
+    fn fuzz_bytecode_decode(data in prop::collection::vec(any::<u8>(), 0..1024)) {
+        let _ = decode(&data);
+    }
+}

--- a/crates/duke-classfile/tests/havoc_classfile_fuzz.rs
+++ b/crates/duke-classfile/tests/havoc_classfile_fuzz.rs
@@ -1,0 +1,12 @@
+#![allow(missing_docs)]
+
+use duke_classfile::parse;
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(5000))]
+    #[test]
+    fn fuzz_classfile_parse(data in prop::collection::vec(any::<u8>(), 0..1024)) {
+        let _ = parse(&data);
+    }
+}

--- a/crates/duke-loader/Cargo.toml
+++ b/crates/duke-loader/Cargo.toml
@@ -11,6 +11,7 @@ flate2.workspace = true
 [dev-dependencies]
 duke-classfile = { path = "../duke-classfile" }
 proptest.workspace = true
+tempfile = "3.27.0"
 
 [lints]
 workspace = true

--- a/crates/duke-loader/tests/havoc_jimage_fuzz.rs
+++ b/crates/duke-loader/tests/havoc_jimage_fuzz.rs
@@ -1,0 +1,14 @@
+#![allow(missing_docs)]
+
+use duke_loader::JImageReader;
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1000))]
+    #[test]
+    fn fuzz_jimage_parse_header(data in any::<Vec<u8>>()) {
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(temp.path(), &data).unwrap();
+        let _ = JImageReader::open(temp.path());
+    }
+}

--- a/crates/duke-loader/tests/havoc_zip_reader_fuzz.rs
+++ b/crates/duke-loader/tests/havoc_zip_reader_fuzz.rs
@@ -1,0 +1,12 @@
+#![allow(missing_docs)]
+
+use duke_loader::ZipReader;
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1000))]
+    #[test]
+    fn fuzz_zip_reader_from_bytes(data in any::<Vec<u8>>()) {
+        let _ = ZipReader::from_bytes(data);
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** Providing malformed, highly compressed, or unexpected arbitrary byte inputs to `parse` and `decode` functions.
📉 **The Stack Trace:** Found no panics yet, but created tests that systematically search for panics when given random bytes in `duke-classfile` and `duke-loader` (JImage/Zip).
🧪 **Reproduction:** Run `cargo test --test havoc_zip_reader_fuzz` or `cargo test --test havoc_classfile_proptest`.
😈 **Comment:** We don't assume the happy path. These fuzzers will continually hunt for your missing bounds checks and unhandled Result errors.

---
*PR created automatically by Jules for task [2487679586611889358](https://jules.google.com/task/2487679586611889358) started by @madmax983*