### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,6 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+## 2024-05-28 - Telemetry Store Exporters
+**Confusion:** I attempted to add `/// # Examples` and `# Panics` across `duke-telemetry` using boilerplate, but realized they are redundant and violate the Bard persona's rule against boilerplate and noise, leading to multiple PR rejections. The original files actually do have un-headed examples under their doc comments.
+**Clarification:** Fixed only the genuine compilation issue in `jar_diff.rs` where `types` import was removed and closure type inference failed, to at least make `cargo clippy` pass cleanly on the codebase.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(Option::as_ref)
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(Option::as_ref);
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
📖 Chapter: The `jar_diff` module
💡 Insight: Fixed unresolved `duke_classfile` imports and type inference closure issues in `jar_diff.rs`.
🧪 Example: Clean `cargo clippy --all-targets --all-features -- -D warnings` run.
🖼️ Preview: Compilation fixed.

---
*PR created automatically by Jules for task [5405786792310809664](https://jules.google.com/task/5405786792310809664) started by @madmax983*