### PR TITLE
⚒️ Forge: [refactor unnecessary wraps]

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,0 @@
-🛡️ Sentry: [test coverage improvement]
-
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter

--- a/crates/duke-bytecode/src/decoder.rs
+++ b/crates/duke-bytecode/src/decoder.rs
@@ -263,9 +263,8 @@ fn decode_math_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
         _ => unreachable!(),
     })
 }
-#[allow(clippy::unnecessary_wraps)]
-fn decode_conversion_op(opcode: u8) -> Result<Instruction> {
-    Ok(match opcode {
+fn decode_conversion_op(opcode: u8) -> Instruction {
+    match opcode {
         op::I2L => Instruction::I2l,
         op::I2F => Instruction::I2f,
         op::I2D => Instruction::I2d,
@@ -282,7 +281,7 @@ fn decode_conversion_op(opcode: u8) -> Result<Instruction> {
         op::I2C => Instruction::I2c,
         op::I2S => Instruction::I2s,
         _ => unreachable!(),
-    })
+    }
 }
 fn decode_control_flow_op(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> Result<Instruction> {
     Ok(match opcode {
@@ -393,7 +392,6 @@ fn decode_extended_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
     })
 }
 
-#[allow(clippy::unnecessary_wraps)]
 #[allow(clippy::too_many_lines)]
 fn decode_one(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> Result<Instruction> {
     match opcode {
@@ -412,7 +410,7 @@ fn decode_one(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> Result<Instruction> 
             _ => unreachable!(),
         }),
         op::IADD..=op::IINC => decode_math_op(c, opcode),
-        op::I2L..=op::I2S => decode_conversion_op(opcode),
+        op::I2L..=op::I2S => Ok(decode_conversion_op(opcode)),
         op::LCMP..=op::RETURN => decode_control_flow_op(c, opcode, pc),
         op::GETSTATIC..=op::MONITOREXIT => decode_object_invoke_op(c, opcode, pc),
         op::WIDE => decode_wide(c, pc),


### PR DESCRIPTION
🚮 Smell: `decode_conversion_op` in `decoder.rs` wrapped its infallible return value in `Result<Instruction>`, requiring an `#![allow(clippy::unnecessary_wraps)]` attribute.
✨ Solution: Changed `decode_conversion_op` to return `Instruction` directly and wrapped its caller.
🧼 Benefit: Removes unnecessary clippy allowances and strictly types infallible operations.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [6454759247540125437](https://jules.google.com/task/6454759247540125437) started by @madmax983*