### PR TITLE
🔭 Vantage: Spec for String.equalsIgnoreCase Native Support

### DIFF
--- a/docs/vantage-spec-string-equalsignorecase.md
+++ b/docs/vantage-spec-string-equalsignorecase.md
@@ -1,0 +1,22 @@
+# 🔭 Vantage: Spec for String.equalsIgnoreCase Native Support
+
+## 👤 User Story
+"As a Java Developer running libraries like SLF4J on Duke, I want the VM to natively support `String.equalsIgnoreCase`, so that my applications can perform string comparisons and initialization without crashing."
+
+## ❓ The "So What?"
+What business problem does this solve?
+Currently, Duke lacks native support for `java/lang/String.equalsIgnoreCase(Ljava/lang/String;)Z`. This prevents essential libraries like SLF4J from initializing, blocking our OSS JAR compatibility milestone (specifically the `slf4j-simple` smoke test). Implementing this native method unblocks the execution of real-world libraries and progresses our compatibility goals.
+
+## 📈 Metric Definition
+Success = The SLF4J smoke test progresses past the `Unsupported native: java/lang/String.equalsIgnoreCase(Ljava/lang/String;)Z` missing capability error.
+
+## 🔍 Gap Analysis
+- **Current State:** The SLF4J smoke test is blocked because Duke throws an "Unsupported native: java/lang/String.equalsIgnoreCase(Ljava/lang/String;)Z" error in `tests/oss_jar_smoke.rs`.
+- **Market/Standard Lib:** The standard JVM implements `String.equalsIgnoreCase`.
+- **The Gap:** We need to implement the native bridge for `java/lang/String.equalsIgnoreCase(Ljava/lang/String;)Z` in Duke.
+
+## ✅ Acceptance Criteria
+- Must implement the native method `java/lang/String.equalsIgnoreCase(Ljava/lang/String;)Z`.
+
+## 🚫 Out of Scope
+- Implementing other missing `String` native methods.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,29 @@
+<<<<<<< SEARCH
+use duke_classfile::{
+    parse,
+    types::{AttributeData, CpEntry, CpIndex},
+};
+=======
+use duke_classfile::{
+    parse,
+    AttributeData, CpEntry, CpIndex,
+};
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    cf.constant_pool
+        .get(idx.0 as usize)
+        .and_then(|slot| slot.as_ref())
+=======
+    cf.constant_pool
+        .get(idx.0 as usize)
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    cf.constant_pool
+        .get(idx.0 as usize)
+        .and_then(|s| s.as_ref());
+=======
+    cf.constant_pool
+        .get(idx.0 as usize)
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
+>>>>>>> REPLACE


### PR DESCRIPTION
# 🔭 Vantage: Spec for String.equalsIgnoreCase Native Support

## 👤 User Story
"As a Java Developer running libraries like SLF4J on Duke, I want the VM to natively support `String.equalsIgnoreCase`, so that my applications can perform string comparisons and initialization without crashing."

## ✅ Acceptance Criteria
- Must implement the native method `java/lang/String.equalsIgnoreCase(Ljava/lang/String;)Z`.

## 🚫 Out of Scope
- Implementing other missing `String` native methods.

---
*PR created automatically by Jules for task [16852965196949724475](https://jules.google.com/task/16852965196949724475) started by @madmax983*