### PR TITLE
🔭 Vantage: Spec for java.lang.String.equalsIgnoreCase

### DIFF
--- a/docs/vantage-spec-string-equalsignorecase.md
+++ b/docs/vantage-spec-string-equalsignorecase.md
@@ -1,0 +1,27 @@
+# 🔭 Vantage: Spec for `java.lang.String.equalsIgnoreCase` Implementation
+
+## 👤 User Story
+"As a Java Developer running frameworks on Duke, I want the VM to natively support `java.lang.String.equalsIgnoreCase`, so that utility methods in core libraries and frameworks (like SLF4J) can compare strings case-insensitively without crashing the runtime due to missing natives."
+
+## ❓ The "So What?"
+What business problem does this solve?
+Currently, Duke is blocked from advancing in real-world application compatibility (specifically the `slf4j-simple` oss-jar smoke test) because it throws an `Unsupported native` error when it encounters `java/lang/String.equalsIgnoreCase(Ljava/lang/String;)Z`. This is a foundational method in the Java standard library used extensively for configuration parsing, HTTP header comparison, and general string manipulation. Without it, even basic logging setups fail to initialize. Implementing this native bridge is a direct, required step to unblock the `slf4j` integration milestone and move Duke closer to running real-world enterprise code.
+
+## 📈 Metric Definition
+Success = The `tests/fixtures/oss-jars/slf4j-simple-2.0.13/oss_jar_smoke.rs` tests (or equivalent) progress past the `java/lang/String.equalsIgnoreCase` exception and either pass or fail on a subsequent, different missing capability. Additionally, explicit unit tests for `equalsIgnoreCase` handle both matching and non-matching case-insensitive pairs, as well as `null` arguments, correctly.
+
+## 🔍 Gap Analysis
+- **Current State:** The native method `java/lang/String.equalsIgnoreCase(Ljava/lang/String;)Z` is not implemented in Duke's `native.rs` or `stdlib.rs`.
+- **Market/Standard Lib:** The OpenJDK standard library relies on this native method (or intrinsics) to perform fast, case-insensitive string comparisons.
+- **The Gap:** We need to implement the Rust equivalent of case-insensitive string comparison and bridge it to the JVM's `String.equalsIgnoreCase` signature, properly handling null references and Java's internal string representation (often UTF-16 or Latin-1).
+
+## ✅ Acceptance Criteria
+- Must implement the native method `java/lang/String.equalsIgnoreCase(Ljava/lang/String;)Z`.
+- Must return `true` if the strings are identical in length and their characters match regardless of case.
+- Must return `false` if the strings differ in length or character content when ignoring case.
+- Must return `false` if the argument passed is `null`.
+- Must successfully unblock the SLF4J smoke test from its current failure state.
+
+## 🚫 Out of Scope
+- Locale-dependent collation or complex Unicode casing rules beyond standard ASCII/basic Unicode case folding required by the Java specification for `equalsIgnoreCase`.
+- Full intrinsification/JIT compilation of the method; a standard native call bridge is sufficient.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
👤 **User Story:** As a Java Developer, I want the VM to natively support java.lang.String.equalsIgnoreCase, so that frameworks like SLF4J can parse configurations correctly.
✅ **Acceptance Criteria:**
Must implement the native method.
Must return true for matching case-insensitive strings.
🚫 **Out of Scope:** Locale-dependent collation.

---
*PR created automatically by Jules for task [10157900112559597396](https://jules.google.com/task/10157900112559597396) started by @madmax983*