### PR TITLE
🎸 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,10 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+## 2024-05-24 - [Nested Imports vs Re-exports]
+**Confusion:** The compiler threw `[E0432]: unresolved import` for nested imports `use duke_classfile::{..., types::{...}}` even though the items exist.
+**Clarification:** The `types` submodule is private and its items (`AttributeData`, `CpEntry`, `CpIndex`) are re-exported at the crate root. Code trying to access them through `types::` or nested braces `use duke_classfile::{..., {CpEntry}}` will fail to compile. They must be imported directly from the root `use duke_classfile::{AttributeData, CpEntry};`.
+
+## 2024-05-24 - [Type Inference in Closures]
+**Confusion:** The compiler threw `[E0282]: type annotations needed` on `.and_then(|slot| slot.as_ref())` when chained onto a `get` from a `Vec<Option<CpEntry>>`.
+**Clarification:** When chaining `Option` methods where the inner type is complex (like an enum), the compiler may fail to infer the reference type automatically. Explicitly typing the closure argument, e.g., `.and_then(|slot: &Option<CpEntry>| slot.as_ref())`, resolves the ambiguity.

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,6 @@
-🛡️ Sentry: [test coverage improvement]
+🎸 Bard: [documentation update]
 
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+📖 Chapter: The `ConstantPool` and nested exports module.
+🔦 Insight: Fixed compiler errors by explicitly specifying types directly from the `duke_classfile` root instead of relying on the removed `types` submodule or invalid nested brace syntax in `duke/src/main.rs` and `duke/src/jar_diff.rs`.
+🧪 Example: N/A, internal refactoring fix to ensure correct test compilation.
+🖼️ Preview: N/A

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -37,9 +37,7 @@ use duke_bytecode::{
     build_basic_blocks, decode, generate_basic_block_cfg, generate_mermaid_call_graph,
     generate_mermaid_cfg,
 };
-use duke_classfile::{
-    ClassFile, MethodAccessFlags, parse, {AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, ClassFile, CpEntry, CpIndex, MethodAccessFlags, parse};
 use duke_gc::Heap;
 use duke_interpreter::{
     ClassRegistry, bootstrap_stdlib, build_class_context, execute_class_to_completion,
@@ -1553,9 +1551,7 @@ mod tests {
 
     #[test]
     fn test_generate_native_stubs_code_empty() {
-        use duke_classfile::{
-            ClassAccessFlags, {ClassFile, CpEntry, CpIndex},
-        };
+        use duke_classfile::{ClassAccessFlags, ClassFile, CpEntry, CpIndex};
 
         let cf = ClassFile {
             minor_version: 0,
@@ -1583,7 +1579,7 @@ mod tests {
     #[test]
     fn test_generate_native_stubs_code() {
         use duke_classfile::{
-            ClassAccessFlags, MethodAccessFlags, {ClassFile, CpEntry, CpIndex, MethodInfo},
+            ClassAccessFlags, ClassFile, CpEntry, CpIndex, MethodAccessFlags, MethodInfo,
         };
 
         let cf = ClassFile {

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,4 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
-
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
-
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
-
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+📖 Chapter: The `ConstantPool` and nested exports module.
+🔦 Insight: Fixed compiler errors by explicitly specifying types directly from the `duke_classfile` root instead of relying on the removed `types` submodule or invalid nested brace syntax in `duke/src/main.rs` and `duke/src/jar_diff.rs`.
+🧪 Example: N/A, internal refactoring fix to ensure correct test compilation.
+🖼️ Preview: N/A


### PR DESCRIPTION
📖 Chapter: The \`ConstantPool\` and nested exports module.
🔦 Insight: Fixed compiler errors by explicitly specifying types directly from the \`duke_classfile\` root instead of relying on the removed \`types\` submodule or invalid nested brace syntax in \`duke/src/main.rs\` and \`duke/src/jar_diff.rs\`.
🧪 Example: N/A, internal refactoring fix to ensure correct test compilation.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [7709642449500399074](https://jules.google.com/task/7709642449500399074) started by @madmax983*