### PR TITLE
⚒️ Forge: [Refactor jar_diff.rs pyramid of doom]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**[Refactoring jar_diff.rs Pyramid of Doom]**
+**Learning:** Nested `if let Ok` patterns often appear when parsing entries from a file and can easily be flattened using the new `let Ok(...) = ... else { ... }` syntax.
+**Action:** Default to using `else { continue; }` guard clauses within loops when skipping unparseable items instead of nesting further blocks.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -35,17 +32,17 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     if idx.0 == 0 {
         return "<none>".to_string();
     }
-    let class_entry = cf
+    let Some(CpEntry::Class { name_index }) = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
-    if let Some(CpEntry::Class { name_index }) = class_entry {
-        cp_str(cf, *name_index)
-            .unwrap_or("<invalid utf8>")
-            .to_string()
-    } else {
-        "<not a class ref>".to_string()
-    }
+        .and_then(|s| s.as_ref())
+    else {
+        return "<not a class ref>".to_string();
+    };
+
+    cp_str(cf, *name_index)
+        .unwrap_or("<invalid utf8>")
+        .to_string()
 }
 
 #[cfg(feature = "nova")]
@@ -151,25 +148,27 @@ fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
 
     for entry_name in class_entries {
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            #[allow(clippy::collapsible_if)]
-            if let Ok(cf) = parse(&bytes) {
-                let class_name = resolve_class_name(&cf, cf.this_class);
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
+        let Ok(cf) = parse(&bytes) else {
+            continue;
+        };
 
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{class_name}::{name_str}{desc_str}");
+        let class_name = resolve_class_name(&cf, cf.this_class);
 
-                    let mut hasher = DefaultHasher::new();
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            code.code.hash(&mut hasher);
-                        }
-                    }
-                    method_hashes.insert(full_name, hasher.finish());
+        for method in &cf.methods {
+            let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+            let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+            let full_name = format!("{class_name}::{name_str}{desc_str}");
+
+            let mut hasher = DefaultHasher::new();
+            for attr in &method.attributes {
+                if let AttributeData::Code(code) = &attr.data {
+                    code.code.hash(&mut hasher);
                 }
             }
+            method_hashes.insert(full_name, hasher.finish());
         }
     }
     method_hashes


### PR DESCRIPTION
⚒️ Forge: Refactor jar_diff.rs pyramid of doom

🚮 Smell: Nested `if let` statements (Pyramid of Doom) in `load_jar_methods` and `resolve_class_name`. Unresolved import on compilation.
✨ Solution: Fixed unresolved import. Used `else { continue; }` and `else { return; }` guard clauses to flatten the logic.
🧼 Benefit: Reduces nesting and cognitive load, improving readability. Fixes build.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [5520970786723636929](https://jules.google.com/task/5520970786723636929) started by @madmax983*