### PR TITLE
🔭 Vantage: Spec for Thread Context ClassLoader

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,3 @@
-🛡️ Sentry: [test coverage improvement]
+docs: add Vantage spec for Thread Context ClassLoader
 
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+Adds the product specification for implementing java.lang.Thread Context ClassLoader support. This addresses the current execution blocker in the SLF4J OSS JAR smoke tests, defining the user story, gap analysis, and acceptance criteria required to progress the vm's real-world compatibility.

--- a/docs/vantage-spec-thread-context-classloader.md
+++ b/docs/vantage-spec-thread-context-classloader.md
@@ -1,0 +1,26 @@
+# 🔭 Vantage: Spec for Thread Context ClassLoader
+
+## 👤 User Story
+"As an Enterprise Framework Maintainer running my code on Duke, I want my threads to support Thread Context ClassLoaders (TCCL), so that my dynamic framework can load user application classes that are not visible to the system classloader."
+
+## ❓ The "So What?"
+What business problem does this solve?
+Currently, Duke lacks support for `java.lang.Thread.getContextClassLoader()`. Frameworks like SLF4J, Spring, and application servers rely heavily on the TCCL to break out of the standard classloader delegation hierarchy and dynamically load plugins, logging implementations, or application code that is supplied at runtime. Without TCCL support, Duke is blocked from running these common enterprise libraries, as demonstrated by the `slf4j-simple` OSS JAR smoke test failing on this missing capability. Implementing TCCL bridges this gap and moves Duke closer to real-world framework compatibility.
+
+## 📈 Metric Definition
+Success = The `slf4j-simple` OSS JAR smoke test progresses past the `java.lang.Thread.getContextClassLoader()` failure, and a user can successfully set and get a context classloader on a thread in Java code, with child threads properly inheriting the classloader from their parent at creation time.
+
+## 🔍 Gap Analysis
+- **Current State:** Duke has basic threading support and classloaders, but lacks the specific native methods `getContextClassLoader` and `setContextClassLoader` on `java.lang.Thread`, as well as the internal VM state to track this per-thread.
+- **Market/Standard Lib:** The standard JVM provides `getContextClassLoader()` to allow code to find classes on behalf of the thread executing the code.
+- **The Gap:** We need to implement the native bridge logic for `java.lang.Thread.getContextClassLoader()` and `setContextClassLoader()`. We also need to add a `contextClassLoader` field to Duke's internal thread representation and ensure it is inherited during thread creation.
+
+## ✅ Acceptance Criteria
+- Must implement native `java.lang.Thread.getContextClassLoader()`.
+- Must implement native `java.lang.Thread.setContextClassLoader(ClassLoader cl)`.
+- Must ensure newly created threads inherit the context classloader from their parent thread.
+- Must correctly return the system classloader (or a suitable default) if no TCCL has been explicitly set or inherited.
+
+## 🚫 Out of Scope
+- Full SecurityManager checks for `getContextClassLoader` (Duke currently uses a no-security-manager approach).
+- Complex custom ClassLoader implementations beyond what is needed to verify TCCL storage and retrieval.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,9 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
-
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
-
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
-
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+Title: 🔭 Vantage: Spec for Thread Context ClassLoader
+Description:
+* 👤 **User Story:** As an Enterprise Framework Maintainer running on Duke, I want my threads to support Thread Context ClassLoaders (TCCL), so that my dynamic framework can load user application classes that are not visible to the system classloader.
+* ✅ **Acceptance Criteria:**
+  - Must implement native java.lang.Thread.getContextClassLoader().
+  - Must implement native java.lang.Thread.setContextClassLoader(ClassLoader cl).
+  - Must ensure newly created threads inherit the context classloader from their parent thread.
+  - Must correctly return the system classloader (or a suitable default) if no TCCL has been explicitly set or inherited.
+* 🚫 **Out of Scope:** Full SecurityManager checks for getContextClassLoader.


### PR DESCRIPTION
* 👤 **User Story:** As an Enterprise Framework Maintainer running on Duke, I want my threads to support Thread Context ClassLoaders (TCCL), so that my dynamic framework can load user application classes that are not visible to the system classloader.
* ✅ **Acceptance Criteria:** 
  - Must implement native java.lang.Thread.getContextClassLoader().
  - Must implement native java.lang.Thread.setContextClassLoader(ClassLoader cl).
  - Must ensure newly created threads inherit the context classloader from their parent thread.
  - Must correctly return the system classloader (or a suitable default) if no TCCL has been explicitly set or inherited.
* 🚫 **Out of Scope:** Full SecurityManager checks for getContextClassLoader.

---
*PR created automatically by Jules for task [5116636325140891957](https://jules.google.com/task/5116636325140891957) started by @madmax983*