### PR TITLE
🗺️ Atlas: [architectural change] Encapsulated duke_classfile API

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -7,3 +7,6 @@
 **[Encapsulate `duke_classfile` Facade]**
 **Tangle:** The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types, and `duke-telemetry` exposed internal serialization helpers via `pub mod ser_helpers`. This creates confusing, leaky abstractions and redundant paths.
 **Blueprint:** Encapsulated both modules. In `duke_classfile`, replaced `pub mod types` with direct `pub use` statements at the crate root, eliminating the `types` namespace from the public API entirely. In `duke_telemetry`, reduced `ser_helpers` visibility to `pub(crate)`.
+**[Fix duke_classfile Encapsulation Compilation Error]**
+**Tangle:** The previous fix to encapsulate `duke_classfile::types` completely removed the `types` module, but `duke/src/jar_diff.rs` still referred to it and experienced closure type inference errors (`[E0282]`) because it chained `.and_then` directly.
+**Blueprint:** Updated `duke/src/jar_diff.rs` to import `AttributeData`, `CpEntry`, and `CpIndex` directly from `duke_classfile` root. Also added explicit type annotations (`&Option<CpEntry>`) to the `and_then` closures to satisfy the type checker.

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,1 @@
-🛡️ Sentry: [test coverage improvement]
-
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+🗺️ Atlas: [architectural change] Encapsulated duke_classfile API

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,6 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
+🗺️ Atlas: [architectural change] Encapsulated `duke_classfile` API
 
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
-
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
-
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+🕸️ Tangle: The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types. This created a confusing, leaky abstraction and redundant paths, breaking code in `duke` binary when encapsulation boundaries were correctly applied.
+📐 Blueprint: Fixed the imports in `duke/src/jar_diff.rs` to consume `AttributeData`, `CpEntry`, and `CpIndex` directly from the crate root instead of the hidden `types` module. Also fixed missing explicit closure types.
+🧱 Stability: Strict separation enforced, eliminating the leaky `types` namespace from the public API entirely.
+🔬 Verification: Builds successfully, all workspace tests pass, and strict visibility boundaries are enforced.


### PR DESCRIPTION
🗺️ Atlas: [architectural change] Encapsulated `duke_classfile` API

🕸️ Tangle: The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types. This created a confusing, leaky abstraction and redundant paths, breaking code in `duke` binary when encapsulation boundaries were correctly applied.
📐 Blueprint: Fixed the imports in `duke/src/jar_diff.rs` to consume `AttributeData`, `CpEntry`, and `CpIndex` directly from the crate root instead of the hidden `types` module. Also fixed missing explicit closure types.
🧱 Stability: Strict separation enforced, eliminating the leaky `types` namespace from the public API entirely.
🔬 Verification: Builds successfully, all workspace tests pass, and strict visibility boundaries are enforced.

---
*PR created automatically by Jules for task [17888604819006090980](https://jules.google.com/task/17888604819006090980) started by @madmax983*