### PR TITLE
🗺️ Atlas: [fix leaky abstractions and broken imports]

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -7,3 +7,6 @@
 **[Encapsulate `duke_classfile` Facade]**
 **Tangle:** The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types, and `duke-telemetry` exposed internal serialization helpers via `pub mod ser_helpers`. This creates confusing, leaky abstractions and redundant paths.
 **Blueprint:** Encapsulated both modules. In `duke_classfile`, replaced `pub mod types` with direct `pub use` statements at the crate root, eliminating the `types` namespace from the public API entirely. In `duke_telemetry`, reduced `ser_helpers` visibility to `pub(crate)`.
+**[Fix Leaky Abstractions and Broken Imports]**
+**Tangle:** A previous encapsulation of `duke_classfile` removed the intermediate `types` module, but the `jar_diff` module in `duke` was still importing from `duke_classfile::types::{...}`. This broke compilation.
+**Blueprint:** Fixed the broken imports in `duke/src/jar_diff.rs` by importing directly from the `duke_classfile` root facade.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,9 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
+🗺️ Atlas: [fix leaky abstractions and broken imports]
 
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
+🕸️ Tangle: A previous encapsulation of `duke_classfile` removed the intermediate `types` module, but the `jar_diff` module in `duke` was still importing from `duke_classfile::types::{...}`. This broke compilation.
 
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
+📐 Blueprint: Fixed the broken imports in `duke/src/jar_diff.rs` by importing directly from the `duke_classfile` root facade.
 
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+🧱 Stability: Restored compilation and correctly enforced the `duke_classfile` root facade abstraction, decoupling internal types from external usage.
+
+🔬 Verification: `cargo test` and `cargo clippy` run successfully, strict separation is now enforced.


### PR DESCRIPTION
🕸️ Tangle: A previous encapsulation of `duke_classfile` removed the intermediate `types` module, but the `jar_diff` module in `duke` was still importing from `duke_classfile::types::{...}`. This broke compilation.

📐 Blueprint: Fixed the broken imports in `duke/src/jar_diff.rs` by importing directly from the `duke_classfile` root facade.

🧱 Stability: Restored compilation and correctly enforced the `duke_classfile` root facade abstraction, decoupling internal types from external usage.

🔬 Verification: `cargo test` and `cargo clippy` run successfully, strict separation is now enforced.

---
*PR created automatically by Jules for task [7619513371493067541](https://jules.google.com/task/7619513371493067541) started by @madmax983*