### PR TITLE
Implement Thread.getContextClassLoader and setContextClassLoader

### DIFF
--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -11522,6 +11522,7 @@ const THREAD_TARGET_SLOT: usize = 0;
 const THREAD_ID_SLOT: usize = 1;
 const THREAD_INTERRUPTED_SLOT: usize = 2;
 const THREAD_HOST_KEY_SLOT: usize = 3;
+const THREAD_CONTEXT_CLASS_LOADER_SLOT: usize = 4;
 
 static NEXT_THREAD_HOST_KEY: AtomicI32 = AtomicI32::new(1);
 
@@ -11603,12 +11604,13 @@ pub(crate) fn native_thread_current_thread(
     _out: &mut dyn Write,
     _control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
-    let thread_ref = heap.allocate("java/lang/Thread".to_string(), 4);
+    let thread_ref = heap.allocate("java/lang/Thread".to_string(), 5);
     let thread = heap.get_mut(thread_ref)?;
     thread.fields[THREAD_TARGET_SLOT] = Slot::Reference(None);
     thread.fields[THREAD_ID_SLOT] = Slot::Int(-1);
     thread.fields[THREAD_INTERRUPTED_SLOT] = Slot::Int(i32::from(current_host_thread_is_interrupted()));
     thread.fields[THREAD_HOST_KEY_SLOT] = Slot::Int(java_host_key_for_current_host().unwrap_or(-1));
+    thread.fields[THREAD_CONTEXT_CLASS_LOADER_SLOT] = Slot::Reference(None);
     Ok(Some(Slot::Reference(Some(thread_ref))))
 }
 
@@ -11624,6 +11626,7 @@ pub(crate) fn native_thread_init(
     this.fields[THREAD_ID_SLOT] = Slot::Int(-1);
     this.fields[THREAD_INTERRUPTED_SLOT] = Slot::Int(0);
     this.fields[THREAD_HOST_KEY_SLOT] = Slot::Int(-1);
+    this.fields[THREAD_CONTEXT_CLASS_LOADER_SLOT] = Slot::Reference(None);
     Ok(None)
 }
 
@@ -11640,6 +11643,7 @@ pub(crate) fn native_thread_init_runnable(
     this.fields[THREAD_ID_SLOT] = Slot::Int(-1);
     this.fields[THREAD_INTERRUPTED_SLOT] = Slot::Int(0);
     this.fields[THREAD_HOST_KEY_SLOT] = Slot::Int(-1);
+    this.fields[THREAD_CONTEXT_CLASS_LOADER_SLOT] = Slot::Reference(None);
     Ok(None)
 }
 
@@ -13338,6 +13342,34 @@ pub(crate) fn native_thread_interrupted(
     Ok(Some(Slot::Int(i32::from(
         take_current_host_thread_interrupted(),
     ))))
+}
+
+pub(crate) fn native_thread_get_context_class_loader(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let thread_ref = extract_ref_arg(args, 0)?;
+    let loader = heap
+        .get(thread_ref)?
+        .fields
+        .get(THREAD_CONTEXT_CLASS_LOADER_SLOT)
+        .cloned()
+        .unwrap_or(Slot::Reference(None));
+    Ok(Some(loader))
+}
+
+pub(crate) fn native_thread_set_context_class_loader(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let thread_ref = extract_ref_arg(args, 0)?;
+    let loader = extract_slot_arg(args, 1);
+    heap.write_field(thread_ref, THREAD_CONTEXT_CLASS_LOADER_SLOT, loader)?;
+    Ok(None)
 }
 
 pub(crate) fn native_count_down_latch_init(

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -13355,7 +13355,7 @@ pub(crate) fn native_thread_get_context_class_loader(
         .get(thread_ref)?
         .fields
         .get(THREAD_CONTEXT_CLASS_LOADER_SLOT)
-        .cloned()
+        .copied()
         .unwrap_or(Slot::Reference(None));
     Ok(Some(loader))
 }

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -4157,9 +4157,14 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
                 descriptor: "I".to_string(),
                 is_static: false,
             },
+            FieldEntry {
+                name: "contextClassLoader".to_string(),
+                descriptor: "Ljava/lang/ClassLoader;".to_string(),
+                is_static: false,
+            },
         ],
         static_fields: Vec::new(),
-        instance_field_count: 4,
+        instance_field_count: 5,
         interfaces: Vec::new(),
         bootstrap_methods: Vec::new(),
         load_source: ClassLoadSource::Synthetic,
@@ -4209,9 +4214,15 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
     );
     registry.natives_mut().register(
         "java/lang/Thread",
+        "getContextClassLoader",
+        "()Ljava/lang/ClassLoader;",
+        native_thread_get_context_class_loader,
+    );
+    registry.natives_mut().register(
+        "java/lang/Thread",
         "setContextClassLoader",
         "(Ljava/lang/ClassLoader;)V",
-        native_void_noop,
+        native_thread_set_context_class_loader,
     );
 
     let stack_trace_element_ctx = ClassContext {

--- a/crates/duke-interpreter/tests/oss_jar_smoke.rs
+++ b/crates/duke-interpreter/tests/oss_jar_smoke.rs
@@ -279,13 +279,13 @@ fn slf4j_simple_smoke_surfaces_next_missing_capability_explicitly() {
     );
     assert_eq!(
         rendered,
-        "Unsupported native: java/lang/Thread.getContextClassLoader()Ljava/lang/ClassLoader;",
+        "Unsupported native: java/lang/ClassLoader.getSystemResourceAsStream(Ljava/lang/String;)Ljava/io/InputStream;",
         "expected the next SLF4J blocker to stay explicit"
     );
 }
 
 #[test]
-#[ignore = "Blocked on Thread.getContextClassLoader after issue #695."]
+#[ignore = "Blocked on ClassLoader.getSystemResourceAsStream after Thread.getContextClassLoader was fixed."]
 fn slf4j_simple_smoke_runs_real_jar_bytecode() {
     let smoke = run_slf4j_simple_smoke();
 


### PR DESCRIPTION
## Summary
This PR implements support for Java's `Thread.getContextClassLoader()` and `Thread.setContextClassLoader()` methods, which are essential for proper class loading behavior in Java applications.

## Key Changes
- Added `THREAD_CONTEXT_CLASS_LOADER_SLOT` constant to track the context class loader field in Thread objects
- Increased Thread instance field count from 4 to 5 to accommodate the new field
- Implemented `native_thread_get_context_class_loader()` to retrieve a thread's context class loader
- Implemented `native_thread_set_context_class_loader()` to set a thread's context class loader
- Added `contextClassLoader` field definition to the Thread class in stdlib
- Initialized the context class loader field to `null` in all Thread constructors (`native_thread_current_thread`, `native_thread_init`, `native_thread_init_runnable`)
- Registered both native methods in the class registry with proper signatures
- Updated test expectations to reflect that `Thread.getContextClassLoader` is now supported

## Implementation Details
- The context class loader is stored as a reference field (nullable) in the Thread object
- Both getter and setter follow the existing patterns for native method implementation
- The field is properly initialized to `null` in all code paths that create Thread instances
- This unblocks SLF4J smoke tests, which now progress to the next missing capability

https://claude.ai/code/session_01Jb4T9rq33WbiyvYFTEStAk