### PR TITLE
⚡ Bolt: [cfg] eliminate hashmap reallocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,6 @@
 **Trust the Iterator: .collect() is Optimized**
 **Learning:** In Rust, `.collect::<Vec<_>>()` called on an `ExactSizeIterator` (which `slice.iter().map()` implements) already knows the exact number of elements. The standard library heavily optimizes this via the `TrustedLen` trait to allocate the precise capacity upfront and completely bypass bounds checks during insertion.
 **Action:** Do not manually replace `.collect::<Vec<_>>()` with `Vec::with_capacity` and a `for` loop, as it re-introduces bounds checks on every push, making the "optimization" unidiomatic and a micro-regression.
+**Pre-allocating HashMaps for Known Workloads**
+**Learning:** Initializing `HashMap` without `with_capacity` when the total size is known ahead of time (like iterating over exactly `N` `blocks` into `pc_to_block` for a CFG) introduces unnecessary heap reallocations.
+**Action:** Use `HashMap::with_capacity(size)` instead of `HashMap::new()` when the final size is known during operations like graph building.

--- a/crates/duke-bytecode/src/cfg.rs
+++ b/crates/duke-bytecode/src/cfg.rs
@@ -390,7 +390,7 @@ pub fn generate_basic_block_cfg(blocks: &[crate::basic_block::BasicBlock]) -> St
     }
 
     // Map PC to Block ID (start_pc) for edge resolution
-    let mut pc_to_block = std::collections::HashMap::new();
+    let mut pc_to_block = std::collections::HashMap::with_capacity(blocks.len());
     for block in blocks {
         pc_to_block.insert(block.start_pc, block.start_pc);
     }


### PR DESCRIPTION
💡 What: Replaced `HashMap::new()` with `HashMap::with_capacity(blocks.len())` in `duke-bytecode`'s `generate_basic_block_cfg` function.
🎯 Why: `generate_basic_block_cfg` iterates over exactly `blocks.len()` blocks to build the PC-to-block resolution map. Initializing with `new()` causes the underlying hash map to dynamically resize and rehash repeatedly during insertion, wasting CPU cycles and triggering unnecessary heap allocations.
📊 Impact: Eliminates multiple heap reallocations and rehashing passes during CFG generation, leading to faster graph building overhead with a minimal targeted fix.
🔬 Measurement: Run `cargo bench` (if available) or `cargo test -p duke-bytecode` to verify correct basic block generation semantics are maintained at zero-cost.

---
*PR created automatically by Jules for task [14462392959276864101](https://jules.google.com/task/14462392959276864101) started by @madmax983*