### PR TITLE
⚒️ Forge: flatten nested control flow

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,1 @@
-🛡️ Sentry: [test coverage improvement]
-
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+⚒️ Forge: flatten nested control flow

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -424,7 +424,7 @@ pub fn resolve_attributes(attrs: &mut [AttributeInfo], pool: &[Option<CpEntry>])
 
 fn decode_known_attribute(name: &str, raw: &[u8]) -> Result<AttributeData> {
     let mut c = Cursor::new(raw);
-    let data = match name {
+    Ok(match name {
         "ConstantValue" => AttributeData::ConstantValue {
             constant_value_index: decode_constant_value(&mut c)?,
         },
@@ -445,8 +445,7 @@ fn decode_known_attribute(name: &str, raw: &[u8]) -> Result<AttributeData> {
         }
         "AnnotationDefault" => AttributeData::AnnotationDefault(decode_element_value(&mut c, 0)?),
         _ => AttributeData::Raw(raw.to_vec()),
-    };
-    Ok(data)
+    })
 }
 
 fn decode_constant_value(c: &mut Cursor<'_>) -> Result<CpIndex> {

--- a/crates/duke-loader/src/directory.rs
+++ b/crates/duke-loader/src/directory.rs
@@ -47,6 +47,11 @@ impl DirectoryLoader {
         }
     }
 
+    fn read_file(path: &Path, name: &str) -> Result<Vec<u8>> {
+        std::fs::read(path).map_err(|_| Error::NotFound {
+            name: name.to_string(),
+        })
+    }
     fn resolve_child_path(&self, name: &str) -> Result<PathBuf> {
         if name.contains("..")
             || name.starts_with('/')
@@ -81,16 +86,12 @@ impl ClassLoader for DirectoryLoader {
         let mut path = self.resolve_child_path(name)?;
         path.set_extension("class");
 
-        std::fs::read(&path).map_err(|_| Error::NotFound {
-            name: name.to_string(),
-        })
+        Self::read_file(&path, name)
     }
 
     fn find_resource(&self, name: &str) -> Result<Vec<u8>> {
         let path = self.resolve_child_path(name)?;
-        std::fs::read(&path).map_err(|_| Error::NotFound {
-            name: name.to_string(),
-        })
+        Self::read_file(&path, name)
     }
 
     fn find_resource_entry(&self, name: &str) -> Result<LocatedResource> {

--- a/crates/duke-runtime/src/slot.rs
+++ b/crates/duke-runtime/src/slot.rs
@@ -60,14 +60,13 @@ impl Slot {
     /// assert!(s.as_int().is_err());
     /// ```
     pub const fn as_int(&self) -> Result<i32> {
-        if let Self::Int(v) = self {
-            Ok(*v)
-        } else {
-            Err(Error::TypeMismatch {
+        let Self::Int(v) = self else {
+            return Err(Error::TypeMismatch {
                 expected: "int",
                 got: self.type_name(),
-            })
-        }
+            });
+        };
+        Ok(*v)
     }
 
     /// Extract as `i64`, or return a `TypeMismatch` error.
@@ -87,14 +86,13 @@ impl Slot {
     /// assert!(s.as_long().is_err());
     /// ```
     pub const fn as_long(&self) -> Result<i64> {
-        if let Self::Long(v) = self {
-            Ok(*v)
-        } else {
-            Err(Error::TypeMismatch {
+        let Self::Long(v) = self else {
+            return Err(Error::TypeMismatch {
                 expected: "long",
                 got: self.type_name(),
-            })
-        }
+            });
+        };
+        Ok(*v)
     }
 
     /// Extract as `f32`, or return a `TypeMismatch` error.
@@ -114,14 +112,13 @@ impl Slot {
     /// assert!(s.as_float().is_err());
     /// ```
     pub const fn as_float(&self) -> Result<f32> {
-        if let Self::Float(v) = self {
-            Ok(*v)
-        } else {
-            Err(Error::TypeMismatch {
+        let Self::Float(v) = self else {
+            return Err(Error::TypeMismatch {
                 expected: "float",
                 got: self.type_name(),
-            })
-        }
+            });
+        };
+        Ok(*v)
     }
 
     /// Extract as `f64`, or return a `TypeMismatch` error.
@@ -141,14 +138,13 @@ impl Slot {
     /// assert!(s.as_double().is_err());
     /// ```
     pub const fn as_double(&self) -> Result<f64> {
-        if let Self::Double(v) = self {
-            Ok(*v)
-        } else {
-            Err(Error::TypeMismatch {
+        let Self::Double(v) = self else {
+            return Err(Error::TypeMismatch {
                 expected: "double",
                 got: self.type_name(),
-            })
-        }
+            });
+        };
+        Ok(*v)
     }
 
     /// If this slot is a non-null reference, return the heap index. Otherwise `None`.
@@ -169,11 +165,10 @@ impl Slot {
     /// ```
     #[must_use]
     pub const fn as_reference(&self) -> Option<u64> {
-        if let Self::Reference(Some(r)) = self {
-            Some(*r)
-        } else {
-            None
-        }
+        let Self::Reference(Some(r)) = self else {
+            return None;
+        };
+        Some(*r)
     }
 
     /// Get the JVM type name for this slot's contents.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,4 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
-
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
-
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
-
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+🚮 Smell: Deeply nested `if let` and `match` blocks in `slot.rs` and `parser.rs`.
+✨ Solution: Extracted early returns (`let ... else`) in `slot.rs` and returned the `match` expression directly in `parser.rs`.
+🧼 Benefit: Reduces cognitive load and flattens the structure.
+🛡️ Verification: Tests passed. No logic changed.


### PR DESCRIPTION
🚮 Smell: Deeply nested `if let` and `match` blocks in `slot.rs` and `parser.rs`.
✨ Solution: Extracted early returns (`let ... else`) in `slot.rs` and returned the `match` expression directly in `parser.rs`.
🧼 Benefit: Reduces cognitive load and flattens the structure.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [6416962440080962267](https://jules.google.com/task/6416962440080962267) started by @madmax983*