### PR TITLE
⚒️ Forge: Fix unresolved import and type inference in jar_diff.rs

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,4 @@
-🛡️ Sentry: [test coverage improvement]
+⚒️ Forge: Fix unresolved import and type inference in jar_diff.rs
 
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+Fixed unresolved import `duke_classfile::types` by importing types directly from `duke_classfile`.
+Fixed type inference errors on closures by adding explicit type annotations `&Option<CpEntry>`.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,4 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
-
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
-
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
-
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+🚮 Smell: The `duke` binary was failing to compile due to an unresolved import (`duke_classfile::types`) and missing type annotations on closures (`and_then(|slot| ...)`).
+✨ Solution: Extracted the imports (`AttributeData`, `CpEntry`, `CpIndex`) to the crate root as they are now re-exported directly. Added explicit `&Option<CpEntry>` types to closures to satisfy the compiler.
+🧼 Benefit: Resolves compilation errors without changing any runtime behavior, keeping the code strictly typed.
+🛡️ Verification: Tests passed. No logic changed.


### PR DESCRIPTION
🚮 Smell: The `duke` binary was failing to compile due to an unresolved import (`duke_classfile::types`) and missing type annotations on closures (`and_then(|slot| ...)`).
✨ Solution: Extracted the imports (`AttributeData`, `CpEntry`, `CpIndex`) to the crate root as they are now re-exported directly. Added explicit `&Option<CpEntry>` types to closures to satisfy the compiler.
🧼 Benefit: Resolves compilation errors without changing any runtime behavior, keeping the code strictly typed.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [14452314261242469494](https://jules.google.com/task/14452314261242469494) started by @madmax983*