### PR TITLE
⚒️ Forge: Refactor jar_diff.rs iterators and guard clauses

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**[Flattening Loop Pyramids]**
+**Learning:** `load_jar_methods` in `duke/src/jar_diff.rs` had deep nesting (`if let Ok(...) { if let Ok(...) { ... } }`) inside a `for` loop, which makes the core logic hard to follow.
+**Action:** When extracting results in a loop, use `let Ok(...) = ... else { continue; };` guard clauses to immediately skip to the next iteration on failure, allowing the main loop body to remain flat and readable.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")
@@ -63,26 +60,16 @@ pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
     let keys1: HashSet<_> = map1.keys().collect();
     let keys2: HashSet<_> = map2.keys().collect();
 
-    let mut added = Vec::new();
-    let mut removed = Vec::new();
-    let mut modified = Vec::new();
-    let mut unchanged = 0;
+    let mut added: Vec<String> = keys2.difference(&keys1).map(|k| (*k).clone()).collect();
+    let mut removed: Vec<String> = keys1.difference(&keys2).map(|k| (*k).clone()).collect();
 
-    for k in keys2.difference(&keys1) {
-        added.push((*k).clone());
-    }
+    let mut modified: Vec<String> = keys1
+        .intersection(&keys2)
+        .filter(|k| map1.get(**k) != map2.get(**k))
+        .map(|k| (*k).clone())
+        .collect();
 
-    for k in keys1.difference(&keys2) {
-        removed.push((*k).clone());
-    }
-
-    for k in keys1.intersection(&keys2) {
-        if map1.get(*k) == map2.get(*k) {
-            unchanged += 1;
-        } else {
-            modified.push((*k).clone());
-        }
-    }
+    let unchanged = keys1.intersection(&keys2).count() - modified.len();
 
     added.sort();
     removed.sort();
@@ -151,25 +138,27 @@ fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
 
     for entry_name in class_entries {
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            #[allow(clippy::collapsible_if)]
-            if let Ok(cf) = parse(&bytes) {
-                let class_name = resolve_class_name(&cf, cf.this_class);
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
+        let Ok(cf) = parse(&bytes) else {
+            continue;
+        };
 
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{class_name}::{name_str}{desc_str}");
+        let class_name = resolve_class_name(&cf, cf.this_class);
 
-                    let mut hasher = DefaultHasher::new();
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            code.code.hash(&mut hasher);
-                        }
-                    }
-                    method_hashes.insert(full_name, hasher.finish());
+        for method in &cf.methods {
+            let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+            let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+            let full_name = format!("{class_name}::{name_str}{desc_str}");
+
+            let mut hasher = DefaultHasher::new();
+            for attr in &method.attributes {
+                if let AttributeData::Code(code) = &attr.data {
+                    code.code.hash(&mut hasher);
                 }
             }
+            method_hashes.insert(full_name, hasher.finish());
         }
     }
     method_hashes

--- a/msg.txt
+++ b/msg.txt
@@ -1,0 +1,6 @@
+⚒️ Forge: Refactor jar_diff.rs iterators and guard clauses
+
+🚮 Smell: The file `duke/src/jar_diff.rs` contained unnecessary mutation with manual `for` loops appending to vectors, deeply nested `if let` blocks inside loops (Pyramid of Doom), and failed to compile under `--features nova` due to invalid imports and missing type annotations.
+✨ Solution: Replaced manual difference/intersection loops with idiomatic `.filter().map().collect()` pipelines. Flattened nested `if let Ok` blocks using `let Ok(...) = ... else { continue; };` guard clauses. Fixed imports and type annotations.
+🧼 Benefit: The main logic loop is strictly flatter and easier to trace, and iterating difference sets avoids mutable state. Also restores `--all-features` compilability.
+🛡️ Verification: Tests passed. No logic changed.

--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,0 +1,6 @@
+⚒️ Forge: Fix unresolved import and missing type annotations in jar_diff.rs
+
+🚮 Smell: The file `duke/src/jar_diff.rs` was failing to compile under the `nova` feature due to attempting to import `duke_classfile::types` which does not exist (the items are exported at the root), and missing explicit type annotations on closures inside `Option::and_then`.
+✨ Solution: Removed the non-existent `types::` module qualifier from imports, and provided explicit type annotations (`&Option<CpEntry>`) for the closure arguments in `cp_str` and `resolve_class_name`.
+🧼 Benefit: Allows `duke` to compile successfully with the `--all-features` flag, fixing build failures and maintaining compile-time safety.
+🛡️ Verification: Tests passed. No logic changed.


### PR DESCRIPTION
⚒️ Forge: Refactor jar_diff.rs iterators and guard clauses

🚮 Smell: The file `duke/src/jar_diff.rs` contained unnecessary mutation with manual `for` loops appending to vectors, deeply nested `if let` blocks inside loops (Pyramid of Doom), and failed to compile under `--features nova` due to invalid imports and missing type annotations.
✨ Solution: Replaced manual difference/intersection loops with idiomatic `.filter().map().collect()` pipelines. Flattened nested `if let Ok` blocks using `let Ok(...) = ... else { continue; };` guard clauses. Fixed imports and type annotations.
🧼 Benefit: The main logic loop is strictly flatter and easier to trace, and iterating difference sets avoids mutable state. Also restores `--all-features` compilability.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [2205483423501100203](https://jules.google.com/task/2205483423501100203) started by @madmax983*