### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ mutants.out.old/
 .claude/
 profile.json.gz
 output_html_dir/
+*.profraw

--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -47,3 +47,6 @@
 ## 2024-05-24 - Testing ReentrantReadWriteLock Native Operations
 **Learning:** Found several native functions implementing `ReentrantReadWriteLock` and `PriorityQueue` operations missing test coverage in `duke-interpreter`. Adding dummy tests correctly executes these logic branches without needing fully mocked multi-threading scenarios.
 **Action:** Add inline unit tests using a mocked heap and manually setting up the `obj_ref` payload.
+## 2024-05-24 - Testing Telemetry Map Serialization and Printing
+**Learning:** Found uncovered branches in the failure scenarios for `Serialize` map components (like when `serialize_map` returns an error on `end()`) inside `helpers.rs`. Also missing coverage on the display strings generated for `print_dispatch_resolution`, `print_native_boundary`, etc, when testing populated objects.
+**Action:** Adding isolated mock `FailingSerializer` that fails on `.end()` execution ensures error path validation for custom wrappers, and initializing mock fields inside telemetry objects allows verification of specific text strings generated during output.

--- a/crates/duke-telemetry/src/helpers.rs
+++ b/crates/duke-telemetry/src/helpers.rs
@@ -435,4 +435,172 @@ mod tests {
         let res = super::ser_helpers::sorted_set(&set, FailingSerializer);
         assert!(res.is_err());
     }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn test_keyed_map_error_end() {
+        struct FailingEndSerializer;
+        impl serde::Serializer for FailingEndSerializer {
+            type Ok = ();
+            type Error = serde::de::value::Error;
+            type SerializeSeq = serde::ser::Impossible<(), Self::Error>;
+            type SerializeTuple = serde::ser::Impossible<(), Self::Error>;
+            type SerializeTupleStruct = serde::ser::Impossible<(), Self::Error>;
+            type SerializeTupleVariant = serde::ser::Impossible<(), Self::Error>;
+            type SerializeMap = FailingEndMapSerializer;
+            type SerializeStruct = serde::ser::Impossible<(), Self::Error>;
+            type SerializeStructVariant = serde::ser::Impossible<(), Self::Error>;
+            fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_some<T: ?Sized + Serialize>(
+                self,
+                _v: &T,
+            ) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_unit_variant(
+                self,
+                _n: &'static str,
+                _vi: u32,
+                _va: &'static str,
+            ) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_newtype_struct<T: ?Sized + Serialize>(
+                self,
+                _name: &'static str,
+                _v: &T,
+            ) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_newtype_variant<T: ?Sized + Serialize>(
+                self,
+                _n: &'static str,
+                _vi: u32,
+                _va: &'static str,
+                _v: &T,
+            ) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_tuple_struct(
+                self,
+                _name: &'static str,
+                _len: usize,
+            ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_tuple_variant(
+                self,
+                _n: &'static str,
+                _vi: u32,
+                _va: &'static str,
+                _len: usize,
+            ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+                Ok(FailingEndMapSerializer)
+            }
+            fn serialize_struct(
+                self,
+                _name: &'static str,
+                _len: usize,
+            ) -> Result<Self::SerializeStruct, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_struct_variant(
+                self,
+                _n: &'static str,
+                _vi: u32,
+                _va: &'static str,
+                _len: usize,
+            ) -> Result<Self::SerializeStructVariant, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+        }
+
+        struct FailingEndMapSerializer;
+        impl serde::ser::SerializeMap for FailingEndMapSerializer {
+            type Ok = ();
+            type Error = serde::de::value::Error;
+            fn serialize_key<T: ?Sized + Serialize>(
+                &mut self,
+                _key: &T,
+            ) -> Result<(), Self::Error> {
+                Ok(())
+            }
+            fn serialize_value<T: ?Sized + Serialize>(
+                &mut self,
+                _value: &T,
+            ) -> Result<(), Self::Error> {
+                Ok(())
+            }
+            fn end(self) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("end err"))
+            }
+        }
+
+        let mut map = HashMap::new();
+        map.insert(
+            ("java/lang/String".to_string(), "intern".to_string(), 42),
+            Dummy { val: 1 },
+        );
+        let res = super::ser_helpers::site3(&map, FailingEndSerializer);
+        assert!(res.is_err());
+    }
 }

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -598,4 +598,66 @@ mod tests {
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("java/lang/Exception"));
     }
+
+    #[test]
+    fn test_print_dispatch_resolution_populated() {
+        let mut store = crate::TelemetryStore::default();
+        store
+            .dispatch_resolution
+            .record("Foo", 42, "TargetClass", true);
+        let mut buf = Vec::new();
+        store.print_dispatch_resolution(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("Foo"));
+        assert!(s.contains("42"));
+        assert!(s.contains("calls=1"));
+    }
+
+    #[test]
+    fn test_print_native_boundary_populated() {
+        let mut store = crate::TelemetryStore::default();
+        store
+            .native_boundary
+            .record_call("java/lang/String", "intern", 100, true);
+        let mut buf = Vec::new();
+        store.print_native_boundary(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("java/lang/String.intern"));
+    }
+
+    #[test]
+    fn test_markdown_object_lineage_populated() {
+        let mut store = crate::TelemetryStore::default();
+        store
+            .object_lineage
+            .record("java/lang/String", "Foo", 10, "bar");
+        let mut out = String::new();
+        store.markdown_object_lineage(&mut out);
+        assert!(out.contains("java/lang/String"));
+        assert!(out.contains("Foo"));
+        assert!(out.contains("10"));
+    }
+
+    #[test]
+    fn test_markdown_dispatch_resolution_populated() {
+        let mut store = crate::TelemetryStore::default();
+        store
+            .dispatch_resolution
+            .record("Foo", 42, "TargetClass", true);
+        let mut out = String::new();
+        store.markdown_dispatch_resolution(&mut out);
+        assert!(out.contains("Foo"));
+        assert!(out.contains("42"));
+    }
+
+    #[test]
+    fn test_markdown_native_boundary_populated() {
+        let mut store = crate::TelemetryStore::default();
+        store
+            .native_boundary
+            .record_call("java/lang/String", "intern", 100, true);
+        let mut out = String::new();
+        store.markdown_native_boundary(&mut out);
+        assert!(out.contains("java/lang/String.intern"));
+    }
 }

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,6 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
+🛡️ Sentry: [test coverage improvement]
 
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
-
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
-
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+🎯 Target: `TelemetryStore` print/markdown helpers and `helpers.rs` map serializers.
+💣 Risk: Missing test coverage for output formats and error propagation could hide bugs during telemetry generation.
+🧪 Strategy: Added unit tests directly invoking formatting functions with populated dummy data and edge-case serialization failures.
+🔬 Verification: Run `cargo test -p duke-telemetry`


### PR DESCRIPTION
🎯 Target: `TelemetryStore` print/markdown helpers and `helpers.rs` map serializers.
💣 Risk: Missing test coverage for output formats and error propagation could hide bugs during telemetry generation.
🧪 Strategy: Added unit tests directly invoking formatting functions with populated dummy data and edge-case serialization failures.
🔬 Verification: Run `cargo test -p duke-telemetry`

---
*PR created automatically by Jules for task [10729889112513369308](https://jules.google.com/task/10729889112513369308) started by @madmax983*