### PR TITLE
⚒️ Forge: Refactor jar_diff to flatten pyramid of doom

### DIFF
--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")
@@ -63,18 +60,10 @@ pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
     let keys1: HashSet<_> = map1.keys().collect();
     let keys2: HashSet<_> = map2.keys().collect();
 
-    let mut added = Vec::new();
-    let mut removed = Vec::new();
+    let mut added: Vec<_> = keys2.difference(&keys1).map(|k| (*k).clone()).collect();
+    let mut removed: Vec<_> = keys1.difference(&keys2).map(|k| (*k).clone()).collect();
     let mut modified = Vec::new();
     let mut unchanged = 0;
-
-    for k in keys2.difference(&keys1) {
-        added.push((*k).clone());
-    }
-
-    for k in keys1.difference(&keys2) {
-        removed.push((*k).clone());
-    }
 
     for k in keys1.intersection(&keys2) {
         if map1.get(*k) == map2.get(*k) {
@@ -151,28 +140,39 @@ fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
 
     for entry_name in class_entries {
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            #[allow(clippy::collapsible_if)]
-            if let Ok(cf) = parse(&bytes) {
-                let class_name = resolve_class_name(&cf, cf.this_class);
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
 
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{class_name}::{name_str}{desc_str}");
+        #[allow(clippy::collapsible_if)]
+        let Ok(cf) = parse(&bytes) else {
+            continue;
+        };
 
-                    let mut hasher = DefaultHasher::new();
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            code.code.hash(&mut hasher);
-                        }
-                    }
-                    method_hashes.insert(full_name, hasher.finish());
-                }
-            }
-        }
+        let class_name = resolve_class_name(&cf, cf.this_class);
+        hash_class_methods(&cf, &class_name, &mut method_hashes);
     }
     method_hashes
+}
+
+fn hash_class_methods(
+    cf: &duke_classfile::ClassFile,
+    class_name: &str,
+    method_hashes: &mut HashMap<String, u64>,
+) {
+    for method in &cf.methods {
+        let name_str = cp_str(cf, method.name_index).unwrap_or("<invalid>");
+        let desc_str = cp_str(cf, method.descriptor_index).unwrap_or("<invalid>");
+        let full_name = format!("{class_name}::{name_str}{desc_str}");
+
+        let mut hasher = DefaultHasher::new();
+        for attr in &method.attributes {
+            if let AttributeData::Code(code) = &attr.data {
+                code.code.hash(&mut hasher);
+            }
+        }
+        method_hashes.insert(full_name, hasher.finish());
+    }
 }
 
 #[cfg(test)]

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,19 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
+🚮 Smell:
+- Deeply nested `if let` blocks ("Pyramid of Doom") in `load_jar_methods` made it difficult to trace the main logic.
+- Raw `for` loops were used for simple set filtering.
+- Missing explicit closure types led to `E0282: type annotations needed` compiler errors on `.and_then`.
 
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
+✨ Solution:
+- Replaced deep nesting in `load_jar_methods` with flat `let Ok(...) = ... else { continue; };` guard clauses.
+- Extracted the core hash calculation into a discrete, well-scoped `hash_class_methods` helper function.
+- Converted raw mutable `for` loops in `dump_jar_diff` into idiomatic Iterator pipelines (`.map(|k| (*k).clone()).collect()`).
+- Added explicit `&Option<CpEntry>` types to closures to resolve E0282.
 
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
+🧼 Benefit:
+- Massively reduces cognitive load and scroll fatigue in `load_jar_methods`.
+- Ensures functions are strictly typed and compiler inference is robust.
+- Code is much more idiomatic to modern Rust.
 
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+🛡️ Verification:
+- Tests passed. No logic changed.
+- Verified cleanly against `cargo check`, `cargo test`, and `cargo clippy`.


### PR DESCRIPTION
🚮 Smell:
- Deeply nested `if let` blocks ("Pyramid of Doom") in `load_jar_methods` made it difficult to trace the main logic.
- Raw `for` loops were used for simple set filtering.
- Missing explicit closure types led to `E0282: type annotations needed` compiler errors on `.and_then`.

✨ Solution:
- Replaced deep nesting in `load_jar_methods` with flat `let Ok(...) = ... else { continue; };` guard clauses.
- Extracted the core hash calculation into a discrete, well-scoped `hash_class_methods` helper function.
- Converted raw mutable `for` loops in `dump_jar_diff` into idiomatic Iterator pipelines (`.map(|k| (*k).clone()).collect()`).
- Added explicit `&Option<CpEntry>` types to closures to resolve E0282.

🧼 Benefit:
- Massively reduces cognitive load and scroll fatigue in `load_jar_methods`.
- Ensures functions are strictly typed and compiler inference is robust.
- Code is much more idiomatic to modern Rust.

🛡️ Verification:
- Tests passed. No logic changed.
- Verified cleanly against `cargo check`, `cargo test`, and `cargo clippy`.

---
*PR created automatically by Jules for task [14202684618802473060](https://jules.google.com/task/14202684618802473060) started by @madmax983*