### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,6 @@
-🛡️ Sentry: [test coverage improvement]
+🎻 Bard: [documentation update]
 
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+📖 Chapter: The test_jar_analyze_scan.rs module and duke_classfile imports
+🔦 Insight: The test_jar_analyze_scan.rs integration test contained a global suppression for allow(missing_docs). This suppression was removed, and proper module-level //! documentation was added to describe its purpose. Additionally, fixed an unresolved import error (duke_classfile::types) by importing types directly from the crate root and adding explicit closure argument types (|slot: &Option<CpEntry>|) to resolve compiler inference errors ([E0282]), addressing broken code that prevented doc generation.
+🧪 Example: N/A
+🖼️ Preview: N/A

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/plan.md
+++ b/plan.md
@@ -1,20 +1,22 @@
-1. **Optimize String concatenation in `native_string_concat`**
-   - The function currently uses `format!("{s1}{s2}")` to concatenate two strings, which allocates a new string buffer inside `format!`, formats the arguments, and returns it.
-   - We can optimize this by pre-allocating a `String` with the exact required capacity and appending the strings:
-     ```rust
-     let mut combined = String::with_capacity(s1.len() + s2.len());
-     combined.push_str(&s1);
-     combined.push_str(&s2);
-     let r = heap.allocate_string(combined);
-     ```
-   - This eliminates the intermediate allocation and parsing overhead of `format!`, which is a common hotspot in interpreters.
-   - Add `// ⚡ Bolt: Eliminate intermediate format! allocation` comment.
-   - Ensure the tests pass.
-1. Refactor `print_report` methods in `duke-telemetry/src/lib.rs` to handle empty states gracefully (Reduces noise from empty reports).
-   - Before: Outputs headers and empty tables for empty components.
-   - After: Outputs a concise message stating no events were recorded.
-2. Complete pre commit steps to make sure proper testing, verifications, reviews and reflections are done.
-3. Submit the change using a descriptive title.
-1. **Optimize Vector Allocations in Execution (Vec::with_capacity)**: Pre-allocate vectors in `crates/duke-interpreter/src/execution.rs` for `Multianewarray` `dims` array and lambda args `impl_args` to avoid unnecessary dynamic heap reallocations.
-2. Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.
-3. **Submit the PR**: Present PR titled '⚡ Bolt: Optimize Vector Allocations in Execution & Native' detailing 💡 What, 🎯 Why, 📊 Impact, and 🔭 Measurement. I will use `run_in_bash_session` to execute `git commit` with the requested PR details.
+1. **Explore Codebase and Identify `missing_docs` Suppressions**
+   - Find all instances of `#![allow(missing_docs)]` in tests and source files.
+   - Identified suppression in `tests/test_jar_analyze_scan.rs`.
+
+2. **Add Documentation and Remove Suppressions**
+   - Used `fix_tests.py` to replace `#![allow(missing_docs)]` with proper `//!` module-level documentation in `tests/test_jar_analyze_scan.rs`.
+   - Verified that `cargo doc --no-deps` with `RUSTDOCFLAGS="-D warnings -W missing_docs"` passes cleanly.
+
+3. **Fix Compilation Errors (`jar_diff.rs`)**
+   - Encountered unresolved import `duke_classfile::types` and `E0282` type inference errors.
+   - Used `fix_jar_diff.py` to update imports to use the crate root directly (`duke_classfile::{...}`) instead of the private `types` module.
+   - Added explicit type annotations (`|slot: &Option<CpEntry>|`) to `jar_diff.rs` closures to resolve `E0282`.
+   - Verified changes using `cargo check` and `cargo test`.
+
+4. **Verify Standards**
+   - Run `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo doc --open`.
+
+5. **Complete pre commit steps**
+   - Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.
+
+6. **Submit PR**
+   - Commit changes and submit the PR as '🎻 Bard: [documentation update]'.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,4 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
-
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
-
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
-
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+📖 Chapter: The test_jar_analyze_scan.rs module and duke_classfile imports
+🔦 Insight: The test_jar_analyze_scan.rs integration test contained a global suppression for allow(missing_docs). This suppression was removed, and proper module-level //! documentation was added to describe its purpose. Additionally, fixed an unresolved import error (duke_classfile::types) by importing types directly from the crate root and adding explicit closure argument types (|slot: &Option<CpEntry>|) to resolve compiler inference errors ([E0282]), addressing broken code that prevented doc generation.
+🧪 Example: N/A
+🖼️ Preview: N/A

--- a/tests/test_jar_analyze_scan.rs
+++ b/tests/test_jar_analyze_scan.rs
@@ -1,4 +1,8 @@
-#![allow(missing_docs)]
+//! Integration test for `jar-analyze` and `jar-scan` commands.
+//!
+//! This module contains tests to verify that the CLI correctly processes
+//! JAR files and outputs the expected analysis and security scan reports.
+
 use std::process::Command;
 use std::path::PathBuf;
 


### PR DESCRIPTION
📖 Chapter: The test_jar_analyze_scan.rs module and duke_classfile imports
🔦 Insight: The test_jar_analyze_scan.rs integration test contained a global suppression for allow(missing_docs). This suppression was removed, and proper module-level //! documentation was added to describe its purpose. Additionally, fixed an unresolved import error (duke_classfile::types) by importing types directly from the crate root and adding explicit closure argument types (|slot: &Option<CpEntry>|) to resolve compiler inference errors ([E0282]), addressing broken code that prevented doc generation.
🧪 Example: N/A
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [10150247559254854468](https://jules.google.com/task/10150247559254854468) started by @madmax983*