### PR TITLE
🗺️ Atlas: [Encapsulate Module Facades]

### DIFF
--- a/crates/duke-bytecode/src/call_graph.rs
+++ b/crates/duke-bytecode/src/call_graph.rs
@@ -6,9 +6,7 @@
 use std::collections::BTreeSet;
 use std::fmt::Write;
 
-use duke_classfile::{
-    ClassFile, {AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, ClassFile, CpEntry, CpIndex};
 
 use crate::{Instruction, decode};
 

--- a/crates/duke-bytecode/src/lib.rs
+++ b/crates/duke-bytecode/src/lib.rs
@@ -40,9 +40,7 @@ pub use verifier::verify;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use duke_classfile::{
-        parse, {AttributeData, CpEntry},
-    };
+    use duke_classfile::{AttributeData, CpEntry, parse};
 
     // -----------------------------------------------------------------------
     // Helpers

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};


### PR DESCRIPTION
🗺️ Atlas: [Encapsulate Module Facades]

**Tangle:** The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types. This created confusing, leaky abstractions and redundant paths.
**Blueprint:** Encapsulated the module. Replaced `pub mod types` with direct `pub use` statements at the crate root, eliminating the `types` namespace from the public API entirely and fixing all downstream import usages.

---
*PR created automatically by Jules for task [12620399018266630899](https://jules.google.com/task/12620399018266630899) started by @madmax983*