### PR TITLE
⚒️ Forge: Refactor jar_diff.rs and fix compiler errors

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,9 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+**[Refactoring jar_diff.rs]
+**Learning:** The  script was using deeply nested closures () instead of simpler early returns via  operator. It was also accessing nested struct properties via tuple destructuring that were cleaner via guards.
+**Action:** Replaced closures with  where possible, reducing nesting. Also replaced explicit type import errors for  due to lack of a  block by importing types directly from the root namespace.
+**[Refactoring jar_diff.rs]**
+**Learning:** The `jar_diff.rs` script had compilation errors because it tried to import from a nonexistent `types` submodule. In addition, it was using deeply nested closures (`and_then`) instead of simpler early returns via `?` operator, and had large blocks of unflattened iterator code.
+**Action:** Replaced closures with `?` and guard clauses `else { return; }` where possible, reducing nesting. Fixed compiler errors by correcting the imports.

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,6 @@
-🛡️ Sentry: [test coverage improvement]
+⚒️ Forge: Refactor jar_diff.rs and fix compiler errors
 
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+- Flatten nested closures into guard clauses and `?` operator.
+- Fix broken `types` import path.
+- Replace manual for loops with iterator chains `difference().copied().cloned().collect()`.
+- Extract duplicate print logic into helper method `print_method_list`.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -16,16 +13,12 @@ use std::path::Path;
 #[cfg(not(tarpaulin_include))]
 #[allow(unexpected_cfgs)]
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
-    cf.constant_pool
-        .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
-        .and_then(|entry| {
-            if let CpEntry::Utf8(s) = entry {
-                Some(s.as_str())
-            } else {
-                None
-            }
-        })
+    let entry = cf.constant_pool.get(idx.0 as usize)?.as_ref()?;
+    if let CpEntry::Utf8(s) = entry {
+        Some(s.as_str())
+    } else {
+        None
+    }
 }
 
 #[cfg(feature = "nova")]
@@ -38,14 +31,13 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
-    if let Some(CpEntry::Class { name_index }) = class_entry {
-        cp_str(cf, *name_index)
-            .unwrap_or("<invalid utf8>")
-            .to_string()
-    } else {
-        "<not a class ref>".to_string()
-    }
+        .and_then(Option::as_ref);
+    let Some(CpEntry::Class { name_index }) = class_entry else {
+        return "<not a class ref>".to_string();
+    };
+    cp_str(cf, *name_index)
+        .unwrap_or("<invalid utf8>")
+        .to_string()
 }
 
 #[cfg(feature = "nova")]
@@ -63,18 +55,11 @@ pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
     let keys1: HashSet<_> = map1.keys().collect();
     let keys2: HashSet<_> = map2.keys().collect();
 
-    let mut added = Vec::new();
-    let mut removed = Vec::new();
+    let mut added: Vec<String> = keys2.difference(&keys1).copied().cloned().collect();
+    let mut removed: Vec<String> = keys1.difference(&keys2).copied().cloned().collect();
+
     let mut modified = Vec::new();
     let mut unchanged = 0;
-
-    for k in keys2.difference(&keys1) {
-        added.push((*k).clone());
-    }
-
-    for k in keys1.difference(&keys2) {
-        removed.push((*k).clone());
-    }
 
     for k in keys1.intersection(&keys2) {
         if map1.get(*k) == map2.get(*k) {
@@ -99,38 +84,26 @@ pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
     println!("Methods Unchanged:    {unchanged}");
     println!();
 
-    if !added.is_empty() {
-        println!("--- Top 10 Added Methods ---");
-        for m in added.iter().take(10) {
-            println!("  + {m}");
-        }
-        if added.len() > 10 {
-            println!("  ... and {} more", added.len() - 10);
-        }
-        println!();
-    }
+    print_method_list("Added", "+", &added);
+    print_method_list("Removed", "-", &removed);
+    print_method_list("Modified", "~", &modified);
+}
 
-    if !removed.is_empty() {
-        println!("--- Top 10 Removed Methods ---");
-        for m in removed.iter().take(10) {
-            println!("  - {m}");
-        }
-        if removed.len() > 10 {
-            println!("  ... and {} more", removed.len() - 10);
-        }
-        println!();
+#[cfg(feature = "nova")]
+#[cfg(not(tarpaulin_include))]
+#[allow(unexpected_cfgs, clippy::print_stdout)]
+fn print_method_list(title: &str, prefix: &str, methods: &[String]) {
+    if methods.is_empty() {
+        return;
     }
-
-    if !modified.is_empty() {
-        println!("--- Top 10 Modified Methods ---");
-        for m in modified.iter().take(10) {
-            println!("  ~ {m}");
-        }
-        if modified.len() > 10 {
-            println!("  ... and {} more", modified.len() - 10);
-        }
-        println!();
+    println!("--- Top 10 {title} Methods ---");
+    for m in methods.iter().take(10) {
+        println!("  {prefix} {m}");
     }
+    if methods.len() > 10 {
+        println!("  ... and {} more", methods.len().saturating_sub(10));
+    }
+    println!();
 }
 
 #[cfg(feature = "nova")]
@@ -151,25 +124,28 @@ fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
 
     for entry_name in class_entries {
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            #[allow(clippy::collapsible_if)]
-            if let Ok(cf) = parse(&bytes) {
-                let class_name = resolve_class_name(&cf, cf.this_class);
 
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{class_name}::{name_str}{desc_str}");
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
+        let Ok(cf) = parse(&bytes) else {
+            continue;
+        };
 
-                    let mut hasher = DefaultHasher::new();
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            code.code.hash(&mut hasher);
-                        }
-                    }
-                    method_hashes.insert(full_name, hasher.finish());
+        let class_name = resolve_class_name(&cf, cf.this_class);
+
+        for method in &cf.methods {
+            let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+            let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+            let full_name = format!("{class_name}::{name_str}{desc_str}");
+
+            let mut hasher = DefaultHasher::new();
+            for attr in &method.attributes {
+                if let AttributeData::Code(code) = &attr.data {
+                    code.code.hash(&mut hasher);
                 }
             }
+            method_hashes.insert(full_name, hasher.finish());
         }
     }
     method_hashes

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,7 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
+**Smell:** The `jar_diff.rs` script was highly nested, using large iterator loops (like `for k in keys2.difference(&keys1)` with multi-line bodies to push elements), deeply nested functional map chains (`and_then` returning options in options instead of early-return guards), and duplicate loops. It also incorrectly referenced `duke_classfile::types::{...}` which triggered compiler errors since the structs are exposed at the crate root instead of `types`.
 
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
+**Solution:** I have flattened the functional map chains and used `?` operator early returns in `cp_str`, removed `types::` from import paths, and refactored the complex collection diff operations to leverage clean `difference().copied().cloned().collect()` chained operators instead of multi-line procedural `for` loop pushes. I also extracted duplicate list-printing logic into a reusable `print_method_list` helper method.
 
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
+**Benefit:** Greatly reduces cognitive load. Functional style is cleaner and less error-prone. Re-uses standard library operations to perform iterator mutations. Code now compiles.
 
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+**Verification:** Ran `cargo clippy`, `cargo fmt`, and `cargo test` and all checks passed. No functional logic was changed.


### PR DESCRIPTION
**Smell:** The `jar_diff.rs` script was highly nested, using large iterator loops (like `for k in keys2.difference(&keys1)` with multi-line bodies to push elements), deeply nested functional map chains (`and_then` returning options in options instead of early-return guards), and duplicate loops. It also incorrectly referenced `duke_classfile::types::{...}` which triggered compiler errors since the structs are exposed at the crate root instead of `types`.

**Solution:** I have flattened the functional map chains and used `?` operator early returns in `cp_str`, removed `types::` from import paths, and refactored the complex collection diff operations to leverage clean `difference().copied().cloned().collect()` chained operators instead of multi-line procedural `for` loop pushes. I also extracted duplicate list-printing logic into a reusable `print_method_list` helper method.

**Benefit:** Greatly reduces cognitive load. Functional style is cleaner and less error-prone. Re-uses standard library operations to perform iterator mutations. Code now compiles.

**Verification:** Ran `cargo clippy`, `cargo fmt`, and `cargo test` and all checks passed. No functional logic was changed.

---
*PR created automatically by Jules for task [7775320032611414113](https://jules.google.com/task/7775320032611414113) started by @madmax983*