### PR TITLE
🔭 Vantage: Spec for String.equalsIgnoreCase

### DIFF
--- a/docs/plans/2026-05-21-spec-string-equalsIgnoreCase.md
+++ b/docs/plans/2026-05-21-spec-string-equalsIgnoreCase.md
@@ -1,0 +1,13 @@
+# Spec for java/lang/String.equalsIgnoreCase
+
+## User Story
+As an end-user of the JVM, I want `java/lang/String.equalsIgnoreCase(Ljava/lang/String;)Z` implemented natively, so that my Java applications (like slf4j) can compare strings case-insensitively without crashing due to unsupported natives.
+
+## Acceptance Criteria
+- Must implement the native method `String.equalsIgnoreCase(String) -> boolean`.
+- Must return true if strings are equal ignoring case, false otherwise.
+- Must handle null arguments gracefully (return false if the argument is null).
+- Must progress the `slf4j` smoke test past the `String.equalsIgnoreCase` blocker.
+
+## Out of Scope
+- Full locale-dependent case folding. Simple ASCII case folding is sufficient for Phase 1.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<duke_classfile::CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<duke_classfile::CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/plan.md
+++ b/plan.md
@@ -1,20 +1,6 @@
-1. **Optimize String concatenation in `native_string_concat`**
-   - The function currently uses `format!("{s1}{s2}")` to concatenate two strings, which allocates a new string buffer inside `format!`, formats the arguments, and returns it.
-   - We can optimize this by pre-allocating a `String` with the exact required capacity and appending the strings:
-     ```rust
-     let mut combined = String::with_capacity(s1.len() + s2.len());
-     combined.push_str(&s1);
-     combined.push_str(&s2);
-     let r = heap.allocate_string(combined);
-     ```
-   - This eliminates the intermediate allocation and parsing overhead of `format!`, which is a common hotspot in interpreters.
-   - Add `// ⚡ Bolt: Eliminate intermediate format! allocation` comment.
-   - Ensure the tests pass.
-1. Refactor `print_report` methods in `duke-telemetry/src/lib.rs` to handle empty states gracefully (Reduces noise from empty reports).
-   - Before: Outputs headers and empty tables for empty components.
-   - After: Outputs a concise message stating no events were recorded.
-2. Complete pre commit steps to make sure proper testing, verifications, reviews and reflections are done.
-3. Submit the change using a descriptive title.
-1. **Optimize Vector Allocations in Execution (Vec::with_capacity)**: Pre-allocate vectors in `crates/duke-interpreter/src/execution.rs` for `Multianewarray` `dims` array and lambda args `impl_args` to avoid unnecessary dynamic heap reallocations.
+As "Vantage" 🔭, I will draft a PR with the specification for implementing the `java/lang/String.equalsIgnoreCase(Ljava/lang/String;)Z` native method to unblock the SLF4J smoke test, following the strict boundaries.
+
+1. Generate the spec documentation `docs/plans/2026-05-21-spec-string-equalsIgnoreCase.md`.
+   - Include the "User Story", "Acceptance Criteria", and "Out of Scope".
 2. Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.
-3. **Submit the PR**: Present PR titled '⚡ Bolt: Optimize Vector Allocations in Execution & Native' detailing 💡 What, 🎯 Why, 📊 Impact, and 🔭 Measurement. I will use `run_in_bash_session` to execute `git commit` with the requested PR details.
+3. Submit the PR using `run_in_bash_session` to execute a git commit with the title "🔭 Vantage: Spec for String.equalsIgnoreCase" and the multi-line PR description.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,9 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
+🔭 Vantage: Spec for String.equalsIgnoreCase
 
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
-
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
-
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+👤 **User Story:** "As an end-user of the JVM, I want String.equalsIgnoreCase implemented natively, so that my Java applications (like slf4j) can compare strings case-insensitively without crashing due to unsupported natives."
+✅ **Acceptance Criteria:**
+  - Must implement the native method String.equalsIgnoreCase(String) -> boolean.
+  - Must return true if strings are equal ignoring case, false otherwise.
+  - Must handle null arguments gracefully (return false if the argument is null).
+  - Must progress the slf4j smoke test past the String.equalsIgnoreCase blocker.
+🚫 **Out of Scope:** Full locale-dependent case folding. Simple ASCII case folding is sufficient for Phase 1.


### PR DESCRIPTION
🔭 Vantage: Spec for String.equalsIgnoreCase

👤 **User Story:** "As an end-user of the JVM, I want String.equalsIgnoreCase implemented natively, so that my Java applications (like slf4j) can compare strings case-insensitively without crashing due to unsupported natives."
✅ **Acceptance Criteria:**
  - Must implement the native method String.equalsIgnoreCase(String) -> boolean.
  - Must return true if strings are equal ignoring case, false otherwise.
  - Must handle null arguments gracefully (return false if the argument is null).
  - Must progress the slf4j smoke test past the String.equalsIgnoreCase blocker.
🚫 **Out of Scope:** Full locale-dependent case folding. Simple ASCII case folding is sufficient for Phase 1.

---
*PR created automatically by Jules for task [16662779791914987040](https://jules.google.com/task/16662779791914987040) started by @madmax983*