### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,6 @@
-🛡️ Sentry: [test coverage improvement]
+🎻 Bard: [documentation update]
 
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+📖 Chapter: jar_diff
+🔦 Insight: Fixed compiler errors caused by missing types import by flattening it and added missing documentation for `dump_jar_diff` with a panics section and examples section.
+🧪 Example: Added `dump_jar_diff` doc-test example.
+🖼️ Preview: None

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")
@@ -56,6 +53,27 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     clippy::use_debug,
     clippy::collapsible_if
 )]
+/// Analyzes two JAR files and dumps a summary of the differences between their methods.
+///
+/// This function is useful for comparing the bytecode of two different builds or versions
+/// of the same library to see what has changed. It compares methods by hashing their
+/// `Code` attributes, identifying methods that have been added, removed, or modified.
+///
+/// ## Panics
+///
+/// This function does not panic on invalid JARs, it simply returns empty results.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// # #[cfg(feature = "nova")]
+/// # {
+/// use duke::jar_diff::dump_jar_diff;
+///
+/// // Diff two JAR files to see what methods changed
+/// dump_jar_diff("old_app.jar", "new_app.jar");
+/// # }
+/// ```
 pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
     let map1 = load_jar_methods(jar1_path);
     let map2 = load_jar_methods(jar2_path);


### PR DESCRIPTION
📖 Chapter: jar_diff
🔦 Insight: Fixed compiler errors caused by missing types import by flattening it and added missing documentation for `dump_jar_diff` with a panics section and examples section.
🧪 Example: Added `dump_jar_diff` doc-test example.
🖼️ Preview: None

---
*PR created automatically by Jules for task [15096412148432385054](https://jules.google.com/task/15096412148432385054) started by @madmax983*