### PR TITLE
⚒️ Forge: Extract zip compression logic

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**Extract Match Block Arms**
+**Learning:** The `read_entry_info` function in `crates/duke-loader/src/zip.rs` contained a 30-line arm for `METHOD_DEFLATED` compression, obscuring the primary logic of the `match` statement.
+**Action:** Extract large, complex arms of `match` blocks into dedicated helper functions (e.g. `decompress_deflated`) to flatten nesting and improve readability.

--- a/crates/duke-loader/src/zip.rs
+++ b/crates/duke-loader/src/zip.rs
@@ -267,28 +267,7 @@ impl ZipReader {
 
         let decompressed = match info.compression_method {
             METHOD_STORED => compressed.to_vec(),
-            METHOD_DEFLATED => {
-                let decoder = flate2::read::DeflateDecoder::new(compressed);
-                let cap = usize::try_from(info.uncompressed_size).unwrap_or(usize::MAX);
-                let max_size = 1024 * 1024 * 256; // 256 MB max size to prevent OOM
-                if cap > max_size {
-                    return Err(Error::ZipFormat {
-                        msg: format!(
-                            "entry '{}' uncompressed size {} exceeds limit {}",
-                            info.name, cap, max_size
-                        ),
-                    });
-                }
-                let mut buf = Vec::with_capacity(cap.min(compressed.len().saturating_mul(2)));
-                decoder
-                    .take(max_size as u64)
-                    .read_to_end(&mut buf)
-                    .map_err(|_| Error::ZipFormat {
-                        msg: format!("failed to deflate entry '{}'", info.name),
-                    })?;
-
-                buf
-            }
+            METHOD_DEFLATED => decompress_deflated(compressed, info)?,
             other => {
                 return Err(Error::ZipFormat {
                     msg: format!(
@@ -1611,4 +1590,26 @@ mod proptests {
             let _ = reader.read_entry_info(&info);
         }
     }
+}
+
+fn decompress_deflated(compressed: &[u8], info: &ZipEntryInfo) -> Result<Vec<u8>> {
+    let decoder = flate2::read::DeflateDecoder::new(compressed);
+    let cap = usize::try_from(info.uncompressed_size).unwrap_or(usize::MAX);
+    let max_size = 1024 * 1024 * 256; // 256 MB max size to prevent OOM
+    if cap > max_size {
+        return Err(Error::ZipFormat {
+            msg: format!(
+                "entry '{}' uncompressed size {} exceeds limit {}",
+                info.name, cap, max_size
+            ),
+        });
+    }
+    let mut buf = Vec::with_capacity(cap.min(compressed.len().saturating_mul(2)));
+    decoder
+        .take(max_size as u64)
+        .read_to_end(&mut buf)
+        .map_err(|_| Error::ZipFormat {
+            msg: format!("failed to deflate entry '{}'", info.name),
+        })?;
+    Ok(buf)
 }

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
🚮 Smell: The `read_entry_info` function in `crates/duke-loader/src/zip.rs` contained a complex `match` block for `DEFLATED` compression, nesting logic heavily inside the loop and inflating the size of the function.
✨ Solution: Extracted the decompression logic into a standalone `decompress_deflated` helper function.
🧼 Benefit: Flattens the `read_entry_info` match structure, keeps the function shorter, and drastically reduces cognitive load for readers.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [10489886763165381130](https://jules.google.com/task/10489886763165381130) started by @madmax983*