### PR TITLE
👺 Havoc: Fix out-of-bounds panic in Regex Matcher on multi-byte unicode strings

### DIFF
--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -28085,10 +28085,14 @@ fn next_find_pos(input: &str, start: usize, end: usize) -> usize {
     if start != end || end >= input.len() {
         return end;
     }
-    input[end..]
+    let mut safe_end = end;
+    while safe_end < input.len() && !input.is_char_boundary(safe_end) {
+        safe_end += 1;
+    }
+    input[safe_end..]
         .chars()
         .next()
-        .map_or(end, |ch| end + ch.len_utf8())
+        .map_or(safe_end, |ch| safe_end + ch.len_utf8())
 }
 
 fn store_matcher_match(
@@ -38212,4 +38216,24 @@ mod tests_sentry {
         assert!(matches!(err_bool, crate::Error::InvalidRef { address: _ }));
     }
 
+}
+
+#[cfg(test)]
+mod havoc_matcher_bounds_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn test_next_find_pos_panics_on_invalid_boundary(
+            s in ".*",
+            end in 0..1000usize
+        ) {
+            let start = end;
+            if start <= s.len() && !s.is_char_boundary(end) {
+                // This should no longer trigger a panic.
+                let _ = next_find_pos(&s, start, end);
+            }
+        }
+    }
 }


### PR DESCRIPTION
👺 Havoc: Fix out-of-bounds panic in Regex Matcher on multi-byte unicode strings

🧨 **The Trigger:** Random non-character boundary indices pushed into the Regex Matcher `pos` field via Reflection or malicious bytes, causing `input[end..]` to panic.
📉 **The Stack Trace:**
```
thread 'main' panicked at test_next_find_pos.rs:5:10:
byte index 2 is not a char boundary; it is inside '💣' (bytes 1..5) of `a💣b`
```
🧪 **Reproduction:** Run `cargo test havoc_matcher_bounds_tests -p duke-interpreter`
😈 **Comment:** You assumed attackers wouldn't modify the regex matcher array state or throw emojis at your offset logic. You were wrong.

---
*PR created automatically by Jules for task [8655457556074349668](https://jules.google.com/task/8655457556074349668) started by @madmax983*