### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,7 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+
+## 2024-05-24 - [ser_helpers Module Missing Docs]
+**Confusion:** The helper functions in `duke-telemetry/src/helpers.rs` like `site3`, `pair_str`, and `sorted_set` were completely undocumented. This made it difficult for developers to understand how complex telemetry map keys are serialized without hitting heap allocations.
+**Clarification:** Added complete rustdocs including explanations for why they exist and executable doctests demonstrating how to use them with `serde::Serialize`.

--- a/crates/duke-bytecode/src/fuzz.rs
+++ b/crates/duke-bytecode/src/fuzz.rs
@@ -1,3 +1,4 @@
+//! Fuzzing utilities and hooks.
 #[cfg(test)]
 mod tests {
     use crate::decoder::decode;

--- a/crates/duke-classfile/src/fuzz.rs
+++ b/crates/duke-classfile/src/fuzz.rs
@@ -1,3 +1,4 @@
+//! Fuzzing utilities and hooks.
 #[cfg(test)]
 mod tests {
     use crate::parse;

--- a/crates/duke-gc/src/fuzz.rs
+++ b/crates/duke-gc/src/fuzz.rs
@@ -1,3 +1,4 @@
+//! Fuzzing utilities and hooks.
 #[cfg(test)]
 mod tests {
     use crate::Heap;

--- a/crates/duke-interpreter/src/fuzz.rs
+++ b/crates/duke-interpreter/src/fuzz.rs
@@ -1,3 +1,4 @@
+//! Fuzzing utilities and hooks.
 #[cfg(test)]
 mod tests {
     #![allow(clippy::large_stack_arrays)]

--- a/crates/duke-loader/src/fuzz.rs
+++ b/crates/duke-loader/src/fuzz.rs
@@ -1,3 +1,4 @@
+//! Fuzzing utilities and hooks.
 #[cfg(test)]
 mod tests {
     use crate::ZipLoader;

--- a/crates/duke-runtime/src/fuzz.rs
+++ b/crates/duke-runtime/src/fuzz.rs
@@ -1,3 +1,4 @@
+//! Fuzzing utilities and hooks.
 #[cfg(test)]
 mod tests {
     use crate::frame::Frame;

--- a/crates/duke-telemetry/src/helpers.rs
+++ b/crates/duke-telemetry/src/helpers.rs
@@ -7,8 +7,29 @@ pub mod ser_helpers {
 
     /// Core helper: serialize any `HashMap<K, V>` by formatting each key with `key_fn`.
     ///
+    /// This allows serialization of complex map keys that serde does not support natively,
+    /// by transforming the key into a formatted string on-the-fly.
+    ///
     /// ⚡ Bolt: Using `SerializeMap` to serialize directly removes the intermediate `HashMap`
     /// collection, avoiding heap allocations and hashing overhead during telemetry generation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use serde::Serialize;
+    /// use duke_telemetry::ser_helpers::keyed_map;
+    ///
+    /// #[derive(Serialize)]
+    /// struct MyWrapper {
+    ///     #[serde(serialize_with = "custom_ser")]
+    ///     map: HashMap<(i32, i32), String>,
+    /// }
+    ///
+    /// fn custom_ser<S: serde::Serializer>(map: &HashMap<(i32, i32), String>, ser: S) -> Result<S::Ok, S::Error> {
+    ///     keyed_map(map, ser, |(k1, k2)| format!("{}|{}", k1, k2))
+    /// }
+    /// ```
     pub fn keyed_map<K, V, S, F>(map: &HashMap<K, V>, ser: S, key_fn: F) -> Result<S::Ok, S::Error>
     where
         K: Eq + std::hash::Hash,
@@ -23,7 +44,23 @@ pub mod ser_helpers {
         map_ser.end()
     }
 
-    /// `HashMap<(class, method, pc), V>` → `"class::method@pc"`.
+    /// Serializes a `HashMap<(String, String, usize), V>` into a map with keys formatted as `"class::method@pc"`.
+    ///
+    /// Used for execution sites in telemetry data (e.g. tracking exceptions thrown at a specific instruction).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use serde::Serialize;
+    /// use duke_telemetry::ser_helpers::site3;
+    ///
+    /// #[derive(Serialize)]
+    /// struct SiteWrapper {
+    ///     #[serde(serialize_with = "site3")]
+    ///     map: HashMap<(String, String, usize), i32>,
+    /// }
+    /// ```
     pub fn site3<V: Serialize, S: serde::Serializer>(
         map: &HashMap<(String, String, usize), V>,
         ser: S,
@@ -31,7 +68,23 @@ pub mod ser_helpers {
         keyed_map(map, ser, |(c, m, pc)| format!("{c}::{m}@{pc}"))
     }
 
-    /// `HashMap<(class, cp_idx), V>` → `"class@cp"`.
+    /// Serializes a `HashMap<(String, u16), V>` into a map with keys formatted as `"class@cp"`.
+    ///
+    /// Used for constant pool resolution telemetry (e.g. tracking when a class resolves a specific CP index).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use serde::Serialize;
+    /// use duke_telemetry::ser_helpers::site2_u16;
+    ///
+    /// #[derive(Serialize)]
+    /// struct CpWrapper {
+    ///     #[serde(serialize_with = "site2_u16")]
+    ///     map: HashMap<(String, u16), String>,
+    /// }
+    /// ```
     pub fn site2_u16<V: Serialize, S: serde::Serializer>(
         map: &HashMap<(String, u16), V>,
         ser: S,
@@ -39,7 +92,23 @@ pub mod ser_helpers {
         keyed_map(map, ser, |(c, cp)| format!("{c}@{cp}"))
     }
 
-    /// `HashMap<(class, method), V>` → `"class::method"`.
+    /// Serializes a `HashMap<(String, String), V>` into a map with keys formatted as `"class::method"`.
+    ///
+    /// Used for method-level telemetry (e.g. tracking native boundary calls).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use serde::Serialize;
+    /// use duke_telemetry::ser_helpers::pair_str;
+    ///
+    /// #[derive(Serialize)]
+    /// struct MethodWrapper {
+    ///     #[serde(serialize_with = "pair_str")]
+    ///     map: HashMap<(String, String), i32>,
+    /// }
+    /// ```
     pub fn pair_str<V: Serialize, S: serde::Serializer>(
         map: &HashMap<(String, String), V>,
         ser: S,
@@ -47,7 +116,24 @@ pub mod ser_helpers {
         keyed_map(map, ser, |(c, m)| format!("{c}::{m}"))
     }
 
-    /// Serialize `HashSet<String>` as a sorted `Vec<String>` for deterministic output.
+    /// Serializes a `HashSet<String>` as a sorted `Vec<String>`.
+    ///
+    /// Ensures deterministic JSON output for telemetry reporting, which is critical for
+    /// snapshot testing and diffing.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashSet;
+    /// use serde::Serialize;
+    /// use duke_telemetry::ser_helpers::sorted_set;
+    ///
+    /// #[derive(Serialize)]
+    /// struct SetWrapper {
+    ///     #[serde(serialize_with = "sorted_set")]
+    ///     set: HashSet<String>,
+    /// }
+    /// ```
     pub fn sorted_set<S: serde::Serializer>(
         set: &std::collections::HashSet<String>,
         ser: S,

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<duke_classfile::CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<duke_classfile::CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/msg.txt
+++ b/msg.txt
@@ -1,0 +1,6 @@
+🎻 Bard: [documentation update]
+
+📖 Chapter: duke-telemetry ser_helpers
+🔦 Insight: Clarified undocumented serialization helpers and fuzzing modules
+🧪 Example: Added executable doctests for keyed_map and others
+🖼️ Preview: Generated docs successfully


### PR DESCRIPTION
Added missing module-level documentation for all `fuzz.rs` modules across the workspace (`duke-bytecode`, `duke-gc`, `duke-classfile`, `duke-runtime`, `duke-loader`, `duke-interpreter`). Added detailed Rustdoc (`///`) examples for all serialization helpers inside `duke-telemetry/src/helpers.rs` (e.g. `keyed_map`, `site3`, `site2_u16`, `pair_str`, `sorted_set`), complete with executable doctests using `serde`. Fixed minor compile errors (`duke/src/jar_diff.rs`) and updated the `.jules/bard.md` journal.

---
*PR created automatically by Jules for task [14842759452282595251](https://jules.google.com/task/14842759452282595251) started by @madmax983*