### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,7 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+
+## 2024-05-29 - [JarDiff Documentation and Cascading Types]
+**Confusion:** The `duke/src/jar_diff.rs` module lacked documentation, obscuring its purpose of comparing JAR bytecodes. In addition, an unresolved import of `CpEntry` caused cascading type inference errors (`E0282`) on closures, confusing the real issue.
+**Clarification:** Documented the module and `dump_jar_diff` to explain how it tracks structural changes. Resolved the `E0432` import error, which automatically fixed the closure type inference errors, proving that fixing unresolved imports should always precede adding explicit types.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -1,11 +1,15 @@
+//! Utility for analyzing and comparing the bytecode contents of two JAR files.
+//!
+//! This module provides tools to track methods added, removed, or modified between
+//! two versions of a JAR. It determines modification by hashing the raw bytecode
+//! of every method. This is invaluable when diagnosing unexpected behavior changes
+//! in third-party dependencies or validating backward compatibility.
+
 #![allow(clippy::items_after_statements)]
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -56,6 +60,24 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     clippy::use_debug,
     clippy::collapsible_if
 )]
+/// Analyzes the bytecode differences between two JAR files and prints a summary to standard output.
+///
+/// This function loads all classes from both provided JAR paths and compares
+/// each method's `Code` attribute hash. It categorizes methods into added, removed,
+/// modified, and unchanged, and prints the top 10 methods in each category.
+///
+/// # Examples
+/// ```no_run
+/// use duke::jar_diff::dump_jar_diff;
+///
+/// // Compare an old library version with a new one
+/// dump_jar_diff("lib-v1.jar", "lib-v2.jar");
+/// ```
+///
+/// # Panics
+/// This function handles missing or malformed JARs gracefully and will not panic.
+/// It treats unreadable JAR files as empty, resulting in all methods appearing as
+/// added or removed relative to a valid JAR.
 pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
     let map1 = load_jar_methods(jar1_path);
     let map2 = load_jar_methods(jar2_path);

--- a/pr_desc.txt
+++ b/pr_desc.txt
@@ -1,0 +1,6 @@
+🎻 Bard: [documentation update]
+
+📖 Chapter: Documented the `jar_diff` module.
+🔦 Insight: Explained how the bytecode hash comparison determines method modifications and clarified that missing JARs are handled gracefully without panicking. Also fixed the cascading type inference issue by correcting the `types` module import.
+🧪 Example: Added a `no_run` doctest to `dump_jar_diff` illustrating standard usage.
+🖼️ Preview: Documentation for `dump_jar_diff` now accurately reflects its non-panicking nature.


### PR DESCRIPTION
🎻 Bard: [documentation update]

📖 Chapter: Documented the `jar_diff` module.
🔦 Insight: Explained how the bytecode hash comparison determines method modifications and clarified that missing JARs are handled gracefully without panicking. Also fixed the cascading type inference issue by correcting the `types` module import.
🧪 Example: Added a `no_run` doctest to `dump_jar_diff` illustrating standard usage.
🖼️ Preview: Documentation for `dump_jar_diff` now accurately reflects its non-panicking nature.

---
*PR created automatically by Jules for task [11702022376228033055](https://jules.google.com/task/11702022376228033055) started by @madmax983*