### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,6 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+## 2024-05-25 - [jar_diff Documentation]
+**Confusion:** The `duke/src/jar_diff.rs` module lacked both module-level and function-level documentation, making it unclear what its purpose was and how to use it. Additionally, there was a missing backtick around "ARchive" which caused a clippy `doc_markdown` warning.
+**Clarification:** Added module-level documentation (`//!`) explaining its role as a diagnostic tool. Added detailed function-level documentation (`///`) for `dump_jar_diff`, including an `## Examples` section and a `## Panics` section. Fixed the `doc_markdown` warning by ensuring proper formatting.

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,6 @@
-🛡️ Sentry: [test coverage improvement]
+🎻 Bard: [documentation update]
 
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+📖 Chapter: Documented the `jar_diff` module.
+🔦 Insight: Explained the module's role as a diagnostic tool for comparing bytecode between JAR files. Also detailed how `dump_jar_diff` gracefully handles failures without panicking.
+🧪 Example: Added an executable `no_run` doctest to demonstrate usage of `dump_jar_diff`.
+🖼️ Preview: Documentation is now visible and adheres to strict `missing_docs` and `doc_markdown` clippy rules.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -1,11 +1,15 @@
+//! The `jar_diff` module provides utilities for comparing the bytecode contents of two Java `ARchive` (JAR) files.
+//!
+//! This module is primarily used as a diagnostic tool to understand how Java libraries evolve.
+//! It opens two JAR files, parses all contained `.class` files, extracts the raw `Code` attributes
+//! for each method, and calculates a hash. By comparing these hashes, it can definitively tell you
+//! which methods were added, removed, or had their implementation changed.
+
 #![allow(clippy::items_after_statements)]
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +22,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +42,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")
@@ -48,6 +52,29 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     }
 }
 
+/// Analyzes and prints the differences between two JAR files to standard output.
+///
+/// This function computes the structural difference between `jar1_path` and `jar2_path`
+/// by evaluating the methods present in their respective `.class` files. It identifies
+/// methods that have been added, removed, or modified (based on bytecode hashing) and
+/// prints a human-readable summary.
+///
+/// # Panics
+///
+/// This function currently does not panic, as it gracefully falls back to empty hash maps
+/// if either JAR file cannot be opened or parsed.
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[cfg(feature = "nova")]
+/// # {
+/// use duke::jar_diff::dump_jar_diff;
+///
+/// // Compare two versions of a library to see what changed
+/// dump_jar_diff("v1.jar", "v2.jar");
+/// # }
+/// ```
 #[cfg(feature = "nova")]
 #[cfg(not(tarpaulin_include))]
 #[allow(


### PR DESCRIPTION
📖 Chapter: Documented the `jar_diff` module.
🔦 Insight: Explained the module's role as a diagnostic tool for comparing bytecode between JAR files. Also detailed how `dump_jar_diff` gracefully handles failures without panicking.
🧪 Example: Added an executable `no_run` doctest to demonstrate usage of `dump_jar_diff`.
🖼️ Preview: Documentation is now visible and adheres to strict `missing_docs` and `doc_markdown` clippy rules.

---
*PR created automatically by Jules for task [17837206011618387264](https://jules.google.com/task/17837206011618387264) started by @madmax983*