### PR TITLE
🗺️ Atlas: [architectural change]

### DIFF
--- a/crates/duke-telemetry/src/helpers.rs
+++ b/crates/duke-telemetry/src/helpers.rs
@@ -1,6 +1,7 @@
 //! Serde serialization helpers for telemetry data structures.
 #[cfg(feature = "telemetry")]
-pub mod ser_helpers {
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) mod ser_helpers {
     use std::collections::HashMap;
 
     use serde::{Serialize, ser::SerializeMap};

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -3,8 +3,7 @@
 
 #[cfg(feature = "nova")]
 use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    parse, AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +17,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<duke_classfile::CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +37,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<duke_classfile::CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
🗺️ Atlas: [architectural change]

🕸️ Tangle: The duke_classfile API exported an intermediate types module merely to re-export its inner types, and duke-telemetry exposed internal serialization helpers via pub mod ser_helpers. This creates confusing, leaky abstractions and redundant paths.
📐 Blueprint: Encapsulated both modules. In duke_classfile, replaced pub mod types with direct pub use statements at the crate root, eliminating the types namespace from the public API entirely. In duke_telemetry, reduced ser_helpers visibility to pub(crate). Fixed import resolution and type inference errors downstream in duke/src/jar_diff.rs.
🧱 Stability: Reduced coupling by encapsulating internal implementation details and creating cleaner public APIs.
🔬 Verification: Ran cargo clippy, cargo test, and cargo fmt. Builds successfully, strict separation enforced.

---
*PR created automatically by Jules for task [15951672919968502606](https://jules.google.com/task/15951672919968502606) started by @madmax983*