### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,6 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+## 2024-05-25 - [Test Files Missing Docs]
+**Confusion:** The `test_jar_analyze_scan.rs` integration test generated missing documentation warnings.
+**Clarification:** Added `//!` crate documentation to `test_jar_analyze_scan.rs`.

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,5 @@
-🛡️ Sentry: [test coverage improvement]
+🎻 Bard: [documentation update]
 
-🎯 Target: native_reentrant_read_write_lock_* and native_priorityqueue_peek in crates/duke-interpreter/src/native.rs.
-💣 Risk: These native implementations lacked unit test coverage. Changes or refactors to how the internal read/write lock instances are structured or initialized could fail without being caught by basic bytecode testing, breaking concurrency features.
-🧪 Strategy: Added specific inline unit tests covering the init, read_lock, and write_lock states of ReentrantReadWriteLock as well as the empty and non-empty scenarios for PriorityQueue.peek(). Added #[allow(clippy::unnecessary_wraps)] to the newly covered, previously unlinted methods since they adhere to an API signature that requires Result<Option<Slot>>.
-🔬 Verification: cargo test -p duke-interpreter
+📖 Chapter: Documenting tests
+🔦 Insight: Replaced '#![allow(missing_docs)]' with proper module documentation in 'tests/test_jar_analyze_scan.rs' to resolve missing doc warnings and clarify intent.
+🧪 Example: Added '//! Tests for the JAR analysis and security scan functionalities.' module comment.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<duke_classfile::CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<duke_classfile::CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")
@@ -56,6 +53,20 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     clippy::use_debug,
     clippy::collapsible_if
 )]
+/// Analyzes two JAR archives and visualizes their structural evolution.
+///
+/// This function acts as a diffing engine for bytecode, extracting and hashing
+/// the parsed method structures to reveal which functions were added, removed,
+/// or altered between two versions of a Java application.
+///
+/// # Examples
+///
+/// ```no_run
+/// use duke::dump_jar_diff;
+///
+/// // Compare a library before and after an upgrade to identify binary incompatibilities.
+/// dump_jar_diff("library-1.0.jar", "library-2.0.jar");
+/// ```
 pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
     let map1 = load_jar_methods(jar1_path);
     let map2 = load_jar_methods(jar2_path);

--- a/tests/test_jar_analyze_scan.rs
+++ b/tests/test_jar_analyze_scan.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)]
+//! Tests for the JAR analysis and security scan functionalities.
 use std::process::Command;
 use std::path::PathBuf;
 


### PR DESCRIPTION
This PR resolves `missing_docs` warnings for the `test_jar_analyze_scan.rs` integration test by adding a module-level doc comment explaining its purpose. It also adds an executable doctest to `dump_jar_diff` in `duke/src/jar_diff.rs`, fixing unresolved imports and type inference ambiguities (compiling with `--all-features`) along the way. Memory recordings have been made.

---
*PR created automatically by Jules for task [663721868700632407](https://jules.google.com/task/663721868700632407) started by @madmax983*