### PR TITLE
Atlas: fix unused import in bytecode

### DIFF
--- a/crates/duke-bytecode/src/lib.rs
+++ b/crates/duke-bytecode/src/lib.rs
@@ -40,9 +40,7 @@ pub use verifier::verify;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use duke_classfile::{
-        parse, {AttributeData, CpEntry},
-    };
+    use duke_classfile::{AttributeData, CpEntry, parse};
 
     // -----------------------------------------------------------------------
     // Helpers

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<duke_classfile::CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<duke_classfile::CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
Fix unused import in bytecode crate to ensure tests pass and there are no clippy warnings.

---
*PR created automatically by Jules for task [483859661993304106](https://jules.google.com/task/483859661993304106) started by @madmax983*