### PR TITLE
⚒️ Forge: Refactor nested let bindings and fix unresolved imports

### DIFF
--- a/crates/duke-bytecode/src/decoder.rs
+++ b/crates/duke-bytecode/src/decoder.rs
@@ -263,9 +263,8 @@ fn decode_math_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
         _ => unreachable!(),
     })
 }
-#[allow(clippy::unnecessary_wraps)]
-fn decode_conversion_op(opcode: u8) -> Result<Instruction> {
-    Ok(match opcode {
+fn decode_conversion_op(opcode: u8) -> Instruction {
+    match opcode {
         op::I2L => Instruction::I2l,
         op::I2F => Instruction::I2f,
         op::I2D => Instruction::I2d,
@@ -282,7 +281,7 @@ fn decode_conversion_op(opcode: u8) -> Result<Instruction> {
         op::I2C => Instruction::I2c,
         op::I2S => Instruction::I2s,
         _ => unreachable!(),
-    })
+    }
 }
 fn decode_control_flow_op(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> Result<Instruction> {
     Ok(match opcode {
@@ -393,7 +392,6 @@ fn decode_extended_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
     })
 }
 
-#[allow(clippy::unnecessary_wraps)]
 #[allow(clippy::too_many_lines)]
 fn decode_one(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> Result<Instruction> {
     match opcode {
@@ -412,7 +410,7 @@ fn decode_one(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> Result<Instruction> 
             _ => unreachable!(),
         }),
         op::IADD..=op::IINC => decode_math_op(c, opcode),
-        op::I2L..=op::I2S => decode_conversion_op(opcode),
+        op::I2L..=op::I2S => Ok(decode_conversion_op(opcode)),
         op::LCMP..=op::RETURN => decode_control_flow_op(c, opcode, pc),
         op::GETSTATIC..=op::MONITOREXIT => decode_object_invoke_op(c, opcode, pc),
         op::WIDE => decode_wide(c, pc),

--- a/crates/duke-bytecode/src/reachability.rs
+++ b/crates/duke-bytecode/src/reachability.rs
@@ -42,11 +42,10 @@ use std::collections::{HashMap, HashSet, VecDeque};
 /// Optimization: Pre-allocate capacity of 2 since branch targets and fallthroughs max out at two.
 /// Reduces dynamic reallocation overhead during CFG construction.
 pub fn get_successors(block: &BasicBlock) -> Vec<usize> {
-    if let Some((last_pc, last_instr)) = block.instructions.last() {
-        last_instr.control_flow_targets(*last_pc, Some(block.end_pc))
-    } else {
-        Vec::new()
-    }
+    let Some((last_pc, last_instr)) = block.instructions.last() else {
+        return Vec::new();
+    };
+    last_instr.control_flow_targets(*last_pc, Some(block.end_pc))
 }
 
 /// Finds all dead (unreachable) basic blocks starting from the given entry PC.
@@ -101,13 +100,14 @@ pub fn find_dead_blocks(blocks: &[BasicBlock], entry_pc: usize) -> Vec<usize> {
     }
 
     while let Some(current_pc) = queue.pop_front() {
-        if let Some(block) = block_map.get(&current_pc) {
-            let successors = get_successors(block);
-            for next_pc in successors {
-                if block_map.contains_key(&next_pc) && !visited.contains(&next_pc) {
-                    visited.insert(next_pc);
-                    queue.push_back(next_pc);
-                }
+        let Some(block) = block_map.get(&current_pc) else {
+            continue;
+        };
+        let successors = get_successors(block);
+        for next_pc in successors {
+            if block_map.contains_key(&next_pc) && !visited.contains(&next_pc) {
+                visited.insert(next_pc);
+                queue.push_back(next_pc);
             }
         }
     }
@@ -192,13 +192,14 @@ pub fn find_shortest_path(
             break;
         }
 
-        if let Some(block) = block_map.get(&current_pc) {
-            for next_pc in get_successors(block) {
-                if block_map.contains_key(&next_pc) && !visited.contains(&next_pc) {
-                    visited.insert(next_pc);
-                    parents.insert(next_pc, current_pc);
-                    queue.push_back(next_pc);
-                }
+        let Some(block) = block_map.get(&current_pc) else {
+            continue;
+        };
+        for next_pc in get_successors(block) {
+            if block_map.contains_key(&next_pc) && !visited.contains(&next_pc) {
+                visited.insert(next_pc);
+                parents.insert(next_pc, current_pc);
+                queue.push_back(next_pc);
             }
         }
     }

--- a/crates/duke-loader/src/bootstrap.rs
+++ b/crates/duke-loader/src/bootstrap.rs
@@ -134,9 +134,10 @@ impl ClassLoader for BootstrapLoader {
         }
         // Application classes: classpath entries (directories and JARs)
         for entry in &self.classpath {
-            if let Ok(bytes) = entry.find_class(name) {
-                return Ok(bytes);
-            }
+            let Ok(bytes) = entry.find_class(name) else {
+                continue;
+            };
+            return Ok(bytes);
         }
         Err(Error::NotFound {
             name: name.to_string(),

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
* 🚮 Smell: Unresolved imports and missing type annotations broke `jar_diff.rs`, and deeply nested `if let Some` patterns existed in CFG reachability analysis (`reachability.rs`) and module loading (`bootstrap.rs`). Unnecessary `Result` wrappers were used in the bytecode decoder.
* ✨ Solution: Fixed `duke/src/jar_diff.rs` imports and added explicit closure types. Refactored nested `if let Some` and `if let Ok` loops in `crates/duke-bytecode/src/reachability.rs` and `crates/duke-loader/src/bootstrap.rs` using `let-else` to flatten control flow. Removed unnecessary `Result` wrapping from `decode_conversion_op` in `crates/duke-bytecode/src/decoder.rs` to fix a clippy warning without using `#[allow]`.
* 🧼 Benefit: Reduces indentation depth in iterative parsing algorithms (Forge's preferred flattening), and eliminates compilation errors and unidiomatic `Result` wraps.
* 🛡️ Verification: `cargo test` and `cargo clippy` passed. No logic changed.

---
*PR created automatically by Jules for task [229564006750740344](https://jules.google.com/task/229564006750740344) started by @madmax983*