### PR TITLE
🛡️ Sentry: test coverage improvement for duke-loader

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -47,3 +47,6 @@
 ## 2024-05-24 - Testing ReentrantReadWriteLock Native Operations
 **Learning:** Found several native functions implementing `ReentrantReadWriteLock` and `PriorityQueue` operations missing test coverage in `duke-interpreter`. Adding dummy tests correctly executes these logic branches without needing fully mocked multi-threading scenarios.
 **Action:** Add inline unit tests using a mocked heap and manually setting up the `obj_ref` payload.
+## 2026-06-06 - Cargo Tarpaulin Output Parsing
+**Learning:** When using `cargo tarpaulin` to measure code coverage programmatically, it's best to specify `--out Json` to generate `tarpaulin-report.json` rather than parsing `lcov.info`, which may lack coverage data for modules guarded by features.
+**Action:** Always use `cargo tarpaulin --all-features --out Json` when analyzing untested code, and ensure you parse the JSON report appropriately.

--- a/crates/duke-loader/src/jimage.rs
+++ b/crates/duke-loader/src/jimage.rs
@@ -983,3 +983,78 @@ mod tests_oob {
         }
     }
 }
+
+#[cfg(test)]
+mod tests_sentry {
+    use super::*;
+
+    #[test]
+    fn test_parse_header_unsupported_version() {
+        let mut data = vec![0; HEADER_SIZE];
+        data[0..4].copy_from_slice(&JIMAGE_MAGIC.to_le_bytes()); // valid magic
+        data[4..8].copy_from_slice(&999u32.to_le_bytes()); // invalid version
+
+        let res = parse_header(&data);
+        assert!(matches!(res, Err(Error::JImageFormat { .. })));
+        if let Err(Error::JImageFormat { msg }) = res {
+            assert!(msg.contains("unsupported jimage version:"));
+        }
+    }
+
+    #[test]
+    fn test_split_class_name_no_slash() {
+        let (pkg, name) = split_class_name("Foo");
+        assert_eq!(pkg, "");
+        assert_eq!(name, "Foo");
+    }
+
+    #[test]
+    fn test_read_str_index_out_of_bounds() {
+        // str_offset + idx_usize > data.len()
+        let data = vec![0, 1, 2, 3];
+        let str_offset = 2;
+        let idx = 10;
+        let res = read_str(&data, str_offset, idx);
+        assert_eq!(res, "");
+    }
+
+    #[test]
+    fn test_build_index_missing_location() {
+        let data = vec![0; HEADER_SIZE];
+        let res = build_index(&data, 0, 10, 10, 10);
+        assert_eq!(res.len(), 0);
+    }
+
+    #[test]
+    fn test_read_resource_decompress_error() {
+        let mut data = vec![0; HEADER_SIZE];
+        data[0..4].copy_from_slice(&0xCAFE_DADA_u32.to_le_bytes()); // magic
+        data[4..8].copy_from_slice(&0x0001_0000_u32.to_le_bytes()); // version
+        data[16..20].copy_from_slice(&1u32.to_le_bytes()); // table_length = 1
+        data[20..24].copy_from_slice(&0u32.to_le_bytes()); // locations_size
+        data[24..28].copy_from_slice(&0u32.to_le_bytes()); // strings_size
+
+        let mut reader = JImageReader {
+            data: data.clone(),
+            index: std::collections::HashMap::new(),
+            data_offset: HEADER_SIZE,
+            resource_count: 0,
+        };
+
+        // Inject a fake index entry pointing to some invalid zip data
+        reader.index.insert(
+            "test".to_string(),
+            ResourceInfo {
+                uncompressed: 100,
+                compressed: 10,
+                offset: 0,
+            },
+        );
+
+        // Let's add the data
+        reader.data.extend_from_slice(&[0; 10]); // Invalid deflate stream
+
+        let res = reader.read_resource("test");
+        assert!(matches!(res, Err(Error::Decompress { .. })));
+    }
+}

--- a/crates/duke-loader/src/zip.rs
+++ b/crates/duke-loader/src/zip.rs
@@ -1612,3 +1612,19 @@ mod proptests {
         }
     }
 }
+
+#[cfg(test)]
+mod tests_sentry {
+    use super::*;
+
+    #[test]
+    fn test_zip_reader_read_entry_not_found() {
+        let archive_data = vec![
+            0x50, 0x4b, 0x05, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        let reader = ZipReader::from_bytes(archive_data).unwrap();
+        let res = reader.read_entry("nonexistent.txt");
+        assert!(matches!(res, Err(Error::NotFound { .. })));
+    }
+}

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    {AttributeData, CpEntry, CpIndex},
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -3,8 +3,7 @@
 
 #[cfg(feature = "nova")]
 use duke_classfile::{
-    parse,
-    {AttributeData, CpEntry, CpIndex},
+    parse, {AttributeData, CpEntry, CpIndex},
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};


### PR DESCRIPTION
🎯 **Target:** `JImageReader` and `ZipReader` modules in `/app/crates/duke-loader/src/`.
💣 **Risk:** The previous codebase had unverified error handling paths (e.g., zip entry missing, decompression failure, jimage version mismatch, out-of-bounds `JImage` strings). 
🧪 **Strategy:** Added pure unit tests under `tests_sentry` to trigger out-of-bounds lookups, unsupported file versions, read errors, and zip entry lookup misses. Additionally, an existing `E0282` compiler bug in `jar_diff.rs` triggered by `--all-features` was correctly annotated to ensure tests pass on all targets.
🔬 **Verification:** `cd crates/duke-loader && cargo test --all-features tests_sentry`

---
*PR created automatically by Jules for task [4124918624886805019](https://jules.google.com/task/4124918624886805019) started by @madmax983*