### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,10 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+## 2024-05-25 - [Proptest File Missing Docs]
+**Confusion:** The proptest file `crates/duke-classfile/tests/havoc_classfile_proptest.rs` generated a missing documentation warning.
+**Clarification:** Added `#![allow(missing_docs)]` to the test file to suppress the warning, as integration test files do not need full crate documentation.
+
+## 2024-05-25 - [jar_diff type inference]
+**Confusion:** The script duke/src/jar_diff.rs was failing to compile under `--all-features` due to missing type inference for closures operating on `Option`. It was also incorrectly trying to import types from `duke_classfile::types`.
+**Clarification:** Removed the bad import. Added explicit type annotations (`&Option<CpEntry>`) to the `.and_then` closures.

--- a/crates/duke-classfile/src/class.rs
+++ b/crates/duke-classfile/src/class.rs
@@ -33,6 +33,29 @@ use crate::constant_pool::CpIndex;
 /// assert_eq!(class_file.major_version, 65);
 /// ```
 #[derive(Debug, Clone)]
+/// Represents a parsed Java Class File.
+///
+/// See JVM SE 21 (§4.1) for details on the structure.
+///
+/// # Examples
+///
+/// ```
+/// use duke_classfile::{ClassFile, ClassAccessFlags, CpIndex};
+///
+/// let cf = ClassFile {
+///     minor_version: 0,
+///     major_version: 65,
+///     constant_pool: vec![],
+///     access_flags: ClassAccessFlags::empty(),
+///     this_class: CpIndex(0),
+///     super_class: CpIndex(0),
+///     interfaces: vec![],
+///     fields: vec![],
+///     methods: vec![],
+///     attributes: vec![],
+/// };
+/// assert_eq!(cf.major_version, 65);
+/// ```
 pub struct ClassFile {
     /// Minor version of the class file format.
     pub minor_version: u16,

--- a/crates/duke-classfile/src/constant_pool.rs
+++ b/crates/duke-classfile/src/constant_pool.rs
@@ -22,6 +22,21 @@ pub struct CpIndex(pub u16);
 
 /// All constant pool entry kinds defined in JVM SE 21 (§4.4).
 #[derive(Debug, Clone, PartialEq)]
+/// Represents an entry in the constant pool.
+///
+/// See JVM SE 21 (§4.4) for details on the constant pool structure.
+///
+/// # Examples
+///
+/// ```
+/// use duke_classfile::CpEntry;
+///
+/// let entry = CpEntry::Integer(42);
+/// match entry {
+///     CpEntry::Integer(val) => assert_eq!(val, 42),
+///     _ => panic!("Expected Integer"),
+/// }
+/// ```
 pub enum CpEntry {
     /// Tag 1
     Utf8(String),

--- a/crates/duke-classfile/tests/havoc_classfile_proptest.rs
+++ b/crates/duke-classfile/tests/havoc_classfile_proptest.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use proptest::prelude::*;
 
 proptest! {

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -3,8 +3,7 @@
 
 #[cfg(feature = "nova")]
 use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    parse, {AttributeData, CpEntry, CpIndex},
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +17,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +37,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
Added narrative documentation and executable doctests for `ClassFile` and `CpEntry` structs in `duke-classfile`. Suppressed missing docs warning in integration tests and fixed a type inference compilation issue.

---
*PR created automatically by Jules for task [11325581597105989473](https://jules.google.com/task/11325581597105989473) started by @madmax983*