### PR TITLE
🗺️ Atlas: [architectural change] fix leaky abstraction in jar_diff imports

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -7,3 +7,6 @@
 **[Encapsulate `duke_classfile` Facade]**
 **Tangle:** The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types, and `duke-telemetry` exposed internal serialization helpers via `pub mod ser_helpers`. This creates confusing, leaky abstractions and redundant paths.
 **Blueprint:** Encapsulated both modules. In `duke_classfile`, replaced `pub mod types` with direct `pub use` statements at the crate root, eliminating the `types` namespace from the public API entirely. In `duke_telemetry`, reduced `ser_helpers` visibility to `pub(crate)`.
+**The Orphanage**
+**Tangle:** The file `duke/src/jar_diff.rs` imported `types` from `duke_classfile`, but that module wasn't public.
+**Blueprint:** Removed `types::` module nesting and imported `AttributeData, CpEntry, CpIndex` directly from `duke_classfile` crate root.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,9 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
+🗺️ Atlas: [architectural change]
 
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
+🕸️ Tangle: The file `duke/src/jar_diff.rs` incorrectly reached into a private module (`duke_classfile::types`) to import `AttributeData`, `CpEntry`, and `CpIndex`, causing a compilation error. This was a leaky abstraction violating the structural boundary of the `duke_classfile` crate.
 
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
+📐 Blueprint: Removed the nested `types::` module import. Refactored `duke/src/jar_diff.rs` to import the types directly from the `duke_classfile` crate root where they are properly exported. Also provided explicit type annotations (`&Option<CpEntry>`) to closures in `and_then` chains to resolve type inference errors resulting from the import change.
 
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+🧱 Stability: Enforced strict architectural boundaries between `duke` and `duke_classfile`. The dependency graph is restored and clean.
+
+🔬 Verification: The codebase compiles successfully. Ran `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace`, and `cargo fmt --all` ensuring no regressions.


### PR DESCRIPTION
🗺️ Atlas: [architectural change]

🕸️ Tangle: The file `duke/src/jar_diff.rs` incorrectly reached into a private module (`duke_classfile::types`) to import `AttributeData`, `CpEntry`, and `CpIndex`, causing a compilation error. This was a leaky abstraction violating the structural boundary of the `duke_classfile` crate.

📐 Blueprint: Removed the nested `types::` module import. Refactored `duke/src/jar_diff.rs` to import the types directly from the `duke_classfile` crate root where they are properly exported. Also provided explicit type annotations (`&Option<CpEntry>`) to closures in `and_then` chains to resolve type inference errors resulting from the import change.

🧱 Stability: Enforced strict architectural boundaries between `duke` and `duke_classfile`. The dependency graph is restored and clean.

🔬 Verification: The codebase compiles successfully. Ran `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace`, and `cargo fmt --all` ensuring no regressions.

---
*PR created automatically by Jules for task [5494216229445180701](https://jules.google.com/task/5494216229445180701) started by @madmax983*