### PR TITLE
⚒️ Forge: Extract method instruction decoding helper

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,6 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+**Extract Duplicate Parsing Block**
+**Learning:** `dump_cfg` and `dump_bbcfg` in `duke/src/main.rs` shared an identical 35-line block for reading a file, parsing a class, finding a method, extracting its code attribute, and decoding its instructions.
+**Action:** Extract the shared parsing, finding, and decoding logic into a helper function `extract_method_instructions` to DRY up the caller functions and centralize error handling.

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,3 @@
-🛡️ Sentry: [test coverage improvement]
+⚒️ Forge: Extract method instruction decoding helper
 
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+Extracted duplicate method instruction decoding logic into a helper function `extract_method_instructions` to DRY up `dump_cfg` and `dump_bbcfg`.

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -981,7 +981,10 @@ fn dump_html(path: &str, output_path: Option<&str>) {
     }
 }
 
-fn dump_cfg(path: &str, method_name: &str) {
+fn extract_method_instructions(
+    path: &str,
+    method_name: &str,
+) -> Vec<(usize, duke_bytecode::Instruction)> {
     let bytes = std::fs::read(path).unwrap_or_else(|e| {
         eprintln!("duke: cannot read '{path}': {e}");
         process::exit(1);
@@ -1011,51 +1014,22 @@ fn dump_cfg(path: &str, method_name: &str) {
                 eprintln!("duke: decode error: {e}");
                 process::exit(1);
             });
-            println!("{}", generate_mermaid_cfg(&instructions));
-            return;
+            return instructions;
         }
     }
     eprintln!("duke: method '{method_name}' has no code attribute");
     process::exit(1);
 }
 
+fn dump_cfg(path: &str, method_name: &str) {
+    let instructions = extract_method_instructions(path, method_name);
+    println!("{}", generate_mermaid_cfg(&instructions));
+}
+
 fn dump_bbcfg(path: &str, method_name: &str) {
-    let bytes = std::fs::read(path).unwrap_or_else(|e| {
-        eprintln!("duke: cannot read '{path}': {e}");
-        process::exit(1);
-    });
-    let cf = parse(&bytes).unwrap_or_else(|e| {
-        eprintln!("duke: parse error: {e}");
-        process::exit(1);
-    });
-
-    let target = cf
-        .methods
-        .iter()
-        .find(|m| {
-            let Some(Some(CpEntry::Utf8(s))) = cf.constant_pool.get(m.name_index.0 as usize) else {
-                return false;
-            };
-            s.as_str() == method_name
-        })
-        .unwrap_or_else(|| {
-            eprintln!("duke: method '{method_name}' not found");
-            process::exit(1);
-        });
-
-    for attr in &target.attributes {
-        if let AttributeData::Code(code) = &attr.data {
-            let instructions = decode(&code.code).unwrap_or_else(|e| {
-                eprintln!("duke: decode error: {e}");
-                process::exit(1);
-            });
-            let blocks = build_basic_blocks(&instructions);
-            println!("{}", generate_basic_block_cfg(&blocks));
-            return;
-        }
-    }
-    eprintln!("duke: method '{method_name}' has no code attribute");
-    process::exit(1);
+    let instructions = extract_method_instructions(path, method_name);
+    let blocks = build_basic_blocks(&instructions);
+    println!("{}", generate_basic_block_cfg(&blocks));
 }
 
 fn dump_cg(path: &str) {

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,6 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
+⚒️ Forge: Extract method instruction decoding helper
 
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
-
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
-
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+🚮 Smell: The `dump_cfg` and `dump_bbcfg` functions in `duke/src/main.rs` shared a duplicated 35-line block for reading files, parsing classes, finding methods, extracting code attributes, and decoding instructions.
+✨ Solution: Extracted the duplicated logic into a new `extract_method_instructions` helper function.
+🧼 Benefit: DRYs up the code, massively flattens both caller functions, and centralizes error handling for method resolution.
+🛡️ Verification: Tests passed. No logic changed.


### PR DESCRIPTION
⚒️ Forge: Extract method instruction decoding helper

🚮 Smell: The `dump_cfg` and `dump_bbcfg` functions in `duke/src/main.rs` shared a duplicated 35-line block for reading files, parsing classes, finding methods, extracting code attributes, and decoding instructions.
✨ Solution: Extracted the duplicated logic into a new `extract_method_instructions` helper function.
🧼 Benefit: DRYs up the code, massively flattens both caller functions, and centralizes error handling for method resolution.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [16168550059156129915](https://jules.google.com/task/16168550059156129915) started by @madmax983*