### PR TITLE
⚒️ Forge: Refactor loops to iterator chains in jar_diff

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,6 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+**Iterator Pipelines Over Manual Loops**
+**Learning:** Manual loops that just collect diffs into new vectors add unnecessary verbosity and mutable state.
+**Action:** Replace manual `for` loops with iterator pipelines (`.difference().map().collect()`).

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -3,8 +3,7 @@
 
 #[cfg(feature = "nova")]
 use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    parse, {AttributeData, CpEntry, CpIndex},
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +17,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<duke_classfile::CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +37,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<duke_classfile::CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")
@@ -63,18 +62,12 @@ pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
     let keys1: HashSet<_> = map1.keys().collect();
     let keys2: HashSet<_> = map2.keys().collect();
 
-    let mut added = Vec::new();
-    let mut removed = Vec::new();
     let mut modified = Vec::new();
     let mut unchanged = 0;
 
-    for k in keys2.difference(&keys1) {
-        added.push((*k).clone());
-    }
+    let mut added: Vec<_> = keys2.difference(&keys1).map(|k| (*k).clone()).collect();
 
-    for k in keys1.difference(&keys2) {
-        removed.push((*k).clone());
-    }
+    let mut removed: Vec<_> = keys1.difference(&keys2).map(|k| (*k).clone()).collect();
 
     for k in keys1.intersection(&keys2) {
         if map1.get(*k) == map2.get(*k) {


### PR DESCRIPTION
Refactored manual loops in `duke/src/jar_diff.rs` to use iterator pipelines for computing set differences, eliminating unnecessary mutable state and verbosity. Also documented this learning in `.jules/forge.md`.

---
*PR created automatically by Jules for task [454345280319175679](https://jules.google.com/task/454345280319175679) started by @madmax983*