### PR TITLE
🔭 Vantage: Spec for Thread Context ClassLoader

### DIFF
--- a/docs/vantage-spec-thread-context-classloader.md
+++ b/docs/vantage-spec-thread-context-classloader.md
@@ -1,0 +1,25 @@
+# 🔭 Vantage: Spec for `java.lang.Thread` Context ClassLoader
+
+## 👤 User Story
+"As a Java Framework Developer running my code on Duke, I want the VM to support `Thread.getContextClassLoader()` and `setContextClassLoader()`, so that my frameworks (like slf4j or Spring) can dynamically locate resources and isolate dependencies on a per-thread basis."
+
+## ❓ The "So What?"
+What business problem does this solve?
+It is the current explicit blocker for running the `slf4j-simple` real-world JAR compatibility test. Modern Java architectures heavily rely on Thread Context ClassLoaders (TCCL) for dependency injection and resource loading, especially when the framework classes are loaded by a parent classloader but need to load application classes. Without TCCL support, Duke is limited to basic standalone applications. Supporting it unlocks compatibility with the broader Java ecosystem.
+
+## 📈 Metric Definition
+Success = The `slf4j-simple` smoke test progresses past `System.getSecurityManager()` without crashing on `java/lang/Thread.getContextClassLoader()Ljava/lang/ClassLoader;` returning null inappropriately or failing to execute.
+
+## 🔍 Gap Analysis
+- **Current State:** Duke has partial internal implementation for threads. The internal memory slot `THREAD_CONTEXT_CLASS_LOADER_SLOT` exists, and the `native_thread_get_context_class_loader` and `native_thread_set_context_class_loader` functions are stubbed in `native.rs` and registered in `stdlib.rs`. However, it appears there might be missing logic for inheriting the context classloader during thread creation or returning appropriate default values, which is causing compatibility issues.
+- **Market/Standard Lib:** The standard JVM `java.lang.Thread` automatically inherits the context classloader of the thread that created it. If not set, it defaults to the system classloader.
+- **The Gap:** We need to ensure that the native bridge logic correctly inherits the context classloader from the parent thread at thread creation (`native_thread_init` and related functions), and correctly exposes this to Java code.
+
+## ✅ Acceptance Criteria
+- Must fully implement native bridges for `getContextClassLoader` and `setContextClassLoader`.
+- Must inherit the context classloader from the parent thread at the time of thread creation.
+- Must fall back to the system classloader if no context classloader has been explicitly set or inherited.
+
+## 🚫 Out of Scope
+- Implementing full custom `ClassLoader` mechanics or `URLClassLoader` behavior. This spec is strictly about exposing and managing the context classloader reference on the `Thread` object.
+- Network-based class loading.

--- a/plan.md
+++ b/plan.md
@@ -1,20 +1,11 @@
-1. **Optimize String concatenation in `native_string_concat`**
-   - The function currently uses `format!("{s1}{s2}")` to concatenate two strings, which allocates a new string buffer inside `format!`, formats the arguments, and returns it.
-   - We can optimize this by pre-allocating a `String` with the exact required capacity and appending the strings:
-     ```rust
-     let mut combined = String::with_capacity(s1.len() + s2.len());
-     combined.push_str(&s1);
-     combined.push_str(&s2);
-     let r = heap.allocate_string(combined);
-     ```
-   - This eliminates the intermediate allocation and parsing overhead of `format!`, which is a common hotspot in interpreters.
-   - Add `// ⚡ Bolt: Eliminate intermediate format! allocation` comment.
-   - Ensure the tests pass.
-1. Refactor `print_report` methods in `duke-telemetry/src/lib.rs` to handle empty states gracefully (Reduces noise from empty reports).
-   - Before: Outputs headers and empty tables for empty components.
-   - After: Outputs a concise message stating no events were recorded.
-2. Complete pre commit steps to make sure proper testing, verifications, reviews and reflections are done.
-3. Submit the change using a descriptive title.
-1. **Optimize Vector Allocations in Execution (Vec::with_capacity)**: Pre-allocate vectors in `crates/duke-interpreter/src/execution.rs` for `Multianewarray` `dims` array and lambda args `impl_args` to avoid unnecessary dynamic heap reallocations.
-2. Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.
-3. **Submit the PR**: Present PR titled '⚡ Bolt: Optimize Vector Allocations in Execution & Native' detailing 💡 What, 🎯 Why, 📊 Impact, and 🔭 Measurement. I will use `run_in_bash_session` to execute `git commit` with the requested PR details.
+1. **Analyze:** We need to create a Product Spec as Vantage for `java.lang.Thread.getContextClassLoader()` and `setContextClassLoader()`. We see from `MEMORY.md` and `README.md` that it's a blocker for running `slf4j-simple`.
+2. **Define Spec:** I will formulate a spec under `docs/vantage-spec-thread-context-classloader.md`.
+3. **Draft the content:** It must contain:
+   - `👤 **User Story:** "As a Java Framework Developer...`
+   - `❓ **The "So What?" (Business Value):**`
+   - `📈 **Metric Definition:**`
+   - `🔍 **Gap Analysis:**`
+   - `✅ **Acceptance Criteria:**`
+   - `🚫 **Out of Scope:**`
+4. Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.
+5. Create a PR (commit) titled '🔭 Vantage: Spec for Thread Context ClassLoader' containing the spec details.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,22 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
+🔭 Vantage: Spec for Thread Context ClassLoader
 
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
+👤 User Story:
+As a Java Framework Developer running my code on Duke, I want the VM to support Thread.getContextClassLoader(), so that my frameworks (like slf4j or Spring) can dynamically locate resources and isolate dependencies on a per-thread basis.
 
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
+❓ The "So What?"
+What business problem does this solve?
+It's a blocker for running slf4j-simple. Modern Java architectures heavily rely on Thread Context ClassLoaders for dependency injection and resource loading. Without it, Duke is limited to basic standalone apps.
 
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+📈 Metric Definition
+Success = slf4j-simple progresses past System.getSecurityManager() without crashing on Thread.getContextClassLoader() returning null or throwing an exception improperly.
+
+🔍 Gap Analysis
+Duke lacks the complete native bridge logic to properly expose and mutate the Thread Context ClassLoader. The fields exist internally (THREAD_CONTEXT_CLASS_LOADER_SLOT) but aren't fully integrated at thread creation for inheritance or fully exposed at the Java boundary for standard library usage across the VM lifecycle.
+
+✅ Acceptance Criteria
+Must implement native bridges for getContextClassLoader and setContextClassLoader.
+Must inherit the context classloader from the parent thread at thread creation.
+Must default to the system classloader if not explicitly set.
+
+🚫 Out of Scope
+Implementing full custom ClassLoaders. This is only about exposing the context classloader reference on the Thread.


### PR DESCRIPTION
🔭 Vantage: Spec for Thread Context ClassLoader

👤 User Story:
As a Java Framework Developer running my code on Duke, I want the VM to support Thread.getContextClassLoader(), so that my frameworks (like slf4j or Spring) can dynamically locate resources and isolate dependencies on a per-thread basis.

❓ The "So What?"
What business problem does this solve?
It's a blocker for running slf4j-simple. Modern Java architectures heavily rely on Thread Context ClassLoaders for dependency injection and resource loading. Without it, Duke is limited to basic standalone apps.

📈 Metric Definition
Success = slf4j-simple progresses past System.getSecurityManager() without crashing on Thread.getContextClassLoader() returning null or throwing an exception improperly.

🔍 Gap Analysis
Duke lacks the complete native bridge logic to properly expose and mutate the Thread Context ClassLoader. The fields exist internally (THREAD_CONTEXT_CLASS_LOADER_SLOT) but aren't fully integrated at thread creation for inheritance or fully exposed at the Java boundary for standard library usage across the VM lifecycle.

✅ Acceptance Criteria
Must implement native bridges for getContextClassLoader and setContextClassLoader.
Must inherit the context classloader from the parent thread at thread creation.
Must default to the system classloader if not explicitly set.

🚫 Out of Scope
Implementing full custom ClassLoaders. This is only about exposing the context classloader reference on the Thread.

---
*PR created automatically by Jules for task [643452125212059686](https://jules.google.com/task/643452125212059686) started by @madmax983*