### PR TITLE
⚒️ Forge: [Refactor parse_cp_entry]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,6 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+**Extract Helper for CpEntry match**
+**Learning:** `parse_cp_entry` was a God Function containing a large inline `match` spanning 69 lines for all JVM constant pool types. This creates a Pyramid of Doom and decreases readability.
+**Action:** Extract large match arms out of God Functions into strictly-typed helper functions (e.g., `parse_utf8`, `parse_method_handle`) to flatten the structure and adhere to YAGNI/DRY.

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -271,8 +271,12 @@ fn parse_cp_entry(c: &mut Cursor<'_>, tag: u8, i: usize) -> Result<CpEntry> {
         4 => Ok(CpEntry::Float(c.read_f32()?)),
         5 => Ok(CpEntry::Long(c.read_i64()?)),
         6 => Ok(CpEntry::Double(c.read_f64()?)),
-        7 => Ok(CpEntry::Class { name_index: c.read_cp_index()? }),
-        8 => Ok(CpEntry::String { string_index: c.read_cp_index()? }),
+        7 => Ok(CpEntry::Class {
+            name_index: c.read_cp_index()?,
+        }),
+        8 => Ok(CpEntry::String {
+            string_index: c.read_cp_index()?,
+        }),
         9 => Ok(CpEntry::Fieldref {
             class_index: c.read_cp_index()?,
             name_and_type_index: c.read_cp_index()?,
@@ -290,7 +294,9 @@ fn parse_cp_entry(c: &mut Cursor<'_>, tag: u8, i: usize) -> Result<CpEntry> {
             descriptor_index: c.read_cp_index()?,
         }),
         15 => parse_method_handle(c),
-        16 => Ok(CpEntry::MethodType { descriptor_index: c.read_cp_index()? }),
+        16 => Ok(CpEntry::MethodType {
+            descriptor_index: c.read_cp_index()?,
+        }),
         17 => Ok(CpEntry::Dynamic {
             bootstrap_method_attr_index: c.read_u16()?,
             name_and_type_index: c.read_cp_index()?,
@@ -299,8 +305,12 @@ fn parse_cp_entry(c: &mut Cursor<'_>, tag: u8, i: usize) -> Result<CpEntry> {
             bootstrap_method_attr_index: c.read_u16()?,
             name_and_type_index: c.read_cp_index()?,
         }),
-        19 => Ok(CpEntry::Module { name_index: c.read_cp_index()? }),
-        20 => Ok(CpEntry::Package { name_index: c.read_cp_index()? }),
+        19 => Ok(CpEntry::Module {
+            name_index: c.read_cp_index()?,
+        }),
+        20 => Ok(CpEntry::Package {
+            name_index: c.read_cp_index()?,
+        }),
         other => Err(Error::UnknownCpTag {
             tag: other,
             index: u16::try_from(i).unwrap_or(u16::MAX),

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -244,24 +244,35 @@ fn parse_class_file(c: &mut Cursor<'_>) -> Result<ClassFile> {
 // Constant pool (§4.4)
 // ---------------------------------------------------------------------------
 
+fn parse_utf8(c: &mut Cursor<'_>) -> Result<CpEntry> {
+    let len = c.read_u16()? as usize;
+    let bytes = c.read_bytes(len)?;
+    let s = String::from_utf8(bytes.to_vec())?;
+    Ok(CpEntry::Utf8(s))
+}
+
+fn parse_method_handle(c: &mut Cursor<'_>) -> Result<CpEntry> {
+    let reference_kind = c.read_u8()?;
+    if !(1..=9).contains(&reference_kind) {
+        return Err(Error::InvalidMethodHandleKind {
+            kind: reference_kind,
+        });
+    }
+    Ok(CpEntry::MethodHandle {
+        reference_kind,
+        reference_index: c.read_cp_index()?,
+    })
+}
+
 fn parse_cp_entry(c: &mut Cursor<'_>, tag: u8, i: usize) -> Result<CpEntry> {
     match tag {
-        1 => {
-            let len = c.read_u16()? as usize;
-            let bytes = c.read_bytes(len)?;
-            let s = String::from_utf8(bytes.to_vec())?;
-            Ok(CpEntry::Utf8(s))
-        }
+        1 => parse_utf8(c),
         3 => Ok(CpEntry::Integer(c.read_i32()?)),
         4 => Ok(CpEntry::Float(c.read_f32()?)),
         5 => Ok(CpEntry::Long(c.read_i64()?)),
         6 => Ok(CpEntry::Double(c.read_f64()?)),
-        7 => Ok(CpEntry::Class {
-            name_index: c.read_cp_index()?,
-        }),
-        8 => Ok(CpEntry::String {
-            string_index: c.read_cp_index()?,
-        }),
+        7 => Ok(CpEntry::Class { name_index: c.read_cp_index()? }),
+        8 => Ok(CpEntry::String { string_index: c.read_cp_index()? }),
         9 => Ok(CpEntry::Fieldref {
             class_index: c.read_cp_index()?,
             name_and_type_index: c.read_cp_index()?,
@@ -278,21 +289,8 @@ fn parse_cp_entry(c: &mut Cursor<'_>, tag: u8, i: usize) -> Result<CpEntry> {
             name_index: c.read_cp_index()?,
             descriptor_index: c.read_cp_index()?,
         }),
-        15 => {
-            let reference_kind = c.read_u8()?;
-            if !(1..=9).contains(&reference_kind) {
-                return Err(Error::InvalidMethodHandleKind {
-                    kind: reference_kind,
-                });
-            }
-            Ok(CpEntry::MethodHandle {
-                reference_kind,
-                reference_index: c.read_cp_index()?,
-            })
-        }
-        16 => Ok(CpEntry::MethodType {
-            descriptor_index: c.read_cp_index()?,
-        }),
+        15 => parse_method_handle(c),
+        16 => Ok(CpEntry::MethodType { descriptor_index: c.read_cp_index()? }),
         17 => Ok(CpEntry::Dynamic {
             bootstrap_method_attr_index: c.read_u16()?,
             name_and_type_index: c.read_cp_index()?,
@@ -301,12 +299,8 @@ fn parse_cp_entry(c: &mut Cursor<'_>, tag: u8, i: usize) -> Result<CpEntry> {
             bootstrap_method_attr_index: c.read_u16()?,
             name_and_type_index: c.read_cp_index()?,
         }),
-        19 => Ok(CpEntry::Module {
-            name_index: c.read_cp_index()?,
-        }),
-        20 => Ok(CpEntry::Package {
-            name_index: c.read_cp_index()?,
-        }),
+        19 => Ok(CpEntry::Module { name_index: c.read_cp_index()? }),
+        20 => Ok(CpEntry::Package { name_index: c.read_cp_index()? }),
         other => Err(Error::UnknownCpTag {
             tag: other,
             index: u16::try_from(i).unwrap_or(u16::MAX),

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    AttributeData, CpEntry, CpIndex,
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
⚒️ Forge: [Refactor parse_cp_entry]

🚮 Smell: `parse_cp_entry` was a God Function containing a large inline `match` spanning 69 lines for all JVM constant pool types. This creates a Pyramid of Doom and decreases readability.
✨ Solution: Extracted the long `Utf8` parsing block into a `parse_utf8` helper function and the `MethodHandle` parsing block into a `parse_method_handle` helper function.
🧼 Benefit: Flattens the `parse_cp_entry` match statement, improving readability and adhering to YAGNI/DRY.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [12013922815268046273](https://jules.google.com/task/12013922815268046273) started by @madmax983*