### PR TITLE
⚒️ Forge: Refactored jar_diff.rs nesting and variable naming

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**Refactoring `clippy` Closure Warnings**
+**Learning:** `clippy` occasionally flags closure inputs inside standard methods like `.and_then()` with `E0282: type annotations needed`. Adding explicit types (like `&Option<CpEntry>`) manually can lead to mismatched type signatures with standard library methods. The issue wasn't the closure itself, but rather `clippy` struggling because the previous `import` failure masked type resolution.
+**Action:** When seeing `E0282` in closures inside `.and_then()`, verify the surrounding imports and variable types are fully resolving first. Do not blindly add `|var: &Type|` explicit annotations, as they usually conflict with the standard method signature. Ensure all imports are correct, then the compiler can infer closure types automatically.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,13 +15,12 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<duke_classfile::CpEntry>| slot.as_ref())
         .and_then(|entry| {
-            if let CpEntry::Utf8(s) = entry {
-                Some(s.as_str())
-            } else {
-                None
-            }
+            let CpEntry::Utf8(s) = entry else {
+                return None;
+            };
+            Some(s.as_str())
         })
 }
 
@@ -38,14 +34,15 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
-    if let Some(CpEntry::Class { name_index }) = class_entry {
-        cp_str(cf, *name_index)
-            .unwrap_or("<invalid utf8>")
-            .to_string()
-    } else {
-        "<not a class ref>".to_string()
-    }
+        .and_then(|s: &Option<duke_classfile::CpEntry>| s.as_ref());
+
+    let Some(CpEntry::Class { name_index }) = class_entry else {
+        return "<not a class ref>".to_string();
+    };
+
+    cp_str(cf, *name_index)
+        .unwrap_or("<invalid utf8>")
+        .to_string()
 }
 
 #[cfg(feature = "nova")]
@@ -151,25 +148,28 @@ fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
 
     for entry_name in class_entries {
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            #[allow(clippy::collapsible_if)]
-            if let Ok(cf) = parse(&bytes) {
-                let class_name = resolve_class_name(&cf, cf.this_class);
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
 
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{class_name}::{name_str}{desc_str}");
+        let Ok(cf) = parse(&bytes) else {
+            continue;
+        };
 
-                    let mut hasher = DefaultHasher::new();
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            code.code.hash(&mut hasher);
-                        }
-                    }
-                    method_hashes.insert(full_name, hasher.finish());
+        let class_name = resolve_class_name(&cf, cf.this_class);
+
+        for method in &cf.methods {
+            let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+            let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+            let full_name = format!("{class_name}::{name_str}{desc_str}");
+
+            let mut hasher = DefaultHasher::new();
+            for attr in &method.attributes {
+                if let AttributeData::Code(code) = &attr.data {
+                    code.code.hash(&mut hasher);
                 }
             }
+            method_hashes.insert(full_name, hasher.finish());
         }
     }
     method_hashes

--- a/pr_desc.txt
+++ b/pr_desc.txt
@@ -1,0 +1,7 @@
+Title: ⚒️ Forge: Refactored jar_diff.rs nesting and variable naming
+
+Description:
+🚮 Smell: The `duke/src/jar_diff.rs` had deep `if let` and `.and_then` nesting inside `cp_str`, `resolve_class_name`, and `load_jar_methods`, combined with slightly ambiguous closures. `clippy` flagged that type annotations were needed for closures.
+✨ Solution: I flattened the `if let` pyramids using `else { return ...; }` Guard Clauses, avoiding multiple nested scopes. Replaced type closures in `.and_then` with explicitly typed parameters `|slot: &Option<duke_classfile::CpEntry>|` and simplified the return paths. Corrected unresolved import paths.
+🧼 Benefit: Reduced cognitive load by removing nesting. Early returns clarify exactly when things fail.
+🛡️ Verification: Tests passed. No logic changed. Checked with `cargo check`, `cargo clippy`, and `cargo test`.


### PR DESCRIPTION
Refactored `jar_diff.rs` to flatten "pyramids of doom" using early returns / guard clauses. Re-checked and fixed compilation.

---
*PR created automatically by Jules for task [8376148389460165862](https://jules.google.com/task/8376148389460165862) started by @madmax983*