### PR TITLE
⚒️ Forge: ZipLoader duplication removal and guard clauses

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**ZipLoader Duplicate Search Logic**
+**Learning:** Found massive duplication across five methods in `ClassLoader for ZipLoader` (`find_class`, `find_resource`, etc.), where each method repeated the exact same try/catch/fallback flow for classpaths, BOOT-INF, and nested libraries.
+**Action:** Extract this flow into higher-order closures (e.g., `try_find_single` and `try_find_multiple`) that take `FnMut` strategies to eliminate boilerplate and unify error handling.

--- a/crates/duke-loader/src/zip.rs
+++ b/crates/duke-loader/src/zip.rs
@@ -447,152 +447,107 @@ impl ZipLoader {
     }
 }
 
-impl ClassLoader for ZipLoader {
-    fn find_class(&self, name: &str) -> Result<Vec<u8>> {
-        // Pre-allocate a single buffer large enough for the longest path
-        // "BOOT-INF/classes/".len() == 17, ".class".len() == 6. Total = 23
-        let mut entry_name = String::with_capacity(name.len() + 23);
-
-        // Try standard class path: {name}.class
-        entry_name.push_str(name);
-        entry_name.push_str(".class");
-        match self.reader.read_entry(&entry_name) {
+impl ZipLoader {
+    /// Helper to find a single item, abstracting the retry logic and nested library fallback.
+    fn try_find_single<T, F, N>(&self, name: &str, mut process_entry: F, nested_find: N) -> Result<T>
+    where
+        F: FnMut(&str) -> Result<T>,
+        N: Fn(&Self, &str) -> Result<T>,
+    {
+        match process_entry(name) {
             Err(Error::NotFound { .. }) => {}
             result => return result,
         }
 
-        // Try BOOT-INF path: BOOT-INF/classes/{name}.class
-        entry_name.clear();
-        Self::append_boot_inf_classes_path(&mut entry_name, name);
-        entry_name.push_str(".class");
-        match self.reader.read_entry(&entry_name) {
+        let mut boot_inf_name = String::with_capacity(name.len() + 17);
+        Self::append_boot_inf_classes_path(&mut boot_inf_name, name);
+        match process_entry(&boot_inf_name) {
             Err(Error::NotFound { .. }) => {}
             result => return result,
         }
 
         for nested_lib in &self.nested_libs {
-            match nested_lib.find_class(name) {
+            match nested_find(nested_lib, name) {
                 Err(Error::NotFound { .. }) => {}
                 result => return result,
             }
         }
+
         Err(Error::NotFound {
             name: name.to_string(),
         })
+    }
+
+    /// Helper to find multiple items, abstracting the accumulation logic.
+    fn try_find_multiple<T, F, N>(&self, name: &str, mut process_entry: F, nested_find: N) -> Result<Vec<T>>
+    where
+        F: FnMut(&str) -> Result<T>,
+        N: Fn(&Self, &str) -> Result<Vec<T>>,
+    {
+        let mut results = Vec::new();
+
+        match process_entry(name) {
+            Ok(item) => results.push(item),
+            Err(Error::NotFound { .. }) => {}
+            Err(err) => return Err(err),
+        }
+
+        let mut boot_inf_name = String::with_capacity(name.len() + 17);
+        Self::append_boot_inf_classes_path(&mut boot_inf_name, name);
+        match process_entry(&boot_inf_name) {
+            Ok(item) => results.push(item),
+            Err(Error::NotFound { .. }) => {}
+            Err(err) => return Err(err),
+        }
+
+        for nested_lib in &self.nested_libs {
+            results.extend(nested_find(nested_lib, name)?);
+        }
+
+        Ok(results)
+    }
+}
+
+impl ClassLoader for ZipLoader {
+    fn find_class(&self, name: &str) -> Result<Vec<u8>> {
+        let mut entry_name = String::with_capacity(name.len() + 23);
+
+        let process_entry = |base_name: &str| {
+            entry_name.clear();
+            entry_name.push_str(base_name);
+            entry_name.push_str(".class");
+            self.reader.read_entry(&entry_name)
+        };
+
+        self.try_find_single(name, process_entry, Self::find_class)
     }
 
     fn find_resource(&self, name: &str) -> Result<Vec<u8>> {
-        match self.reader.read_entry(name) {
-            Err(Error::NotFound { .. }) => {}
-            result => return result,
-        }
-
-        // ⚡ Bolt: Eliminate intermediate String allocation and format! macro overhead
-        let mut boot_inf_name = String::with_capacity(name.len() + 17);
-        Self::append_boot_inf_classes_path(&mut boot_inf_name, name);
-        match self.reader.read_entry(&boot_inf_name) {
-            Err(Error::NotFound { .. }) => {}
-            result => return result,
-        }
-
-        for nested_lib in &self.nested_libs {
-            match nested_lib.find_resource(name) {
-                Err(Error::NotFound { .. }) => {}
-                result => return result,
-            }
-        }
-        Err(Error::NotFound {
-            name: name.to_string(),
-        })
+        self.try_find_single(name, |n| self.reader.read_entry(n), Self::find_resource)
     }
 
     fn find_resources(&self, name: &str) -> Result<Vec<Vec<u8>>> {
-        let mut resources = Vec::new();
-        match self.reader.read_entry(name) {
-            Ok(bytes) => resources.push(bytes),
-            Err(Error::NotFound { .. }) => {}
-            Err(err) => return Err(err),
-        }
-
-        // ⚡ Bolt: Eliminate intermediate String allocation and format! macro overhead
-        let mut boot_inf_name = String::with_capacity(name.len() + 17);
-        Self::append_boot_inf_classes_path(&mut boot_inf_name, name);
-        match self.reader.read_entry(&boot_inf_name) {
-            Ok(bytes) => resources.push(bytes),
-            Err(Error::NotFound { .. }) => {}
-            Err(err) => return Err(err),
-        }
-
-        for nested_lib in &self.nested_libs {
-            resources.extend(nested_lib.find_resources(name)?);
-        }
-        Ok(resources)
+        self.try_find_multiple(name, |n| self.reader.read_entry(n), Self::find_resources)
     }
 
     fn find_resource_entry(&self, name: &str) -> Result<LocatedResource> {
-        match self.reader.read_entry(name) {
-            Ok(bytes) => {
-                return Ok(LocatedResource {
-                    bytes,
-                    url: self.resource_url(name),
-                });
-            }
-            Err(Error::NotFound { .. }) => {}
-            Err(err) => return Err(err),
-        }
-
-        let mut boot_inf_name = String::with_capacity(name.len() + 17);
-        Self::append_boot_inf_classes_path(&mut boot_inf_name, name);
-        match self.reader.read_entry(&boot_inf_name) {
-            Ok(bytes) => {
-                return Ok(LocatedResource {
-                    bytes,
-                    url: self.resource_url(&boot_inf_name),
-                });
-            }
-            Err(Error::NotFound { .. }) => {}
-            Err(err) => return Err(err),
-        }
-
-        for nested_lib in &self.nested_libs {
-            match nested_lib.find_resource_entry(name) {
-                Err(Error::NotFound { .. }) => {}
-                result => return result,
-            }
-        }
-
-        Err(Error::NotFound {
-            name: name.to_string(),
-        })
+        let process_entry = |n: &str| {
+            self.reader.read_entry(n).map(|bytes| LocatedResource {
+                bytes,
+                url: self.resource_url(n),
+            })
+        };
+        self.try_find_single(name, process_entry, Self::find_resource_entry)
     }
 
     fn find_resource_entries(&self, name: &str) -> Result<Vec<LocatedResource>> {
-        let mut resources = Vec::new();
-        match self.reader.read_entry(name) {
-            Ok(bytes) => resources.push(LocatedResource {
+        let process_entry = |n: &str| {
+            self.reader.read_entry(n).map(|bytes| LocatedResource {
                 bytes,
-                url: self.resource_url(name),
-            }),
-            Err(Error::NotFound { .. }) => {}
-            Err(err) => return Err(err),
-        }
-
-        let mut boot_inf_name = String::with_capacity(name.len() + 17);
-        Self::append_boot_inf_classes_path(&mut boot_inf_name, name);
-        match self.reader.read_entry(&boot_inf_name) {
-            Ok(bytes) => resources.push(LocatedResource {
-                bytes,
-                url: self.resource_url(&boot_inf_name),
-            }),
-            Err(Error::NotFound { .. }) => {}
-            Err(err) => return Err(err),
-        }
-
-        for nested_lib in &self.nested_libs {
-            resources.extend(nested_lib.find_resource_entries(name)?);
-        }
-
-        Ok(resources)
+                url: self.resource_url(n),
+            })
+        };
+        self.try_find_multiple(name, process_entry, Self::find_resource_entries)
     }
 }
 

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")
@@ -68,13 +68,9 @@ pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
     let mut modified = Vec::new();
     let mut unchanged = 0;
 
-    for k in keys2.difference(&keys1) {
-        added.push((*k).clone());
-    }
+    added.extend(keys2.difference(&keys1).map(|&s| s.clone()));
 
-    for k in keys1.difference(&keys2) {
-        removed.push((*k).clone());
-    }
+    removed.extend(keys1.difference(&keys2).map(|&s| s.clone()));
 
     for k in keys1.intersection(&keys2) {
         if map1.get(*k) == map2.get(*k) {
@@ -150,26 +146,24 @@ fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
         .collect();
 
     for entry_name in class_entries {
-        let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            #[allow(clippy::collapsible_if)]
-            if let Ok(cf) = parse(&bytes) {
-                let class_name = resolve_class_name(&cf, cf.this_class);
+        let Some(class_name_internal) = entry_name.strip_suffix(".class") else { continue; };
+        let Ok(bytes) = loader.find_class(class_name_internal) else { continue; };
+        let Ok(cf) = parse(&bytes) else { continue; };
 
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{class_name}::{name_str}{desc_str}");
+        let class_name = resolve_class_name(&cf, cf.this_class);
 
-                    let mut hasher = DefaultHasher::new();
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            code.code.hash(&mut hasher);
-                        }
-                    }
-                    method_hashes.insert(full_name, hasher.finish());
+        for method in &cf.methods {
+            let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+            let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+            let full_name = format!("{class_name}::{name_str}{desc_str}");
+
+            let mut hasher = DefaultHasher::new();
+            for attr in &method.attributes {
+                if let AttributeData::Code(code) = &attr.data {
+                    code.code.hash(&mut hasher);
                 }
             }
+            method_hashes.insert(full_name, hasher.finish());
         }
     }
     method_hashes


### PR DESCRIPTION
🚮 Smell: `impl ClassLoader for ZipLoader` contained 5 identically structured methods (`find_class`, `find_resource`, `find_resources`, etc.) that repeated the same try-catch fallback search logic (normal path, BOOT-INF path, nested lib path). Also, `duke/src/jar_diff.rs` had a classic Pyramid of Doom using nested `if let Ok()`.
✨ Solution: Created two generic higher-order functions `try_find_single` and `try_find_multiple` on `ZipLoader` that take closures to define the specific lookup mechanisms, completely DRY-ing up the boilerplate. Extracted deeply nested logic in `jar_diff.rs` using `let else` guard clauses.
🧼 Benefit: Significantly reduces cognitive load. `ZipLoader` is now flat and intention-revealing, and `jar_diff.rs` is much easier to read.
🛡️ Verification: `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt --all` passed successfully. No logic changed.

---
*PR created automatically by Jules for task [11589440363787792804](https://jules.google.com/task/11589440363787792804) started by @madmax983*