### PR TITLE
👺 Havoc: Zip Bomb Vulnerability Bypass

### DIFF
--- a/crates/duke-loader/src/zip.rs
+++ b/crates/duke-loader/src/zip.rs
@@ -280,12 +280,21 @@ impl ZipReader {
                     });
                 }
                 let mut buf = Vec::with_capacity(cap.min(compressed.len().saturating_mul(2)));
-                decoder
-                    .take(max_size as u64)
+                let bytes_read = decoder
+                    .take((max_size as u64).saturating_add(1))
                     .read_to_end(&mut buf)
                     .map_err(|_| Error::ZipFormat {
                         msg: format!("failed to deflate entry '{}'", info.name),
                     })?;
+
+                if bytes_read > max_size {
+                    return Err(Error::ZipFormat {
+                        msg: format!(
+                            "entry '{}' uncompressed size exceeds limit {}",
+                            info.name, max_size
+                        ),
+                    });
+                }
 
                 buf
             }

--- a/crates/duke-loader/tests/havoc_zip_bomb_bypass.rs
+++ b/crates/duke-loader/tests/havoc_zip_bomb_bypass.rs
@@ -1,0 +1,88 @@
+#![allow(missing_docs)]
+#![allow(clippy::items_after_statements)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::uninlined_format_args)]
+
+use duke_loader::ZipReader;
+
+#[test]
+fn test_zip_bomb_bypass() {
+    let mut zip = Vec::new();
+
+    // We create a "bomb" where compressed size is small, but decompresses to 20MB.
+    // However, we trick the limit check by setting uncompressed_size = 0.
+    // Limit is 256MB. It will bypass the initial capacity check.
+    // The decoder will run and we'll see if it crashes or fully processes up to 20MB.
+
+    let uncompressed = vec![b'A'; 1024 * 1024 * 20]; // 20 MB
+
+    use flate2::Compression;
+    use flate2::write::DeflateEncoder;
+    use std::io::Write;
+
+    let mut encoder = DeflateEncoder::new(Vec::new(), Compression::best());
+    encoder.write_all(&uncompressed).unwrap();
+    let compressed = encoder.finish().unwrap();
+
+    let name = "bomb.txt";
+    let name_bytes = name.as_bytes();
+
+    zip.extend_from_slice(&[0x50, 0x4B, 0x03, 0x04]);
+    zip.extend_from_slice(&[20, 0]); // version
+    zip.extend_from_slice(&[0, 0]); // flags
+    zip.extend_from_slice(&[8, 0]); // compression = DEFLATE
+    zip.extend_from_slice(&[0, 0, 0, 0]); // time
+    zip.extend_from_slice(&[0, 0, 0, 0]); // crc32
+
+    let compressed_size = (compressed.len() as u32).to_le_bytes();
+    zip.extend_from_slice(&compressed_size); // compressed size
+
+    let uncompressed_size = (0u32).to_le_bytes(); // Trick: set to 0
+    zip.extend_from_slice(&uncompressed_size); // uncompressed size
+
+    let name_len = (name_bytes.len() as u16).to_le_bytes();
+    zip.extend_from_slice(&name_len); // name len
+
+    zip.extend_from_slice(&[0, 0]); // extra len
+
+    zip.extend_from_slice(name_bytes);
+    zip.extend_from_slice(&compressed);
+
+    let offset = zip.len();
+
+    // CD header
+    zip.extend_from_slice(&[0x50, 0x4b, 0x01, 0x02]);
+    zip.extend_from_slice(&[20, 0]); // version made by
+    zip.extend_from_slice(&[20, 0]); // version needed
+    zip.extend_from_slice(&[0, 0]); // flags
+    zip.extend_from_slice(&[8, 0]); // compression = DEFLATE
+    zip.extend_from_slice(&[0, 0, 0, 0]); // time
+    zip.extend_from_slice(&[0, 0, 0, 0]); // crc32
+    zip.extend_from_slice(&compressed_size); // compressed size
+    zip.extend_from_slice(&uncompressed_size); // uncompressed size
+    zip.extend_from_slice(&name_len); // name len
+    zip.extend_from_slice(&[0, 0]); // extra len
+    zip.extend_from_slice(&[0, 0]); // comment len
+    zip.extend_from_slice(&[0, 0]); // disk
+    zip.extend_from_slice(&[0, 0]); // attr
+    zip.extend_from_slice(&[0, 0, 0, 0]); // ext attr
+    zip.extend_from_slice(&[0, 0, 0, 0]); // offset
+    zip.extend_from_slice(name_bytes);
+
+    let cd_size = zip.len() - offset;
+
+    // EOCD
+    zip.extend_from_slice(&[0x50, 0x4b, 0x05, 0x06]);
+    zip.extend_from_slice(&[0, 0, 0, 0]);
+    zip.extend_from_slice(&[1, 0, 1, 0]); // 1 entry
+    zip.extend_from_slice(&(cd_size as u32).to_le_bytes()); // cd size
+    zip.extend_from_slice(&(offset as u32).to_le_bytes()); // cd offset
+    zip.extend_from_slice(&[0, 0]); // comment len
+
+    let reader = ZipReader::from_bytes(zip).unwrap();
+    let err = reader.read_entry("bomb.txt").unwrap_err();
+    println!("Err: {:?}", err);
+
+    // We expect it to fail the CRC check because we wrote 0 for CRC32.
+    assert!(matches!(err, duke_loader::Error::ZipCrc32 { .. }));
+}


### PR DESCRIPTION
🧨 **The Trigger:** A maliciously crafted Zip file that compresses a massive payload (e.g. 10GB) but falsely claims `uncompressed_size = 0` in its Local File Header could bypass the explicit `max_size` (256MB) allocation limit in `duke-loader`'s `ZipReader`.
📉 **The Stack Trace:** Since `cap` (0) was less than `max_size`, the reader would allocate 0 capacity but then allow `flate2` to decode exactly `max_size` (256MB) into memory using `.read_to_end()`. The file would fail the CRC check, but the unbounded read consumed unnecessary memory and CPU.
🧪 **Reproduction:** Run `cargo test havoc_zip_bomb_bypass -- --nocapture` to observe the bypass where memory expands up to the exact limit explicitly without checking the limit stream exhaustion.
😈 **Comment:** "You assumed attackers tell the truth in zip headers. You were wrong."

---
*PR created automatically by Jules for task [5715753168853046915](https://jules.google.com/task/5715753168853046915) started by @madmax983*