### PR TITLE
🗺️ Atlas: [architectural change] Fix duke imports and type inference

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,5 @@
-🛡️ Sentry: [test coverage improvement]
+🗺️ Atlas: [architectural change] Fix duke imports and type inference
 
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+Fixed unresolved imports by removing `types::` module prefix in `jar_diff.rs`, as `AttributeData`, `CpEntry`, and `CpIndex` are exported from the root of `duke-classfile`.
+
+Added explicit type annotations to closures to fix `E0282` compiler errors.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,7 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
+🕸️ Tangle: The module `types` inside `duke_classfile` is missing (or types are re-exported at the root instead of under a `types` submodule). The `duke` bin was incorrectly trying to import from `duke_classfile::types`. Additionally, the closures inside `jar_diff.rs` had ambiguous types that caused compiler errors (`E0282`).
 
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
+📐 Blueprint: Removed the `types::` prefix from the imports in `duke/src/jar_diff.rs`, importing `AttributeData`, `CpEntry`, and `CpIndex` directly from `duke_classfile`. Also added explicit type annotations (`&Option<CpEntry>`) to the closures to fix `E0282`.
 
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
+🧱 Stability: Fixed build errors allowing the `nova` feature and the root binary to compile successfully. Reduced coupling by not relying on a potentially non-existent submodule.
 
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+🔬 Verification: Ran `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt --all`. All tests pass and warnings are resolved.


### PR DESCRIPTION
🕸️ Tangle: The module `types` inside `duke_classfile` is missing (or types are re-exported at the root instead of under a `types` submodule). The `duke` bin was incorrectly trying to import from `duke_classfile::types`. Additionally, the closures inside `jar_diff.rs` had ambiguous types that caused compiler errors (`E0282`).

📐 Blueprint: Removed the `types::` prefix from the imports in `duke/src/jar_diff.rs`, importing `AttributeData`, `CpEntry`, and `CpIndex` directly from `duke_classfile`. Also added explicit type annotations (`&Option<CpEntry>`) to the closures to fix `E0282`.

🧱 Stability: Fixed build errors allowing the `nova` feature and the root binary to compile successfully. Reduced coupling by not relying on a potentially non-existent submodule.

🔬 Verification: Ran `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt --all`. All tests pass and warnings are resolved.

---
*PR created automatically by Jules for task [4211749422010637916](https://jules.google.com/task/4211749422010637916) started by @madmax983*