### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,7 @@
 **Trust the Iterator: .collect() is Optimized**
 **Learning:** In Rust, `.collect::<Vec<_>>()` called on an `ExactSizeIterator` (which `slice.iter().map()` implements) already knows the exact number of elements. The standard library heavily optimizes this via the `TrustedLen` trait to allocate the precise capacity upfront and completely bypass bounds checks during insertion.
 **Action:** Do not manually replace `.collect::<Vec<_>>()` with `Vec::with_capacity` and a `for` loop, as it re-introduces bounds checks on every push, making the "optimization" unidiomatic and a micro-regression.
+
+**Removed intermediate HashSet allocations in jar_diff**
+**Learning:** Intermediate collections like `.collect::<HashSet<_>>()` used just for computing set differences create unnecessary heap allocations. We can avoid this entirely by directly iterating over the keys of the HashMaps and checking for containment in the other.
+**Action:** When finding differences or intersections between two HashMaps, avoid allocating temporary `HashSet`s. Instead, directly iterate over the maps and use `.contains_key()` or `.get()`.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -8,7 +8,7 @@ use duke_classfile::{
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::Path;
 
@@ -60,27 +60,27 @@ pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
     let map1 = load_jar_methods(jar1_path);
     let map2 = load_jar_methods(jar2_path);
 
-    let keys1: HashSet<_> = map1.keys().collect();
-    let keys2: HashSet<_> = map2.keys().collect();
-
+    /// ⚡ Bolt: Removed intermediate HashSet allocations by iterating directly over HashMaps.
     let mut added = Vec::new();
     let mut removed = Vec::new();
     let mut modified = Vec::new();
     let mut unchanged = 0;
 
-    for k in keys2.difference(&keys1) {
-        added.push((*k).clone());
-    }
-
-    for k in keys1.difference(&keys2) {
-        removed.push((*k).clone());
-    }
-
-    for k in keys1.intersection(&keys2) {
-        if map1.get(*k) == map2.get(*k) {
-            unchanged += 1;
+    for (k, v2) in &map2 {
+        if let Some(v1) = map1.get(k) {
+            if v1 == v2 {
+                unchanged += 1;
+            } else {
+                modified.push(k.clone());
+            }
         } else {
-            modified.push((*k).clone());
+            added.push(k.clone());
+        }
+    }
+
+    for k in map1.keys() {
+        if !map2.contains_key(k) {
+            removed.push(k.clone());
         }
     }
 

--- a/pr_desc.txt
+++ b/pr_desc.txt
@@ -1,0 +1,4 @@
+💡 What: Replaced intermediate `HashSet` allocations with direct `HashMap` iteration when diffing jars.
+🎯 Why: Creating two full `HashSet`s of keys from both HashMaps was an unnecessary memory allocation bottleneck on the hot path just to compute the difference and intersection.
+📊 Impact: Removes two O(N) heap allocations (one for each map) per jar diff operation.
+🔬 Measurement: Run `cargo test` to verify logic correctness, and bench `dump_jar_diff` to see the win.


### PR DESCRIPTION
💡 What: Replaced intermediate `HashSet` allocations with direct `HashMap` iteration when diffing jars.
🎯 Why: Creating two full `HashSet`s of keys from both HashMaps was an unnecessary memory allocation bottleneck on the hot path just to compute the difference and intersection.
📊 Impact: Removes two O(N) heap allocations (one for each map) per jar diff operation.
🔬 Measurement: Run `cargo test` to verify logic correctness, and bench `dump_jar_diff` to see the win.

---
*PR created automatically by Jules for task [15710801147233662817](https://jules.google.com/task/15710801147233662817) started by @madmax983*