### PR TITLE
⚒️ Forge: Simplify imports and assist type inference in jar_diff.rs

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,6 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+**Unresolved imports due to invalid paths and Visual Clutter due to repeated full paths**
+**Learning:** `types::` module doesn't exist under `duke_classfile`, instead `AttributeData`, `CpEntry`, `CpIndex` are re-exported in the top-level module. Repeated usage of full paths like `duke_classfile::ClassFile` makes function parameters cluttered and harder to read.
+**Action:** Always verify paths for correctness and import structs/types directly to clean up function signatures and reduce visual clutter.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -3,8 +3,7 @@
 
 #[cfg(feature = "nova")]
 use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, ClassFile, CpEntry, CpIndex, parse,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -15,10 +14,10 @@ use std::path::Path;
 #[cfg(feature = "nova")]
 #[cfg(not(tarpaulin_include))]
 #[allow(unexpected_cfgs)]
-fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
+fn cp_str(cf: &ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -31,14 +30,14 @@ fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
 #[cfg(feature = "nova")]
 #[cfg(not(tarpaulin_include))]
 #[allow(unexpected_cfgs)]
-fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
+fn resolve_class_name(cf: &ClassFile, idx: CpIndex) -> String {
     if idx.0 == 0 {
         return "<none>".to_string();
     }
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,9 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    AttributeData, ClassFile, CpEntry, CpIndex, parse,
-};
+use duke_classfile::{AttributeData, ClassFile, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};


### PR DESCRIPTION
🚮 Smell: Invalid module path `types::` leading to missing import errors, and repeated full path `duke_classfile::ClassFile` in function parameters causing visual clutter.
✨ Solution: Corrected path for `AttributeData`, `CpEntry`, `CpIndex` as they are re-exported in the top-level module in `duke_classfile`. Imported `ClassFile` directly, and simplified type signatures. Re-added explicit type annotations to closures to assist the compiler with type inference after import resolution.
🧼 Benefit: Cleaned up imports and function signatures, strictly typed closures preventing inference errors.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [7415488400097001185](https://jules.google.com/task/7415488400097001185) started by @madmax983*