### PR TITLE
⚡ Bolt: optimize descriptor parsing with .as_bytes()

### DIFF
--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -23181,35 +23181,43 @@ fn parse_arg_count(descriptor: &str) -> usize {
         .and_then(|s| s.split_once(')'))
         .map_or("", |(p, _)| p);
     let mut count = 0;
-    let mut chars = params.chars().peekable();
-    while let Some(c) = chars.next() {
-        match c {
-            'B' | 'C' | 'D' | 'F' | 'I' | 'J' | 'S' | 'Z' => count += 1,
-            '[' => {
-                while chars.peek() == Some(&'[') {
-                    chars.next();
+    let bytes = params.as_bytes();
+    let mut idx = 0;
+    while idx < bytes.len() {
+        match bytes[idx] {
+            b'B' | b'C' | b'D' | b'F' | b'I' | b'J' | b'S' | b'Z' => {
+                count += 1;
+                idx += 1;
+            }
+            b'[' => {
+                idx += 1;
+                while idx < bytes.len() && bytes[idx] == b'[' {
+                    idx += 1;
                 }
-                if chars.peek() == Some(&'L') {
-                    chars.next();
-                    for c2 in chars.by_ref() {
-                        if c2 == ';' {
-                            break;
-                        }
+                if idx < bytes.len() && bytes[idx] == b'L' {
+                    idx += 1;
+                    while idx < bytes.len() && bytes[idx] != b';' {
+                        idx += 1;
+                    }
+                    if idx < bytes.len() {
+                        idx += 1;
                     }
                 } else {
-                    chars.next();
+                    idx += 1;
                 }
                 count += 1;
             }
-            'L' => {
-                for c2 in chars.by_ref() {
-                    if c2 == ';' {
-                        break;
-                    }
+            b'L' => {
+                idx += 1;
+                while idx < bytes.len() && bytes[idx] != b';' {
+                    idx += 1;
+                }
+                if idx < bytes.len() {
+                    idx += 1;
                 }
                 count += 1;
             }
-            _ => {}
+            _ => idx += 1,
         }
     }
     count
@@ -23323,36 +23331,44 @@ fn parse_arg_types(descriptor: &str) -> Vec<char> {
         .and_then(|s| s.split_once(')'))
         .map_or("", |(p, _)| p);
     let mut types = Vec::with_capacity(params.len());
-    let mut chars = params.chars().peekable();
-    while let Some(c) = chars.next() {
-        match c {
-            'B' | 'C' | 'D' | 'F' | 'I' | 'J' | 'S' | 'Z' => types.push(c),
-            '[' => {
+    let bytes = params.as_bytes();
+    let mut idx = 0;
+    while idx < bytes.len() {
+        match bytes[idx] {
+            b'B' | b'C' | b'D' | b'F' | b'I' | b'J' | b'S' | b'Z' => {
+                types.push(bytes[idx] as char);
+                idx += 1;
+            }
+            b'[' => {
                 // Skip array dimensions and element type.
-                while chars.peek() == Some(&'[') {
-                    chars.next();
+                idx += 1;
+                while idx < bytes.len() && bytes[idx] == b'[' {
+                    idx += 1;
                 }
-                if chars.peek() == Some(&'L') {
-                    chars.next();
-                    for c2 in chars.by_ref() {
-                        if c2 == ';' {
-                            break;
-                        }
+                if idx < bytes.len() && bytes[idx] == b'L' {
+                    idx += 1;
+                    while idx < bytes.len() && bytes[idx] != b';' {
+                        idx += 1;
+                    }
+                    if idx < bytes.len() {
+                        idx += 1;
                     }
                 } else {
-                    chars.next();
+                    idx += 1;
                 }
                 types.push('[');
             }
-            'L' => {
-                for c2 in chars.by_ref() {
-                    if c2 == ';' {
-                        break;
-                    }
+            b'L' => {
+                idx += 1;
+                while idx < bytes.len() && bytes[idx] != b';' {
+                    idx += 1;
+                }
+                if idx < bytes.len() {
+                    idx += 1;
                 }
                 types.push('L');
             }
-            _ => {}
+            _ => idx += 1,
         }
     }
     types
@@ -23535,39 +23551,44 @@ fn parse_arg_descriptors(descriptor: &str) -> Vec<String> {
         .and_then(|s| s.split_once(')'))
         .map_or("", |(p, _)| p);
     let mut descriptors = Vec::with_capacity(params.len());
-    let mut chars = params.chars().peekable();
-    while let Some(c) = chars.next() {
-        match c {
-            'B' | 'C' | 'D' | 'F' | 'I' | 'J' | 'S' | 'Z' => descriptors.push(c.to_string()),
-            '[' => {
-                let mut desc = String::from("[");
-                while chars.peek() == Some(&'[') {
-                    desc.push(chars.next().unwrap_or('['));
-                }
-                if chars.peek() == Some(&'L') {
-                    desc.push(chars.next().unwrap_or('L'));
-                    for c2 in chars.by_ref() {
-                        desc.push(c2);
-                        if c2 == ';' {
-                            break;
-                        }
-                    }
-                } else if let Some(elem) = chars.next() {
-                    desc.push(elem);
-                }
-                descriptors.push(desc);
+    let bytes = params.as_bytes();
+    let mut idx = 0;
+    while idx < bytes.len() {
+        let start = idx;
+        match bytes[idx] {
+            b'B' | b'C' | b'D' | b'F' | b'I' | b'J' | b'S' | b'Z' => {
+                descriptors.push((bytes[idx] as char).to_string());
+                idx += 1;
             }
-            'L' => {
-                let mut desc = String::from("L");
-                for c2 in chars.by_ref() {
-                    desc.push(c2);
-                    if c2 == ';' {
-                        break;
-                    }
+            b'[' => {
+                idx += 1;
+                while idx < bytes.len() && bytes[idx] == b'[' {
+                    idx += 1;
                 }
-                descriptors.push(desc);
+                if idx < bytes.len() && bytes[idx] == b'L' {
+                    idx += 1;
+                    while idx < bytes.len() && bytes[idx] != b';' {
+                        idx += 1;
+                    }
+                    if idx < bytes.len() {
+                        idx += 1;
+                    }
+                } else if idx < bytes.len() {
+                    idx += 1;
+                }
+                descriptors.push(String::from_utf8_lossy(&bytes[start..idx]).into_owned());
             }
-            _ => {}
+            b'L' => {
+                idx += 1;
+                while idx < bytes.len() && bytes[idx] != b';' {
+                    idx += 1;
+                }
+                if idx < bytes.len() {
+                    idx += 1;
+                }
+                descriptors.push(String::from_utf8_lossy(&bytes[start..idx]).into_owned());
+            }
+            _ => idx += 1,
         }
     }
     descriptors


### PR DESCRIPTION
💡 What: Replaced chars().peekable() iterators with byte-slice indexing (.as_bytes()) in parse_arg_count, parse_arg_types, and parse_arg_descriptors.
🎯 Why: JVM method descriptors are strictly ASCII strings. Decoding UTF-8 characters and managing peekable iterator state creates unnecessary overhead on a hot path during method resolution and execution. 
📊 Impact: Eliminates UTF-8 decoding overhead and iterator state tracking for parsing method signatures.
🔬 Measurement: Run cargo test -p duke-interpreter

---
*PR created automatically by Jules for task [4547850741793856312](https://jules.google.com/task/4547850741793856312) started by @madmax983*