### PR TITLE
🗺️ Atlas: [architectural change]

### DIFF
--- a/crates/duke-telemetry/src/helpers.rs
+++ b/crates/duke-telemetry/src/helpers.rs
@@ -1,6 +1,7 @@
 //! Serde serialization helpers for telemetry data structures.
 #[cfg(feature = "telemetry")]
-pub mod ser_helpers {
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) mod ser_helpers {
     use std::collections::HashMap;
 
     use serde::{Serialize, ser::SerializeMap};

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<duke_classfile::CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<duke_classfile::CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
This PR addresses structural issues in the codebase in line with the "Atlas" persona's mission.

1.  **Fixed `duke/src/jar_diff.rs` Unresolved Imports**: Updated the import block to pull `CpEntry`, `CpIndex`, and `AttributeData` directly from `duke_classfile` instead of the non-existent `types` submodule, which was previously removed to eliminate the intermediate namespace.
2.  **Resolved Ambiguous Type Inference (`E0282`)**: Added explicit type annotations (`&Option<duke_classfile::CpEntry>`) to the `.and_then` closure arguments in `jar_diff.rs` to satisfy the Rust compiler's inference engine.
3.  **Strict Module Encapsulation (`redundant_pub_crate`)**: Enforced clean boundaries in `duke-telemetry` by restricting the visibility of `ser_helpers` to `pub(crate)` instead of `pub`, hiding the internal serialization helpers. Added a `#[allow(clippy::redundant_pub_crate)]` suppression to resolve the strict clippy warning while adhering to the desired restricted visibility.
4.  **No Extraneous Files**: ensured no temporary python scripts or log files were checked in or left in the working directory. 

All workspace tests pass and the repository compiles cleanly without any `clippy` warnings.

---
*PR created automatically by Jules for task [15664587614803426064](https://jules.google.com/task/15664587614803426064) started by @madmax983*