### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,6 @@
 **Trust the Iterator: .collect() is Optimized**
 **Learning:** In Rust, `.collect::<Vec<_>>()` called on an `ExactSizeIterator` (which `slice.iter().map()` implements) already knows the exact number of elements. The standard library heavily optimizes this via the `TrustedLen` trait to allocate the precise capacity upfront and completely bypass bounds checks during insertion.
 **Action:** Do not manually replace `.collect::<Vec<_>>()` with `Vec::with_capacity` and a `for` loop, as it re-introduces bounds checks on every push, making the "optimization" unidiomatic and a micro-regression.
+**[Capacity Allocation Optimization]
+**Learning:** Initializing `HashMap` and `String` with `.new()` in a hot loop leads to multiple heap reallocations.
+**Action:** Always verify if the capacity is known beforehand (`blocks.len()`) and use `HashMap::with_capacity(size)` and `String::with_capacity(size)` to reduce heap allocations.

--- a/crates/duke-bytecode/src/call_graph.rs
+++ b/crates/duke-bytecode/src/call_graph.rs
@@ -110,7 +110,8 @@ fn extract_method_ref(cf: &ClassFile, idx: CpIndex) -> Option<(String, String, S
 #[must_use]
 /// ⚡ Bolt: Using `BTreeSet<String>` removes the need to collect and sort a `Vec` and avoids cloning `source_id` in the hot loop.
 pub fn generate_mermaid_call_graph(cf: &ClassFile) -> String {
-    let mut cg = String::from("graph TD\n");
+    let mut cg = String::with_capacity(1024);
+    cg.push_str("graph TD\n");
     let mut edges = BTreeSet::new();
 
     let this_class_name = resolve_class_name(cf, cf.this_class);

--- a/crates/duke-bytecode/src/cfg.rs
+++ b/crates/duke-bytecode/src/cfg.rs
@@ -390,7 +390,7 @@ pub fn generate_basic_block_cfg(blocks: &[crate::basic_block::BasicBlock]) -> St
     }
 
     // Map PC to Block ID (start_pc) for edge resolution
-    let mut pc_to_block = std::collections::HashMap::new();
+    let mut pc_to_block = std::collections::HashMap::with_capacity(blocks.len());
     for block in blocks {
         pc_to_block.insert(block.start_pc, block.start_pc);
     }

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
💡 What: Changed `HashMap::new()` to `HashMap::with_capacity(blocks.len())` and `String::from()` to `String::with_capacity()` in bytecode analysis paths. Also resolved compiler type inference and pathing errors in `jar_diff.rs`.
🎯 Why: Utilizing pre-allocated capacities prevents unnecessary heap reallocations when calculating graph edges and control flow blocks.
📊 Impact: Eliminates multiple heap re-allocations per method analyzed during call graph and CFG generation.
🔬 Measurement: Verified with `cargo clippy`, `cargo test`, and `cargo fmt`. Compilation now correctly passes with warnings treated as errors.

---
*PR created automatically by Jules for task [10703841284046081390](https://jules.google.com/task/10703841284046081390) started by @madmax983*