### PR TITLE
🗺️ Atlas: [Enforce Crate Root Encapsulation]

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -7,3 +7,6 @@
 **[Encapsulate `duke_classfile` Facade]**
 **Tangle:** The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types, and `duke-telemetry` exposed internal serialization helpers via `pub mod ser_helpers`. This creates confusing, leaky abstractions and redundant paths.
 **Blueprint:** Encapsulated both modules. In `duke_classfile`, replaced `pub mod types` with direct `pub use` statements at the crate root, eliminating the `types` namespace from the public API entirely. In `duke_telemetry`, reduced `ser_helpers` visibility to `pub(crate)`.
+**[Crate Root Encapsulation]
+**Tangle:** Crates were declaring submodules as `pub(crate) mod name;` at the crate root, which creates an inconsistent internal API surface and bypasses strict encapsulation.
+**Blueprint:** Refactored crate roots to use private `mod name;` declarations to idiomaticaly enforce structural boundaries.

--- a/crates/duke-bytecode/src/lib.rs
+++ b/crates/duke-bytecode/src/lib.rs
@@ -9,18 +9,18 @@
 //! - `error` — [`DecodeError`] and [`VerifyError`]
 
 #[cfg(feature = "nova")]
-pub(crate) mod basic_block;
-pub(crate) mod call_graph;
-pub(crate) mod cfg;
-pub(crate) mod decoder;
-pub(crate) mod error;
-pub(crate) mod instruction;
-pub(crate) mod opcodes;
+mod basic_block;
+mod call_graph;
+mod cfg;
+mod decoder;
+mod error;
+mod instruction;
+mod opcodes;
 #[cfg(feature = "nova")]
-pub(crate) mod reachability;
+mod reachability;
 #[cfg(feature = "nova")]
-pub(crate) mod similarity;
-pub(crate) mod verifier;
+mod similarity;
+mod verifier;
 
 #[cfg(feature = "nova")]
 pub use basic_block::{BasicBlock, build_basic_blocks};
@@ -40,9 +40,7 @@ pub use verifier::verify;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use duke_classfile::{
-        parse, {AttributeData, CpEntry},
-    };
+    use duke_classfile::{AttributeData, CpEntry, parse};
 
     // -----------------------------------------------------------------------
     // Helpers

--- a/crates/duke-classfile/src/lib.rs
+++ b/crates/duke-classfile/src/lib.rs
@@ -15,12 +15,12 @@
 //! println!("Methods: {}", class_file.methods.len());
 //! ```
 
-pub(crate) mod access_flags;
-pub(crate) mod attributes;
-pub(crate) mod class;
-pub(crate) mod constant_pool;
-pub(crate) mod error;
-pub(crate) mod parser;
+mod access_flags;
+mod attributes;
+mod class;
+mod constant_pool;
+mod error;
+mod parser;
 
 pub use crate::attributes::*;
 pub use crate::class::*;

--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, Condvar, Mutex};
 
 use duke_runtime::{Error, Result, Slot};
 
-pub(crate) mod host;
+mod host;
 mod mermaid;
 pub use host::{HostFileHandle, HostProcessHandle, SpawnedProcessIds};
 

--- a/crates/duke-interpreter/src/lib.rs
+++ b/crates/duke-interpreter/src/lib.rs
@@ -18,13 +18,13 @@
 #![cfg_attr(test, allow(clippy::large_stack_arrays))]
 
 /// Core execution context types for methods and classes.
-pub(crate) mod context;
-pub(crate) mod execution;
+mod context;
+mod execution;
 /// Repositories for loaded classes and registered native methods.
-pub(crate) mod registry;
+mod registry;
 /// Core standard library classes and methods bootstrap.
-pub(crate) mod stdlib;
-pub(crate) mod threading;
+mod stdlib;
+mod threading;
 
 pub use context::*;
 pub use registry::*;

--- a/crates/duke-loader/src/lib.rs
+++ b/crates/duke-loader/src/lib.rs
@@ -11,12 +11,12 @@
 
 use std::path::{Path, PathBuf};
 
-pub(crate) mod bootstrap;
-pub(crate) mod directory;
-pub(crate) mod error;
-pub(crate) mod jimage;
-pub(crate) mod manifest;
-pub(crate) mod zip;
+mod bootstrap;
+mod directory;
+mod error;
+mod jimage;
+mod manifest;
+mod zip;
 
 pub use bootstrap::{BootstrapLoader, ClasspathEntry};
 pub use directory::DirectoryLoader;

--- a/crates/duke-runtime/src/lib.rs
+++ b/crates/duke-runtime/src/lib.rs
@@ -31,9 +31,9 @@
 //! assert_eq!(frame.pop_int().unwrap(), 30);
 //! ```
 
-pub(crate) mod error;
-pub(crate) mod frame;
-pub(crate) mod slot;
+mod error;
+mod frame;
+mod slot;
 
 pub use error::{Error, Result};
 pub use frame::Frame;

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -35,19 +35,19 @@
 //! let json = store.to_json();
 //! ```
 
-pub(crate) mod helpers;
+mod helpers;
 
-pub(crate) mod bytecode_cost;
+mod bytecode_cost;
 pub use bytecode_cost::*;
-pub(crate) mod object_lineage;
+mod object_lineage;
 pub use object_lineage::*;
-pub(crate) mod class_init_dag;
+mod class_init_dag;
 pub use class_init_dag::*;
-pub(crate) mod exception_flow;
+mod exception_flow;
 pub use exception_flow::*;
-pub(crate) mod dispatch_resolution;
+mod dispatch_resolution;
 pub use dispatch_resolution::*;
-pub(crate) mod native_boundary;
+mod native_boundary;
 pub use native_boundary::*;
 
 // -- TelemetryStore --------------------------------------------------------------

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -1553,9 +1553,7 @@ mod tests {
 
     #[test]
     fn test_generate_native_stubs_code_empty() {
-        use duke_classfile::{
-            ClassAccessFlags, {ClassFile, CpEntry, CpIndex},
-        };
+        use duke_classfile::{ClassAccessFlags, ClassFile, CpEntry, CpIndex};
 
         let cf = ClassFile {
             minor_version: 0,
@@ -1583,7 +1581,7 @@ mod tests {
     #[test]
     fn test_generate_native_stubs_code() {
         use duke_classfile::{
-            ClassAccessFlags, MethodAccessFlags, {ClassFile, CpEntry, CpIndex, MethodInfo},
+            ClassAccessFlags, ClassFile, CpEntry, CpIndex, MethodAccessFlags, MethodInfo,
         };
 
         let cf = ClassFile {


### PR DESCRIPTION
🗺️ Atlas: [Enforce Crate Root Encapsulation]

🕸️ Tangle: Crates were declaring submodules as `pub(crate) mod name;` at the crate root, which creates an inconsistent internal API surface and bypasses strict encapsulation.
📐 Blueprint: Refactored crate roots to use private `mod name;` declarations to idiomaticaly enforce structural boundaries.
🧱 Stability: Reduced coupling, enforces explicit internal dependencies.
🔬 Verification: Builds successfully, strict separation enforced.

---
*PR created automatically by Jules for task [9805015990036075748](https://jules.google.com/task/9805015990036075748) started by @madmax983*