### PR TITLE
🛡️ Sentry: [test coverage improvement] Prevent OOM in JDWP GetValues

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -47,3 +47,6 @@
 ## 2024-05-24 - Testing ReentrantReadWriteLock Native Operations
 **Learning:** Found several native functions implementing `ReentrantReadWriteLock` and `PriorityQueue` operations missing test coverage in `duke-interpreter`. Adding dummy tests correctly executes these logic branches without needing fully mocked multi-threading scenarios.
 **Action:** Add inline unit tests using a mocked heap and manually setting up the `obj_ref` payload.
+## 2026-06-01 - Testing Network Payload Allocation Bounds
+**Learning:** Blindly trusting unvalidated `length` or `count` fields read from a network payload to pre-allocate collections (`Vec::with_capacity` or loops appending to arrays) is an uncatchable vector for Denial-of-Service OOM errors. Fuzzing or fuzzing-like tests sending massive allocation requests will identify missing boundary limit checks on those inputs.
+**Action:** When inspecting protocol parsers (like JDWP handlers), identify areas constructing collections and bound them to a reasonable size (e.g., `10_000` items) returning protocol-level errors like `ERR_OUT_OF_MEMORY` instead of overflowing or crashing the VM.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    AttributeData, CpEntry, CpIndex,
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/duke/src/jdwp.rs
+++ b/duke/src/jdwp.rs
@@ -7,6 +7,7 @@ const HANDSHAKE: &[u8] = b"JDWP-Handshake";
 const REPLY_FLAG: u8 = 0x80;
 const ERR_NONE: u16 = 0;
 const ERR_NOT_IMPLEMENTED: u16 = 99;
+const ERR_OUT_OF_MEMORY: u16 = 110;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct JdwpConfig {
@@ -171,6 +172,13 @@ fn dispatch_command(
             let count = payload
                 .get(8..12)
                 .map_or(0, |b| u32::from_be_bytes([b[0], b[1], b[2], b[3]]));
+
+            // Bound count to prevent OOM DOS
+            let max_safe_count = 10_000;
+            if count > max_safe_count {
+                return (ERR_OUT_OF_MEMORY, vec![], false);
+            }
+
             let mut out = Vec::new();
             out.extend_from_slice(&count.to_be_bytes());
             for _ in 0..count {
@@ -185,6 +193,13 @@ fn dispatch_command(
             let slots = payload
                 .get(8..12)
                 .map_or(0, |b| u32::from_be_bytes([b[0], b[1], b[2], b[3]]));
+
+            // Bound slots to prevent OOM DOS
+            let max_safe_slots = 10_000;
+            if slots > max_safe_slots {
+                return (ERR_OUT_OF_MEMORY, vec![], false);
+            }
+
             let mut out = Vec::new();
             out.extend_from_slice(&slots.to_be_bytes());
             for _ in 0..slots {
@@ -377,6 +392,24 @@ mod tests {
         assert_eq!(err, ERR_NOT_IMPLEMENTED);
         assert!(data.is_empty());
         assert!(!close);
+    }
+
+    #[test]
+    fn test_dispatch_command_get_values_oom() {
+        let req_id = AtomicI32::new(1);
+        let suspended = AtomicBool::new(false);
+
+        let mut payload = vec![0; 8];
+        payload.extend_from_slice(&1_000_000_u32.to_be_bytes()); // Count 1 million
+
+        // This would OOM or consume excessive memory if not bounded
+        let (err, data, _) = dispatch_command(9, 2, &payload, &req_id, &suspended);
+        assert_eq!(err, 110); // ERR_OUT_OF_MEMORY
+        assert!(data.is_empty());
+
+        let (err_stack, data_stack, _) = dispatch_command(16, 1, &payload, &req_id, &suspended);
+        assert_eq!(err_stack, 110);
+        assert!(data_stack.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement] Prevent OOM in JDWP GetValues

🎯 Target: `duke/src/jdwp.rs` (specifically `dispatch_command` for ObjectReference.GetValues and StackFrame.GetValues).
💣 Risk: Blindly trusting `count` and `slots` sizes from network payloads can cause uncatchable Out-Of-Memory (OOM) Denial of Service when creating allocations like `Vec::with_capacity` or extending collections dynamically.
🧪 Strategy: Bounded the requested size limits to a safe default (`10_000`) and explicitly returned the protocol's `ERR_OUT_OF_MEMORY` code on violation. Added a custom test `test_dispatch_command_get_values_oom` to verify OOM paths.
🔬 Verification: `cargo test --bin duke -- test_dispatch_command_get_values_oom`

---
*PR created automatically by Jules for task [8344489405596278015](https://jules.google.com/task/8344489405596278015) started by @madmax983*