### PR TITLE
👺 Havoc: Fix thread interrupt leak race

### DIFF
--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -11572,11 +11572,10 @@ fn register_java_host_thread(host_key: i32, host_thread_id: std::thread::ThreadI
 }
 
 fn unregister_java_host_thread(host_key: i32) {
-    let removed_host_thread = java_thread_hosts()
+    let mut hosts_write = java_thread_hosts()
         .write()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .remove(&host_key);
-    if let Some(host_thread_id) = removed_host_thread {
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(host_thread_id) = hosts_write.remove(&host_key) {
         interrupted_host_threads()
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -11601,11 +11600,16 @@ fn java_host_key_for_current_host() -> Option<i32> {
         .find_map(|(host_key, mapped_host)| (*mapped_host == host_thread_id).then_some(*host_key))
 }
 
-fn interrupt_host_thread(host_thread_id: std::thread::ThreadId) {
-    interrupted_host_threads()
-        .write()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .insert(host_thread_id);
+fn interrupt_host_thread_by_key(host_key: i32) {
+    let hosts_read = java_thread_hosts()
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(&host_thread_id) = hosts_read.get(&host_key) {
+        interrupted_host_threads()
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(host_thread_id);
+    }
 }
 
 fn current_host_thread_is_interrupted() -> bool {
@@ -13323,9 +13327,7 @@ pub(crate) fn native_thread_interrupt(
         _ => -1,
     };
     heap.write_field(thread_ref, THREAD_INTERRUPTED_SLOT, Slot::Int(1))?;
-    if let Some(host_thread_id) = host_thread_for_java_thread(host_key) {
-        interrupt_host_thread(host_thread_id);
-    }
+    interrupt_host_thread_by_key(host_key);
     Ok(None)
 }
 
@@ -21185,7 +21187,7 @@ fn spawn_java_thread(
             )
         };
         if interrupted_before_start {
-            interrupt_host_thread(host_thread_id);
+            interrupt_host_thread_by_key(host_key);
         }
         let result = run_thread_to_completion(state, &shared_clone, &runtime_clone, &loader_clone);
         {

--- a/crates/duke-interpreter/tests/havoc_thread_interrupt_leak_loom.rs
+++ b/crates/duke-interpreter/tests/havoc_thread_interrupt_leak_loom.rs
@@ -1,0 +1,47 @@
+#![allow(missing_docs)]
+#![allow(clippy::significant_drop_tightening)]
+use loom::sync::RwLock;
+use loom::thread;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+#[test]
+fn test_interrupted_thread_leak_race() {
+    loom::model(|| {
+        let hosts = Arc::new(RwLock::new(HashMap::<i32, loom::thread::ThreadId>::new()));
+        let interrupted = Arc::new(RwLock::new(HashSet::<loom::thread::ThreadId>::new()));
+
+        let target_id = loom::thread::current().id();
+        hosts.write().unwrap().insert(1, target_id);
+
+        let h1 = hosts.clone();
+        let i1 = interrupted.clone();
+        // Thread 1: unregister
+        let t1 = thread::spawn(move || {
+            let mut hosts_write = h1.write().unwrap();
+            let removed = hosts_write.remove(&1);
+            if let Some(id) = removed {
+                i1.write().unwrap().remove(&id);
+            }
+        });
+
+        let h2 = hosts;
+        let i2 = interrupted.clone();
+        // Thread 2: interrupt
+        let t2 = thread::spawn(move || {
+            let hosts_read = h2.read().unwrap();
+            let id = hosts_read.get(&1).copied();
+            if let Some(id) = id {
+                i2.write().unwrap().insert(id);
+            }
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+
+        assert!(
+            interrupted.read().unwrap().is_empty(),
+            "Leak detected: thread ID remained in interrupted set after unregistration"
+        );
+    });
+}


### PR DESCRIPTION
Fixes a Time-of-Check to Time-of-Use race condition in `duke-interpreter` where `Thread.interrupt()` executing concurrently with thread exit causes the host thread ID to be leaked permanently in the `interrupted_host_threads` set. Validated with a new Loom model test.

---
*PR created automatically by Jules for task [10747180486630302459](https://jules.google.com/task/10747180486630302459) started by @madmax983*