### PR TITLE
🗺️ Atlas: [Encapsulate Module Facades]

### DIFF
--- a/crates/duke-telemetry/src/helpers.rs
+++ b/crates/duke-telemetry/src/helpers.rs
@@ -1,6 +1,7 @@
 //! Serde serialization helpers for telemetry data structures.
 #[cfg(feature = "telemetry")]
-pub mod ser_helpers {
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) mod ser_helpers {
     use std::collections::HashMap;
 
     use serde::{Serialize, ser::SerializeMap};

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -3,8 +3,7 @@
 
 #[cfg(feature = "nova")]
 use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    parse, AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +17,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<duke_classfile::CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +37,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<duke_classfile::CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
Encapsulated the `ser_helpers` module in `duke-telemetry` to restrict its visibility to `pub(crate)` and fixed a residual compilation error in `duke/src/jar_diff.rs` caused by a prior architectural change in `duke-classfile`.

---
*PR created automatically by Jules for task [8742274502607265133](https://jules.google.com/task/8742274502607265133) started by @madmax983*