### PR TITLE
👺 Havoc: Fix OOM Capacity Overflow in JImageReader

### DIFF
--- a/crates/duke-loader/src/jimage.rs
+++ b/crates/duke-loader/src/jimage.rs
@@ -407,7 +407,9 @@ fn build_index(
     // To prevent OOM crashes from huge allocations (e.g. 0x3FFFFFFF), we clamp it.
     // Since each location entry requires at least one END byte (1 byte),
     // the absolute maximum number of entries is `locs_size`.
-    let safe_capacity = capacity.min(locs_size);
+    // We also clamp it against `data.len()` to prevent capacity overflow panics
+    // when `locs_size` is spoofed to be larger than the physical file size.
+    let safe_capacity = capacity.min(locs_size).min(data.len());
     let mut index = HashMap::with_capacity(safe_capacity);
     let mut pos = locs_offset;
     let locs_end = locs_offset + locs_size;


### PR DESCRIPTION
👺 Havoc: Fix OOM Capacity Overflow in JImageReader

🧨 **The Trigger:** A malicious jimage file with a spoofed `resource_count` (capacity) and `locs_size` causes `HashMap::with_capacity` to attempt allocating an impossibly large block of memory, resulting in a capacity overflow panic.
📉 **The Stack Trace:** `panic in a destructor during cleanup: capacity overflow` in `HashMap::with_capacity`.
🧪 **Reproduction:** Run a proptest that fuzzes `resource_count` and `locs_size` fields in the jimage header.
😈 **Comment:** You blindly trusted the header's capacity and `locs_size` to pre-allocate memory without bounding it against the actual physical size of the file.

---
*PR created automatically by Jules for task [11816905467870906027](https://jules.google.com/task/11816905467870906027) started by @madmax983*