### PR TITLE
⚒️ Forge: Refactor jar_diff.rs nesting and loops

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,6 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+**Refactoring `jar_diff.rs` for Clarity**
+**Learning:** Manual loops and nested if/let mappings reduce readability where standard explicit iterators and guard clauses dramatically flatten the nesting.
+**Action:** Use guard clauses like `let Ok(_) = ... else { continue; }` within loops and explicit iterator mapping to collect set differences in `jar_diff.rs`.

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,6 @@
-🛡️ Sentry: [test coverage improvement]
+⚒️ Forge: Refactor jar_diff.rs nesting and loops
 
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+🚮 Smell: Deeply nested blocks and manual iterating loops in `duke/src/jar_diff.rs`.
+✨ Solution: Extracted inner code with early returns via guard clauses (`else { continue; }`) and replaced manual loops with flat iterator pipelines (`map().collect()`).
+🧼 Benefit: Significantly reduced nesting depth and improved cognitive readability.
+🛡️ Verification: Cargo clippy, tests, and formatting checks passed perfectly.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -16,16 +13,11 @@ use std::path::Path;
 #[cfg(not(tarpaulin_include))]
 #[allow(unexpected_cfgs)]
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
-    cf.constant_pool
-        .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
-        .and_then(|entry| {
-            if let CpEntry::Utf8(s) = entry {
-                Some(s.as_str())
-            } else {
-                None
-            }
-        })
+    let entry = cf.constant_pool.get(idx.0 as usize)?.as_ref()?;
+    let CpEntry::Utf8(s) = entry else {
+        return None;
+    };
+    Some(s.as_str())
 }
 
 #[cfg(feature = "nova")]
@@ -35,17 +27,16 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     if idx.0 == 0 {
         return "<none>".to_string();
     }
-    let class_entry = cf
+    let Some(CpEntry::Class { name_index }) = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
-    if let Some(CpEntry::Class { name_index }) = class_entry {
-        cp_str(cf, *name_index)
-            .unwrap_or("<invalid utf8>")
-            .to_string()
-    } else {
-        "<not a class ref>".to_string()
-    }
+        .and_then(|s: &Option<CpEntry>| s.as_ref())
+    else {
+        return "<not a class ref>".to_string();
+    };
+    cp_str(cf, *name_index)
+        .unwrap_or("<invalid utf8>")
+        .to_string()
 }
 
 #[cfg(feature = "nova")]
@@ -63,18 +54,10 @@ pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
     let keys1: HashSet<_> = map1.keys().collect();
     let keys2: HashSet<_> = map2.keys().collect();
 
-    let mut added = Vec::new();
-    let mut removed = Vec::new();
+    let mut added: Vec<String> = keys2.difference(&keys1).map(|k| (*k).clone()).collect();
+    let mut removed: Vec<String> = keys1.difference(&keys2).map(|k| (*k).clone()).collect();
     let mut modified = Vec::new();
     let mut unchanged = 0;
-
-    for k in keys2.difference(&keys1) {
-        added.push((*k).clone());
-    }
-
-    for k in keys1.difference(&keys2) {
-        removed.push((*k).clone());
-    }
 
     for k in keys1.intersection(&keys2) {
         if map1.get(*k) == map2.get(*k) {
@@ -151,25 +134,27 @@ fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
 
     for entry_name in class_entries {
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            #[allow(clippy::collapsible_if)]
-            if let Ok(cf) = parse(&bytes) {
-                let class_name = resolve_class_name(&cf, cf.this_class);
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
+        let Ok(cf) = parse(&bytes) else {
+            continue;
+        };
 
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{class_name}::{name_str}{desc_str}");
+        let class_name = resolve_class_name(&cf, cf.this_class);
 
-                    let mut hasher = DefaultHasher::new();
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            code.code.hash(&mut hasher);
-                        }
-                    }
-                    method_hashes.insert(full_name, hasher.finish());
+        for method in &cf.methods {
+            let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+            let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+            let full_name = format!("{class_name}::{name_str}{desc_str}");
+
+            let mut hasher = DefaultHasher::new();
+            for attr in &method.attributes {
+                if let AttributeData::Code(code) = &attr.data {
+                    code.code.hash(&mut hasher);
                 }
             }
+            method_hashes.insert(full_name, hasher.finish());
         }
     }
     method_hashes

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,6 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
+⚒️ Forge: Refactor jar_diff.rs nesting and loops
 
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
-
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
-
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+🚮 Smell: Deeply nested blocks and manual iterating loops in `duke/src/jar_diff.rs`.
+✨ Solution: Extracted inner code with early returns via guard clauses (`else { continue; }`) and replaced manual loops with flat iterator pipelines (`map().collect()`).
+🧼 Benefit: Significantly reduced nesting depth and improved cognitive readability.
+🛡️ Verification: Cargo clippy, tests, and formatting checks passed perfectly.


### PR DESCRIPTION
⚒️ Forge: Refactor jar_diff.rs nesting and loops

🚮 Smell: Deeply nested blocks and manual iterating loops in `duke/src/jar_diff.rs`.
✨ Solution: Extracted inner code with early returns via guard clauses (`else { continue; }`) and replaced manual loops with flat iterator pipelines (`map().collect()`).
🧼 Benefit: Significantly reduced nesting depth and improved cognitive readability.
🛡️ Verification: Cargo clippy, tests, and formatting checks passed perfectly.

---
*PR created automatically by Jules for task [8417609305064438347](https://jules.google.com/task/8417609305064438347) started by @madmax983*