### PR TITLE
👺 Havoc: [Panic] String.indexOf and String.lastIndexOf multi-byte split

### DIFF
--- a/.jules/havoc.md
+++ b/.jules/havoc.md
@@ -3,3 +3,8 @@
 **The Stack Trace:** The process panics with `stack overflow` or crashes due to OOM when allocating vectors at each recursion level, or exceeds system limits.
 **Reproduction:** Run `cargo test --test havoc_classfile_annotation_oom` (which we added and fixed).
 **Comment:** "You assumed the JVM specification limit of annotation depth was naturally bounded by the class file size, but deep nesting of `[` arrays with 1 element allows exponential stack growth compared to byte size. You were wrong."
+## 2024-06-03 - String.indexOf Multi-byte Bounds Panic
+**The Trigger:** Inputting an Emoji (e.g. `🦀`) or other multi-byte characters and searching via `indexOf` or `lastIndexOf` with an offset (e.g., `fromIndex=1`).
+**The Stack Trace:** Panic: byte index is not a char boundary.
+**Reproduction:** Call `String.indexOf(String, int)` with `fromIndex=1` on "🦀rust".
+**Comment:** You assumed characters are always 1 byte. You were wrong.

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,6 @@
-🛡️ Sentry: [test coverage improvement]
+👺 Havoc: [Panic] String.indexOf and String.lastIndexOf multi-byte split
 
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+🧨 The Trigger: Inputting an Emoji or other multi-byte characters and searching via indexOf with an offset could trigger an out-of-bounds byte slice in Rust.
+📉 The Stack Trace: Panic: byte index is not a char boundary.
+🧪 Reproduction: Call String.indexOf or String.lastIndexOf with a fromIndex > 0 on a string with multi-byte characters before fromIndex.
+😈 Comment: You assumed characters are always 1 byte. You were wrong.

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -14620,9 +14620,13 @@ pub(crate) fn native_string_indexof_from(
     let target_obj = heap.get(target_ref)?;
     let s = this_obj.string_value.as_deref().unwrap_or_default();
     let target = target_obj.string_value.as_deref().unwrap_or_default();
-    let search_in = if from < s.len() { &s[from..] } else { "" };
+    let byte_from = s.char_indices().nth(from).map_or(s.len(), |(i, _)| i);
+    let search_in = if byte_from < s.len() { &s[byte_from..] } else { "" };
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    let result = search_in.find(target).map_or(-1, |i| (from + i) as i32);
+    let result = search_in.find(target).map_or(-1, |byte_offset| {
+        let actual_byte_index = byte_from + byte_offset;
+        s[..actual_byte_index].chars().count() as i32
+    });
     Ok(Some(Slot::Int(result)))
 }
 
@@ -14639,13 +14643,18 @@ pub(crate) fn native_string_last_indexof_from(
     let from = extract_int_arg(args, 2).unwrap_or(0).max(0) as usize;
     let this_str = heap.get(this_ref)?.string_value.clone().unwrap_or_default();
     let sub_str = heap.get(sub_ref)?.string_value.clone().unwrap_or_default();
-    let search_in = if from + sub_str.len() < this_str.len() {
-        &this_str[..from + sub_str.len()]
-    } else {
-        &this_str
-    };
+    let byte_from = this_str.char_indices().nth(from).map_or(this_str.len(), |(i, _)| i);
+    let safe_end = (byte_from + sub_str.len()).min(this_str.len());
+    let mut actual_end = safe_end;
+    while actual_end > 0 && !this_str.is_char_boundary(actual_end) {
+        actual_end -= 1;
+    }
+
+    let search_in = &this_str[..actual_end];
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    let result = search_in.rfind(sub_str.as_str()).map_or(-1, |i| i as i32);
+    let result = search_in.rfind(sub_str.as_str()).map_or(-1, |byte_offset| {
+        this_str[..byte_offset].chars().count() as i32
+    });
     Ok(Some(Slot::Int(result)))
 }
 
@@ -38169,4 +38178,51 @@ mod tests_sentry {
         assert!(matches!(err_bool, crate::Error::InvalidRef { address: _ }));
     }
 
+}
+
+#[cfg(test)]
+mod havoc_string_split_tests {
+    use super::*;
+    use duke_gc::Heap;
+
+    #[test]
+    fn test_string_indexof_split_char() {
+        let mut heap = Heap::new();
+        let s = "🦀rust"; // 🦀 is 4 bytes
+        let s_ref = heap.allocate_string(s.to_string());
+
+        let target = "ust";
+        let target_ref = heap.allocate_string(target.to_string());
+
+        let args = [
+            Slot::Reference(Some(s_ref)),
+            Slot::Reference(Some(target_ref)),
+            Slot::Int(1), // fromIndex
+        ];
+
+        let mut out = std::io::sink();
+        let mut control = NativeControl::default();
+        let _ = native_string_indexof_from(&args, &mut heap, &mut out, &mut control);
+    }
+
+    #[test]
+    fn test_string_last_indexof_split_char() {
+        let mut heap = Heap::new();
+        let s = "🦀rust"; // 🦀 is 4 bytes
+        let s_ref = heap.allocate_string(s.to_string());
+
+        let target = "r"; // length 1 byte
+        let target_ref = heap.allocate_string(target.to_string());
+
+        // from = 0 -> search in `this_str[..0+1]` -> `this_str[..1]`, splitting the 4-byte 🦀.
+        let args = [
+            Slot::Reference(Some(s_ref)),
+            Slot::Reference(Some(target_ref)),
+            Slot::Int(0), // fromIndex
+        ];
+
+        let mut out = std::io::sink();
+        let mut control = NativeControl::default();
+        let _ = native_string_last_indexof_from(&args, &mut heap, &mut out, &mut control);
+    }
 }

--- a/plan.md
+++ b/plan.md
@@ -1,20 +1,9 @@
-1. **Optimize String concatenation in `native_string_concat`**
-   - The function currently uses `format!("{s1}{s2}")` to concatenate two strings, which allocates a new string buffer inside `format!`, formats the arguments, and returns it.
-   - We can optimize this by pre-allocating a `String` with the exact required capacity and appending the strings:
-     ```rust
-     let mut combined = String::with_capacity(s1.len() + s2.len());
-     combined.push_str(&s1);
-     combined.push_str(&s2);
-     let r = heap.allocate_string(combined);
-     ```
-   - This eliminates the intermediate allocation and parsing overhead of `format!`, which is a common hotspot in interpreters.
-   - Add `// ⚡ Bolt: Eliminate intermediate format! allocation` comment.
-   - Ensure the tests pass.
-1. Refactor `print_report` methods in `duke-telemetry/src/lib.rs` to handle empty states gracefully (Reduces noise from empty reports).
-   - Before: Outputs headers and empty tables for empty components.
-   - After: Outputs a concise message stating no events were recorded.
-2. Complete pre commit steps to make sure proper testing, verifications, reviews and reflections are done.
-3. Submit the change using a descriptive title.
-1. **Optimize Vector Allocations in Execution (Vec::with_capacity)**: Pre-allocate vectors in `crates/duke-interpreter/src/execution.rs` for `Multianewarray` `dims` array and lambda args `impl_args` to avoid unnecessary dynamic heap reallocations.
-2. Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.
-3. **Submit the PR**: Present PR titled '⚡ Bolt: Optimize Vector Allocations in Execution & Native' detailing 💡 What, 🎯 Why, 📊 Impact, and 🔭 Measurement. I will use `run_in_bash_session` to execute `git commit` with the requested PR details.
+1. **Fix String.indexOf Bounds Panic**
+   - Execute a Python script to fix `native_string_indexof_from` and `native_string_last_indexof_from` in `crates/duke-interpreter/src/native.rs` to map Java `fromIndex` using `.char_indices().nth(from)` instead of using it as a raw byte index, which previously caused slicing panics on multi-byte characters.
+
+2. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+   - Run `pre_commit_instructions` and follow the steps.
+
+3. **Submit the PR**
+   - Run `cargo test` and `cargo fmt`.
+   - Submit with title "👺 Havoc: [Panic] String.indexOf and String.lastIndexOf multi-byte split".


### PR DESCRIPTION
🧨 **The Trigger:** Inputting an Emoji or other multi-byte characters and searching via `indexOf` with an offset could trigger an out-of-bounds byte slice in Rust.
📉 **The Stack Trace:** `Panic: byte index is not a char boundary.`
🧪 **Reproduction:** Call `String.indexOf` or `String.lastIndexOf` with a `fromIndex > 0` on a string with multi-byte characters before `fromIndex`.
😈 **Comment:** You assumed characters are always 1 byte. You were wrong.

---
*PR created automatically by Jules for task [9366745802004753418](https://jules.google.com/task/9366745802004753418) started by @madmax983*