### PR TITLE
🗺️ Atlas: [encapsulate module facades]

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -7,3 +7,6 @@
 **[Encapsulate `duke_classfile` Facade]**
 **Tangle:** The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types, and `duke-telemetry` exposed internal serialization helpers via `pub mod ser_helpers`. This creates confusing, leaky abstractions and redundant paths.
 **Blueprint:** Encapsulated both modules. In `duke_classfile`, replaced `pub mod types` with direct `pub use` statements at the crate root, eliminating the `types` namespace from the public API entirely. In `duke_telemetry`, reduced `ser_helpers` visibility to `pub(crate)`.
+**[Encapsulate Module Facades]**
+**Tangle:** The `ser_helpers` module in `duke-telemetry` was exported as `pub mod ser_helpers`, incorrectly leaking test helpers into the public API of the crate and violating strict visibility boundaries.
+**Blueprint:** Modified `pub mod ser_helpers` to `pub(crate) mod ser_helpers`, correctly encapsulating the module within the crate.

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,6 @@
-🛡️ Sentry: [test coverage improvement]
+🗺️ Atlas: [encapsulate module facades]
 
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+🕸️ Tangle: `ser_helpers` was publicly exported as `pub mod` in `duke-telemetry`.
+📐 Blueprint: Changed to `pub(crate) mod` to restrict visibility and encapsulate the module within the crate.
+🧱 Stability: Prevents internal serialization test helpers from leaking into the public API.
+🔭 Verification: `cargo test` and `cargo check` compile successfully.

--- a/crates/duke-telemetry/src/helpers.rs
+++ b/crates/duke-telemetry/src/helpers.rs
@@ -1,6 +1,7 @@
 //! Serde serialization helpers for telemetry data structures.
 #[cfg(feature = "telemetry")]
-pub mod ser_helpers {
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) mod ser_helpers {
     use std::collections::HashMap;
 
     use serde::{Serialize, ser::SerializeMap};

--- a/plan.md
+++ b/plan.md
@@ -1,20 +1,10 @@
-1. **Optimize String concatenation in `native_string_concat`**
-   - The function currently uses `format!("{s1}{s2}")` to concatenate two strings, which allocates a new string buffer inside `format!`, formats the arguments, and returns it.
-   - We can optimize this by pre-allocating a `String` with the exact required capacity and appending the strings:
-     ```rust
-     let mut combined = String::with_capacity(s1.len() + s2.len());
-     combined.push_str(&s1);
-     combined.push_str(&s2);
-     let r = heap.allocate_string(combined);
-     ```
-   - This eliminates the intermediate allocation and parsing overhead of `format!`, which is a common hotspot in interpreters.
-   - Add `// ⚡ Bolt: Eliminate intermediate format! allocation` comment.
-   - Ensure the tests pass.
-1. Refactor `print_report` methods in `duke-telemetry/src/lib.rs` to handle empty states gracefully (Reduces noise from empty reports).
-   - Before: Outputs headers and empty tables for empty components.
-   - After: Outputs a concise message stating no events were recorded.
-2. Complete pre commit steps to make sure proper testing, verifications, reviews and reflections are done.
-3. Submit the change using a descriptive title.
-1. **Optimize Vector Allocations in Execution (Vec::with_capacity)**: Pre-allocate vectors in `crates/duke-interpreter/src/execution.rs` for `Multianewarray` `dims` array and lambda args `impl_args` to avoid unnecessary dynamic heap reallocations.
-2. Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.
-3. **Submit the PR**: Present PR titled '⚡ Bolt: Optimize Vector Allocations in Execution & Native' detailing 💡 What, 🎯 Why, 📊 Impact, and 🔭 Measurement. I will use `run_in_bash_session` to execute `git commit` with the requested PR details.
+1. Use `run_in_bash_session` to execute a Python script (`unify_errors.py`) that implements the "Encapsulate Module Facades" architectural change by:
+   - Modifying `crates/duke-telemetry/src/helpers.rs` to replace `pub mod ser_helpers` with `pub(crate) mod ser_helpers`, properly encapsulating the internal serialization test helpers.
+   - Deleting the python script after execution.
+2. Use `run_in_bash_session` to run `cargo check` to verify the automated refactoring succeeded.
+3. Use `run_in_bash_session` to run `cargo test --workspace` to verify the codebase behaves correctly with the new visibility.
+4. Use `run_in_bash_session` to append the CRITICAL learning regarding "Encapsulate Module Facades" to `.jules/atlas.md` in the required `**Tangle:** / **Blueprint:**` format via a bash heredoc.
+5. Use `run_in_bash_session` to write the verbatim multi-line commit message to `commit_msg.txt` and PR description to `pr_body.txt` via a bash heredoc.
+6. Use `run_in_bash_session` to run the full workspace test suite `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt --all`.
+7. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+8. Use `run_in_bash_session` to execute explicit `git add -A`, `git commit -F commit_msg.txt`, and `git push` commands to submit the branch `atlas_error` using the generated PR text.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,4 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
-
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
-
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
-
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+🕸️ Tangle: `ser_helpers` was publicly exported as `pub mod` in `duke-telemetry`.
+📐 Blueprint: Changed to `pub(crate) mod` to restrict visibility and encapsulate the module within the crate.
+🧱 Stability: Prevents internal serialization test helpers from leaking into the public API.
+🔭 Verification: `cargo test` and `cargo check` compile successfully.


### PR DESCRIPTION
🕸️ Tangle: `ser_helpers` was publicly exported as `pub mod` in `duke-telemetry`.
📐 Blueprint: Changed to `pub(crate) mod` to restrict visibility and encapsulate the module within the crate.
🧱 Stability: Prevents internal serialization test helpers from leaking into the public API.
🔭 Verification: `cargo test` and `cargo check` compile successfully.

---
*PR created automatically by Jules for task [607253386405577622](https://jules.google.com/task/607253386405577622) started by @madmax983*