### PR TITLE
🔭 Vantage: Spec for Thread Context ClassLoader

### DIFF
--- a/docs/vantage-spec-thread-context-classloader.md
+++ b/docs/vantage-spec-thread-context-classloader.md
@@ -1,0 +1,20 @@
+# 🔭 Vantage: Spec for Thread Context ClassLoader
+
+## 👤 User Story
+As a Java Application Developer using the Duke JVM, I want the Thread.getContextClassLoader() method to function correctly, so that standard library and third-party frameworks (like slf4j) can dynamically load resources and classes appropriate to the execution context.
+
+## 💡 So What? (Business Problem)
+Without the Context ClassLoader (TCCL), enterprise frameworks fail to boot on Duke. Java relies heavily on TCCL to load service providers and resources. The immediate business value is unblocking slf4j-simple smoke tests, allowing Duke to run standard OSS logging out of the box.
+
+## 📏 Success Metrics
+- Success = slf4j-simple-2.0.13 OSS JAR smoke test progresses past the Thread.getContextClassLoader() call.
+- Overhead < 1us.
+
+## ✅ Acceptance Criteria
+- Must support java/lang/Thread.getContextClassLoader()Ljava/lang/ClassLoader;.
+- By default, a newly created thread must inherit the Context ClassLoader of its parent thread.
+- If called by the primordial/main thread, it should return the System ClassLoader.
+
+## 🚫 Out of Scope
+- Complete OSGi or Java 9 Module System classloader isolation layers.
+- SecurityManager checks for fetching/setting the TCCL.


### PR DESCRIPTION
🔭 Vantage: Spec for Thread Context ClassLoader

👤 User Story:
As a Java Application Developer using the Duke JVM, I want the Thread.getContextClassLoader() method to function correctly, so that standard library and third-party frameworks (like slf4j) can dynamically load resources.

✅ Acceptance Criteria:
- Must support java/lang/Thread.getContextClassLoader()Ljava/lang/ClassLoader;.
- Newly created threads must inherit the parent's context classloader.
- The slf4j-simple smoke test must progress past the TCCL check.

🚫 Out of Scope:
- Complete OSGi or Java 9 Module System classloader isolation layers.
- SecurityManager checks.

---
*PR created automatically by Jules for task [8709555859909638836](https://jules.google.com/task/8709555859909638836) started by @madmax983*