### PR TITLE
⚡ Bolt: [performance improvement] eliminate unnecessary `.collect::<Vec<_>>()` on JAR entry iterations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,6 @@
 **Trust the Iterator: .collect() is Optimized**
 **Learning:** In Rust, `.collect::<Vec<_>>()` called on an `ExactSizeIterator` (which `slice.iter().map()` implements) already knows the exact number of elements. The standard library heavily optimizes this via the `TrustedLen` trait to allocate the precise capacity upfront and completely bypass bounds checks during insertion.
 **Action:** Do not manually replace `.collect::<Vec<_>>()` with `Vec::with_capacity` and a `for` loop, as it re-introduces bounds checks on every push, making the "optimization" unidiomatic and a micro-regression.
+**Zero-cost ZipReader iteration**
+**Learning:** Using `.collect::<Vec<String>>()` or `.collect::<Vec<&str>>()` when iterating over `reader.entry_names()` just to filter and loop creates unnecessary allocations for every string and the backing vector.
+**Action:** When working with `.entry_names()`, perform the `.filter` inside the `for` loop body using `if !` checks to achieve zero-cost abstraction. If file extension string matching triggers lints, use `#[allow(clippy::case_sensitive_file_extension_comparisons)]`.

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,1 @@
-🛡️ Sentry: [test coverage improvement]
-
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+⚡ Bolt: [performance improvement] eliminate unnecessary `.collect::<Vec<_>>()` on JAR entry iterations

--- a/duke/src/audit.rs
+++ b/duke/src/audit.rs
@@ -86,19 +86,15 @@ pub fn dump_jar_audit(jar_path: &str) {
     });
 
     let reader = loader.reader();
-    let class_entries: Vec<String> = reader
-        .entry_names()
-        .filter(|name| {
-            std::path::Path::new(name)
-                .extension()
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("class"))
-        })
-        .map(std::string::ToString::to_string)
-        .collect();
-
     let mut findings = Vec::new();
 
-    for entry_name in class_entries {
+    for entry_name in reader.entry_names() {
+        if !std::path::Path::new(&entry_name)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("class"))
+        {
+            continue;
+        }
         let class_name_internal = &entry_name[..entry_name.len() - 6];
         if let Ok(bytes) = loader.find_class(class_name_internal) {
             if let Ok(cf) = parse(&bytes) {

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -143,13 +140,11 @@ fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
 
     let mut method_hashes = HashMap::new();
     let reader = loader.reader();
-    let class_entries: Vec<String> = reader
-        .entry_names()
-        .filter(|name| name.ends_with(".class"))
-        .map(std::string::ToString::to_string)
-        .collect();
-
-    for entry_name in class_entries {
+    for entry_name in reader.entry_names() {
+        #[allow(clippy::case_sensitive_file_extension_comparisons)]
+        if !entry_name.ends_with(".class") {
+            continue;
+        }
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
         if let Ok(bytes) = loader.find_class(class_name_internal) {
             #[allow(clippy::collapsible_if)]

--- a/duke/src/jar_search.rs
+++ b/duke/src/jar_search.rs
@@ -41,20 +41,16 @@ pub fn dump_jar_search(jar_path: &str, query: &str) {
     });
 
     let reader = loader.reader();
-    let class_entries: Vec<String> = reader
-        .entry_names()
-        .filter(|name| {
-            std::path::Path::new(name)
-                .extension()
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("class"))
-        })
-        .map(std::string::ToString::to_string)
-        .collect();
-
     let query_lower = query.to_lowercase();
     let mut found_any = false;
 
-    for entry_name in class_entries {
+    for entry_name in reader.entry_names() {
+        if !std::path::Path::new(&entry_name)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("class"))
+        {
+            continue;
+        }
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
         if let Ok(bytes) = loader.find_class(class_name_internal) {
             if let Ok(cf) = parse(&bytes) {

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,4 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
-
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
-
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
-
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+💡 What: Removed `.collect::<Vec<String>>()` and instead directly iterate over `ZipReader::entry_names()`.
+🎯 Why: Collecting into a vector requires allocating memory for every string and the vector itself, which is unnecessary when we only need to iterate over them and check file extensions.
+📊 Impact: Reduces heap allocations significantly when processing large JAR files.
+🔬 Measurement: Run the CLI `duke jar diff`, `duke jar search`, `duke jar audit`, etc., on large JAR files to see reduced memory usage.


### PR DESCRIPTION
💡 What: Removed `.collect::<Vec<String>>()` and instead directly iterate over `ZipReader::entry_names()`.
🎯 Why: Collecting into a vector requires allocating memory for every string and the vector itself, which is unnecessary when we only need to iterate over them and check file extensions.
📊 Impact: Reduces heap allocations significantly when processing large JAR files.
🔬 Measurement: Run the CLI `duke jar diff`, `duke jar search`, `duke jar audit`, etc., on large JAR files to see reduced memory usage.

---
*PR created automatically by Jules for task [9508705671174659898](https://jules.google.com/task/9508705671174659898) started by @madmax983*