### PR TITLE
⚒️ Forge: Flatten Pyramids of Doom in load_jar_methods

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**Extract Pyramids of doom from load_jar_methods in jar_diff.rs**
+**Learning:** `load_jar_methods` in `duke/src/jar_diff.rs` had deep nesting of `if let Ok(bytes) = loader.find_class(class_name_internal)` and `if let Ok(cf) = parse(&bytes)`. This is an unidiomatic "Pyramid of Doom" disguising the underlying intent of extracting the method hashes.
+**Action:** Always flatten deeply nested `if let` blocks inside loops using "Guard Clauses" with `else { continue; }` to reduce cognitive load and improve readability without changing behavior.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -151,25 +151,26 @@ fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
 
     for entry_name in class_entries {
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            #[allow(clippy::collapsible_if)]
-            if let Ok(cf) = parse(&bytes) {
-                let class_name = resolve_class_name(&cf, cf.this_class);
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
+        let Ok(cf) = parse(&bytes) else {
+            continue;
+        };
+        let class_name = resolve_class_name(&cf, cf.this_class);
 
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{class_name}::{name_str}{desc_str}");
+        for method in &cf.methods {
+            let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+            let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+            let full_name = format!("{class_name}::{name_str}{desc_str}");
 
-                    let mut hasher = DefaultHasher::new();
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            code.code.hash(&mut hasher);
-                        }
-                    }
-                    method_hashes.insert(full_name, hasher.finish());
+            let mut hasher = DefaultHasher::new();
+            for attr in &method.attributes {
+                if let AttributeData::Code(code) = &attr.data {
+                    code.code.hash(&mut hasher);
                 }
             }
+            method_hashes.insert(full_name, hasher.finish());
         }
     }
     method_hashes


### PR DESCRIPTION
### 🚮 Smell
`load_jar_methods` in `duke/src/jar_diff.rs` had deep nesting of `if let Ok(bytes) = loader.find_class(class_name_internal)` and `if let Ok(cf) = parse(&bytes)`. This is an unidiomatic "Pyramid of Doom" disguising the underlying intent of extracting the method hashes.

### ✨ Solution
Used idiomatic Rust guard clauses (`let Ok(...) = ... else { continue; };`) to flatten the loop structure. 

### 🧼 Benefit
Dramatically reduces cognitive load and improves readability without changing any behavior. The flow of method hash extraction is now a flat sequence of operations.

### 🛡️ Verification
Tests passed (`cargo test --all-targets --all-features`).
Clippy is happy (`cargo clippy --all-targets --all-features -- -D warnings`).
No logic changed.

---
*PR created automatically by Jules for task [12800464567974987011](https://jules.google.com/task/12800464567974987011) started by @madmax983*