### PR TITLE
⚒️ Forge: [Fix uncompilable code in jar_diff.rs]

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,10 @@
-🛡️ Sentry: [test coverage improvement]
+⚒️ Forge: [Fix uncompilable code in jar_diff.rs]
 
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+Trash:
+The previous changes apparently introduced an unresolved import `duke_classfile::types` which didn't exist, and left missing closure types for `.and_then` which the compiler complained about (`type annotations needed`).
+
+Solution:
+Removed the `types` module path prefix, using `AttributeData, CpEntry, CpIndex` directly since they're exported at the root of `duke_classfile`. Added explicit `&Option<CpEntry>` types to the closure arguments in `.and_then` to satisfy the Rust compiler's type inference.
+
+Verification:
+Ran `cargo clippy --all-targets --all-features` and `cargo test --all-features` which passed.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/pr_desc.txt
+++ b/pr_desc.txt
@@ -1,0 +1,4 @@
+🚮 Smell: The previous changes apparently introduced an unresolved import `duke_classfile::types` which didn't exist, and left missing closure types for `.and_then` which the compiler complained about (`type annotations needed`).
+✨ Solution: Removed the `types` module path prefix, using `AttributeData, CpEntry, CpIndex` directly since they're exported at the root of `duke_classfile`. Added explicit `&Option<CpEntry>` types to the closure arguments in `.and_then` to satisfy the Rust compiler's type inference.
+🧼 Benefit: Code compiles again and the `jar_diff` feature works.
+🛡️ Verification: Tests passed. No logic changed.


### PR DESCRIPTION
🚮 Smell: The previous changes apparently introduced an unresolved import `duke_classfile::types` which didn't exist, and left missing closure types for `.and_then` which the compiler complained about (`type annotations needed`).
✨ Solution: Removed the `types` module path prefix, using `AttributeData, CpEntry, CpIndex` directly since they're exported at the root of `duke_classfile`. Added explicit `&Option<CpEntry>` types to the closure arguments in `.and_then` to satisfy the Rust compiler's type inference.
🧼 Benefit: Code compiles again and the `jar_diff` feature works.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [2477660881872216968](https://jules.google.com/task/2477660881872216968) started by @madmax983*