### PR TITLE
🗺️ Atlas: Encapsulate module facades and fix broken imports

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -7,3 +7,7 @@
 **[Encapsulate `duke_classfile` Facade]**
 **Tangle:** The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types, and `duke-telemetry` exposed internal serialization helpers via `pub mod ser_helpers`. This creates confusing, leaky abstractions and redundant paths.
 **Blueprint:** Encapsulated both modules. In `duke_classfile`, replaced `pub mod types` with direct `pub use` statements at the crate root, eliminating the `types` namespace from the public API entirely. In `duke_telemetry`, reduced `ser_helpers` visibility to `pub(crate)`.
+
+**[Fix `jar_diff` and Encapsulate `ser_helpers` Facade]
+**Tangle:** The `duke_classfile` API had its `types` namespace previously removed but left broken type paths in `jar_diff.rs`. In `duke_telemetry`, the internal serialization helpers were still exposed via `pub mod ser_helpers`.
+**Blueprint:** Fixed `jar_diff.rs` to use correct module paths and closure parameter types. Reduced `ser_helpers` visibility to `pub(crate)` in `duke_telemetry`.

--- a/crates/duke-telemetry/src/helpers.rs
+++ b/crates/duke-telemetry/src/helpers.rs
@@ -1,6 +1,6 @@
 //! Serde serialization helpers for telemetry data structures.
 #[cfg(feature = "telemetry")]
-pub mod ser_helpers {
+pub(crate) mod ser_helpers {
     use std::collections::HashMap;
 
     use serde::{Serialize, ser::SerializeMap};

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<duke_classfile::CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<duke_classfile::CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/msg.txt
+++ b/msg.txt
@@ -1,0 +1,6 @@
+🗺️ Atlas: Encapsulate module facades and fix broken imports
+
+🕸️ Tangle: The `duke_classfile` and `duke-telemetry` APIs exposed internal module structures. `jar_diff.rs` had broken imports and type inferences due to previous incomplete refactoring.
+📐 Blueprint: Fixed the `jar_diff.rs` imports and type inference issues. Changed `pub mod ser_helpers` to `pub(crate) mod ser_helpers` in `duke-telemetry`.
+🧱 Stability: Reduced coupling, enforced encapsulation, and fixed build errors.
+🔬 Verification: Builds successfully, strict separation enforced.


### PR DESCRIPTION
🕸️ Tangle: The `duke_classfile` and `duke-telemetry` APIs exposed internal module structures. `jar_diff.rs` had broken imports and type inferences due to previous incomplete refactoring.
📐 Blueprint: Fixed the `jar_diff.rs` imports and type inference issues. Changed `pub mod ser_helpers` to `pub(crate) mod ser_helpers` in `duke-telemetry`.
🧱 Stability: Reduced coupling, enforced encapsulation, and fixed build errors.
🔬 Verification: Builds successfully, strict separation enforced.

---
*PR created automatically by Jules for task [4083054031615289811](https://jules.google.com/task/4083054031615289811) started by @madmax983*