### PR TITLE
🗺️ Atlas: Encapsulate module facades

### DIFF
--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -3,8 +3,7 @@
 
 #[cfg(feature = "nova")]
 use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    parse, AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +17,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<duke_classfile::CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +37,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<duke_classfile::CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
🕸️ Tangle: The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types. This created confusing, leaky abstractions and redundant paths. During the facade change, `duke/src/jar_diff.rs` was left with unresolved `types` path imports.
📐 Blueprint: Fixed the unresolved `types` path in `duke/src/jar_diff.rs` to use the correctly encapsulated `duke_classfile` root exports due to the previous facade change.
🧱 Stability: Reduced coupling, closed leaky abstractions, and improved encapsulation without breaking functionality.
🔬 Verification: Checked with `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test`, which build successfully and pass all tests.

---
*PR created automatically by Jules for task [8177660414782249342](https://jules.google.com/task/8177660414782249342) started by @madmax983*