### PR TITLE
⚡ Bolt: Replace 2D Vec with 1D Vec in Bytecode Similarity calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,7 @@
 **Trust the Iterator: .collect() is Optimized**
 **Learning:** In Rust, `.collect::<Vec<_>>()` called on an `ExactSizeIterator` (which `slice.iter().map()` implements) already knows the exact number of elements. The standard library heavily optimizes this via the `TrustedLen` trait to allocate the precise capacity upfront and completely bypass bounds checks during insertion.
 **Action:** Do not manually replace `.collect::<Vec<_>>()` with `Vec::with_capacity` and a `for` loop, as it re-introduces bounds checks on every push, making the "optimization" unidiomatic and a micro-regression.
+
+## 2024-05-30 - Replace 2D Vec with 1D Vec in DP
+**Learning:** `vec![vec![0; len2 + 1]; len1 + 1]` inside `calculate_similarity` allocated `len1 + 1` separate vectors on the heap, making it O(M) allocations and O(M*N) memory usage.
+**Action:** Replaced it with a single 1D vector of length `len2 + 1` representing the dynamic programming rows, avoiding multiple allocations and improving locality.

--- a/crates/duke-bytecode/src/similarity.rs
+++ b/crates/duke-bytecode/src/similarity.rs
@@ -41,30 +41,26 @@ pub fn calculate_similarity(seq1: &[Instruction], seq2: &[Instruction]) -> f64 {
         return 0.0;
     }
 
-    let mut dp = vec![vec![0; len2 + 1]; len1 + 1];
-
-    for (i, row) in dp.iter_mut().enumerate().take(len1 + 1) {
-        row[0] = i;
-    }
-    for (j, item) in dp[0].iter_mut().enumerate().take(len2 + 1) {
-        *item = j;
-    }
+    // ⚡ Bolt: Removed 2D vector `vec![vec![...]]` to eliminate O(N) heap allocations
+    // and reduce memory usage from O(M*N) to O(N).
+    let mut dp: Vec<usize> = (0..=len2).collect();
 
     for i in 1..=len1 {
+        let mut prev_diag = dp[0];
+        dp[0] = i;
         for j in 1..=len2 {
+            let old_dp_j = dp[j];
             let cost = usize::from(discriminant(&seq1[i - 1]) != discriminant(&seq2[j - 1]));
 
-            dp[i][j] = std::cmp::min(
-                std::cmp::min(dp[i - 1][j] + 1, dp[i][j - 1] + 1),
-                dp[i - 1][j - 1] + cost,
-            );
+            dp[j] = std::cmp::min(std::cmp::min(dp[j] + 1, dp[j - 1] + 1), prev_diag + cost);
+            prev_diag = old_dp_j;
         }
     }
 
     #[allow(clippy::cast_precision_loss)]
     let max_len = std::cmp::max(len1, len2) as f64;
     #[allow(clippy::cast_precision_loss)]
-    let distance = dp[len1][len2] as f64;
+    let distance = dp[len2] as f64;
 
     1.0 - (distance / max_len)
 }

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
⚡ Bolt: Replace 2D Vec with 1D Vec in Bytecode Similarity calculation

💡 What: Replaced the O(N) allocation `vec![vec![0; len2 + 1]; len1 + 1]` with a 1D vector `vec![0; len2 + 1]` inside `calculate_similarity`.
🎯 Why: The original DP implementation created `len1 + 1` separate vectors on the heap inside a loop.
📊 Impact: Reduces memory usage from O(M*N) to O(N) and eliminates O(M) heap allocations per comparison.
🔬 Measurement: Run `cargo test -p duke-bytecode --features nova` or benchmarks to verify.

---
*PR created automatically by Jules for task [5577518837430809929](https://jules.google.com/task/5577518837430809929) started by @madmax983*