### PR TITLE
⚒️ Forge: [refactor deep nesting]

### DIFF
--- a/crates/duke-bytecode/src/decoder.rs
+++ b/crates/duke-bytecode/src/decoder.rs
@@ -399,18 +399,7 @@ fn decode_one(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> Result<Instruction> 
     match opcode {
         op::NOP..=op::LDC2_W => decode_constant_op(c, opcode),
         op::ILOAD..=op::SASTORE => decode_load_store_op(c, opcode),
-        op::POP..=op::SWAP => Ok(match opcode {
-            op::POP => Instruction::Pop,
-            op::POP2 => Instruction::Pop2,
-            op::DUP => Instruction::Dup,
-            op::DUP_X1 => Instruction::DupX1,
-            op::DUP_X2 => Instruction::DupX2,
-            op::DUP2 => Instruction::Dup2,
-            op::DUP2_X1 => Instruction::Dup2X1,
-            op::DUP2_X2 => Instruction::Dup2X2,
-            op::SWAP => Instruction::Swap,
-            _ => unreachable!(),
-        }),
+        op::POP..=op::SWAP => Ok(decode_stack_op(opcode)),
         op::IADD..=op::IINC => decode_math_op(c, opcode),
         op::I2L..=op::I2S => decode_conversion_op(opcode),
         op::LCMP..=op::RETURN => decode_control_flow_op(c, opcode, pc),
@@ -518,6 +507,22 @@ fn decode_wide(c: &mut Cursor<'_>, pc: usize) -> Result<Instruction> {
     };
     Ok(instr)
 }
+
+fn decode_stack_op(opcode: u8) -> Instruction {
+    match opcode {
+        op::POP => Instruction::Pop,
+        op::POP2 => Instruction::Pop2,
+        op::DUP => Instruction::Dup,
+        op::DUP_X1 => Instruction::DupX1,
+        op::DUP_X2 => Instruction::DupX2,
+        op::DUP2 => Instruction::Dup2,
+        op::DUP2_X1 => Instruction::Dup2X1,
+        op::DUP2_X2 => Instruction::Dup2X2,
+        op::SWAP => Instruction::Swap,
+        _ => unreachable!(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/crates/duke-loader/src/zip.rs
+++ b/crates/duke-loader/src/zip.rs
@@ -267,28 +267,7 @@ impl ZipReader {
 
         let decompressed = match info.compression_method {
             METHOD_STORED => compressed.to_vec(),
-            METHOD_DEFLATED => {
-                let decoder = flate2::read::DeflateDecoder::new(compressed);
-                let cap = usize::try_from(info.uncompressed_size).unwrap_or(usize::MAX);
-                let max_size = 1024 * 1024 * 256; // 256 MB max size to prevent OOM
-                if cap > max_size {
-                    return Err(Error::ZipFormat {
-                        msg: format!(
-                            "entry '{}' uncompressed size {} exceeds limit {}",
-                            info.name, cap, max_size
-                        ),
-                    });
-                }
-                let mut buf = Vec::with_capacity(cap.min(compressed.len().saturating_mul(2)));
-                decoder
-                    .take(max_size as u64)
-                    .read_to_end(&mut buf)
-                    .map_err(|_| Error::ZipFormat {
-                        msg: format!("failed to deflate entry '{}'", info.name),
-                    })?;
-
-                buf
-            }
+            METHOD_DEFLATED => decompress_deflated(info, compressed)?,
             other => {
                 return Err(Error::ZipFormat {
                     msg: format!(
@@ -1611,4 +1590,26 @@ mod proptests {
             let _ = reader.read_entry_info(&info);
         }
     }
+}
+fn decompress_deflated(info: &ZipEntryInfo, compressed: &[u8]) -> Result<Vec<u8>> {
+    let decoder = flate2::read::DeflateDecoder::new(compressed);
+    let cap = usize::try_from(info.uncompressed_size).unwrap_or(usize::MAX);
+    let max_size = 1024 * 1024 * 256; // 256 MB max size to prevent OOM
+    if cap > max_size {
+        return Err(Error::ZipFormat {
+            msg: format!(
+                "entry '{}' uncompressed size {} exceeds limit {}",
+                info.name, cap, max_size
+            ),
+        });
+    }
+    let mut buf = Vec::with_capacity(cap.min(compressed.len().saturating_mul(2)));
+    decoder
+        .take(max_size as u64)
+        .read_to_end(&mut buf)
+        .map_err(|_| Error::ZipFormat {
+            msg: format!("failed to deflate entry '{}'", info.name),
+        })?;
+
+    Ok(buf)
 }

--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,0 +1,4 @@
+🚮 Smell: The `decode_one` function in `decoder.rs` and the `read_entry_info` function in `zip.rs` both suffered from "Pyramid of Doom" nesting. They contained inline blocks for opcode matching and deflation decompression respectively, violating clarity and causing excessive rightward drift.
+✨ Solution: Extracted the `op::POP..=op::SWAP` match block into a `decode_stack_op` function. Extracted the `METHOD_DEFLATED` decompression block into a `decompress_deflated` helper function.
+🧼 Benefit: Reduces cognitive load and strictly flattens the execution flow by replacing large inline blocks with named method calls, making the parent functions significantly easier to understand.
+🛡️ Verification: Tests passed. No logic changed. All changes verified by `cargo test`, `cargo clippy`, and `cargo fmt`.


### PR DESCRIPTION
🚮 Smell: The `decode_one` function in `decoder.rs` and the `read_entry_info` function in `zip.rs` both suffered from "Pyramid of Doom" nesting. They contained inline blocks for opcode matching and deflation decompression respectively, violating clarity and causing excessive rightward drift.
✨ Solution: Extracted the `op::POP..=op::SWAP` match block into a `decode_stack_op` function. Extracted the `METHOD_DEFLATED` decompression block into a `decompress_deflated` helper function.
🧼 Benefit: Reduces cognitive load and strictly flattens the execution flow by replacing large inline blocks with named method calls, making the parent functions significantly easier to understand.
🛡️ Verification: Tests passed. No logic changed. All changes verified by `cargo test`, `cargo clippy`, and `cargo fmt`.

---
*PR created automatically by Jules for task [4907417084710970896](https://jules.google.com/task/4907417084710970896) started by @madmax983*