### PR TITLE
⚒️ Forge: Flatten Pyramids of Doom in Duke Tools

### DIFF
--- a/duke/src/audit.rs
+++ b/duke/src/audit.rs
@@ -78,7 +78,7 @@ fn resolve_method_ref(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<(S
 }
 
 #[cfg(feature = "nova")]
-#[allow(clippy::print_stdout, clippy::collapsible_if, clippy::use_debug)]
+#[allow(clippy::print_stdout, clippy::use_debug)]
 pub fn dump_jar_audit(jar_path: &str) {
     let loader = ZipLoader::open(Path::new(jar_path)).unwrap_or_else(|e| {
         eprintln!("duke: failed to open JAR '{jar_path}': {e}");
@@ -100,48 +100,53 @@ pub fn dump_jar_audit(jar_path: &str) {
 
     for entry_name in class_entries {
         let class_name_internal = &entry_name[..entry_name.len() - 6];
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            if let Ok(cf) = parse(&bytes) {
-                let this_class = resolve_class_name(&cf, cf.this_class);
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{this_class}::{name_str}{desc_str}");
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
+        let Ok(cf) = parse(&bytes) else {
+            continue;
+        };
 
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            if let Ok(instructions) = decode(&code.code) {
-                                for (pc, instr) in instructions {
-                                    let method_ref_idx = match instr {
-                                        Instruction::Invokevirtual(idx)
-                                        | Instruction::Invokespecial(idx)
-                                        | Instruction::Invokestatic(idx) => Some(idx),
-                                        Instruction::Invokeinterface { index, .. } => Some(index),
-                                        _ => None,
-                                    };
+        let this_class = resolve_class_name(&cf, cf.this_class);
+        for method in &cf.methods {
+            let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+            let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+            let full_name = format!("{this_class}::{name_str}{desc_str}");
 
-                                    if let Some(idx) = method_ref_idx {
-                                        if let Some((target_class, target_method)) =
-                                            resolve_method_ref(&cf, idx)
-                                        {
-                                            if target_class == "java/lang/System"
-                                                && target_method == "exit"
-                                            {
-                                                findings.push(format!("  [!] System.exit() called in {full_name} @ {pc}"));
-                                            } else if target_class == "java/lang/Runtime"
-                                                && target_method == "exec"
-                                            {
-                                                findings.push(format!("  [!] Runtime.exec() called in {full_name} @ {pc}"));
-                                            } else if target_class == "java/lang/reflect/Method"
-                                                && target_method == "invoke"
-                                            {
-                                                findings.push(format!("  [!] Method.invoke() (Reflection) used in {full_name} @ {pc}"));
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+            for attr in &method.attributes {
+                let AttributeData::Code(code) = &attr.data else {
+                    continue;
+                };
+                let Ok(instructions) = decode(&code.code) else {
+                    continue;
+                };
+
+                for (pc, instr) in instructions {
+                    let method_ref_idx = match instr {
+                        Instruction::Invokevirtual(idx)
+                        | Instruction::Invokespecial(idx)
+                        | Instruction::Invokestatic(idx) => Some(idx),
+                        Instruction::Invokeinterface { index, .. } => Some(index),
+                        _ => None,
+                    };
+
+                    let Some(idx) = method_ref_idx else {
+                        continue;
+                    };
+                    let Some((target_class, target_method)) = resolve_method_ref(&cf, idx) else {
+                        continue;
+                    };
+
+                    if target_class == "java/lang/System" && target_method == "exit" {
+                        findings.push(format!("  [!] System.exit() called in {full_name} @ {pc}"));
+                    } else if target_class == "java/lang/Runtime" && target_method == "exec" {
+                        findings.push(format!("  [!] Runtime.exec() called in {full_name} @ {pc}"));
+                    } else if target_class == "java/lang/reflect/Method"
+                        && target_method == "invoke"
+                    {
+                        findings.push(format!(
+                            "  [!] Method.invoke() (Reflection) used in {full_name} @ {pc}"
+                        ));
                     }
                 }
             }

--- a/duke/src/dead_code.rs
+++ b/duke/src/dead_code.rs
@@ -74,11 +74,7 @@ fn extract_method_ref(cf: &ClassFile, idx: CpIndex) -> Option<(String, String, S
 
 #[cfg(feature = "nova")]
 #[cfg(not(tarpaulin_include))]
-#[allow(
-    unexpected_cfgs,
-    clippy::collapsible_if,
-    clippy::items_after_statements
-)]
+#[allow(unexpected_cfgs, clippy::items_after_statements)]
 pub fn dump_dead_code(cf: &ClassFile) {
     let mut defined_methods = HashSet::new();
     let mut called_methods = HashSet::new();
@@ -97,29 +93,33 @@ pub fn dump_dead_code(cf: &ClassFile) {
         }
 
         for attr in &method.attributes {
-            if let AttributeData::Code(code) = &attr.data {
-                if let Ok(instructions) = decode(&code.code) {
-                    for (_, instr) in instructions {
-                        let target_idx = match instr {
-                            Instruction::Invokevirtual(idx)
-                            | Instruction::Invokespecial(idx)
-                            | Instruction::Invokestatic(idx)
-                            | Instruction::Invokeinterface { index: idx, .. } => Some(idx),
-                            _ => None,
-                        };
+            let AttributeData::Code(code) = &attr.data else {
+                continue;
+            };
+            let Ok(instructions) = decode(&code.code) else {
+                continue;
+            };
+            for (_, instr) in instructions {
+                let target_idx = match instr {
+                    Instruction::Invokevirtual(idx)
+                    | Instruction::Invokespecial(idx)
+                    | Instruction::Invokestatic(idx)
+                    | Instruction::Invokeinterface { index: idx, .. } => Some(idx),
+                    _ => None,
+                };
 
-                        if let Some(idx) = target_idx {
-                            if let Some((target_class, target_method, target_descriptor)) =
-                                extract_method_ref(cf, idx)
-                            {
-                                if target_class == class_name {
-                                    called_methods.insert(format!(
-                                        "{target_class}::{target_method}{target_descriptor}"
-                                    ));
-                                }
-                            }
-                        }
-                    }
+                let Some(idx) = target_idx else {
+                    continue;
+                };
+                let Some((target_class, target_method, target_descriptor)) =
+                    extract_method_ref(cf, idx)
+                else {
+                    continue;
+                };
+                if target_class == class_name {
+                    called_methods.insert(format!(
+                        "{target_class}::{target_method}{target_descriptor}"
+                    ));
                 }
             }
         }
@@ -148,7 +148,6 @@ pub fn dump_dead_code(cf: &ClassFile) {
 #[allow(
     unexpected_cfgs,
     clippy::cast_precision_loss,
-    clippy::collapsible_if,
     clippy::case_sensitive_file_extension_comparisons,
     clippy::items_after_statements
 )]
@@ -170,52 +169,56 @@ pub fn dump_jar_dead_code(jar_path: &str) {
             continue;
         }
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            if let Ok(cf) = duke_classfile::parse(&bytes) {
-                total_classes += 1;
-                let class_name = resolve_class_name(&cf, cf.this_class);
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
+        let Ok(cf) = duke_classfile::parse(&bytes) else {
+            continue;
+        };
 
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{class_name}::{name_str}{desc_str}");
+        total_classes += 1;
+        let class_name = resolve_class_name(&cf, cf.this_class);
 
-                    defined_methods.insert(full_name.clone());
+        for method in &cf.methods {
+            let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+            let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+            let full_name = format!("{class_name}::{name_str}{desc_str}");
 
-                    if name_str == "main" || name_str == "<clinit>" || name_str == "<init>" {
-                        called_methods.insert(full_name);
-                    }
+            defined_methods.insert(full_name.clone());
 
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            if let Ok(instructions) = decode(&code.code) {
-                                for (_, instr) in instructions {
-                                    let target_idx = match instr {
-                                        Instruction::Invokevirtual(idx)
-                                        | Instruction::Invokespecial(idx)
-                                        | Instruction::Invokestatic(idx)
-                                        | Instruction::Invokeinterface { index: idx, .. } => {
-                                            Some(idx)
-                                        }
-                                        _ => None,
-                                    };
+            if name_str == "main" || name_str == "<clinit>" || name_str == "<init>" {
+                called_methods.insert(full_name);
+            }
 
-                                    if let Some(idx) = target_idx {
-                                        if let Some((
-                                            target_class,
-                                            target_method,
-                                            target_descriptor,
-                                        )) = extract_method_ref(&cf, idx)
-                                        {
-                                            called_methods.insert(format!(
-                                                "{target_class}::{target_method}{target_descriptor}"
-                                            ));
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+            for attr in &method.attributes {
+                let AttributeData::Code(code) = &attr.data else {
+                    continue;
+                };
+                let Ok(instructions) = decode(&code.code) else {
+                    continue;
+                };
+
+                for (_, instr) in instructions {
+                    let target_idx = match instr {
+                        Instruction::Invokevirtual(idx)
+                        | Instruction::Invokespecial(idx)
+                        | Instruction::Invokestatic(idx)
+                        | Instruction::Invokeinterface { index: idx, .. } => Some(idx),
+                        _ => None,
+                    };
+
+                    let Some(idx) = target_idx else {
+                        continue;
+                    };
+                    let Some((target_class, target_method, target_descriptor)) =
+                        extract_method_ref(&cf, idx)
+                    else {
+                        continue;
+                    };
+
+                    called_methods.insert(format!(
+                        "{target_class}::{target_method}{target_descriptor}"
+                    ));
                 }
             }
         }

--- a/duke/src/inspect.rs
+++ b/duke/src/inspect.rs
@@ -3,7 +3,7 @@ use duke_classfile::{parse, AttributeData};
 use duke_loader::ZipReader;
 use std::fs;
 
-#[allow(clippy::cast_precision_loss, clippy::case_sensitive_file_extension_comparisons, clippy::collapsible_if)]
+#[allow(clippy::cast_precision_loss, clippy::case_sensitive_file_extension_comparisons)]
 /// Prints a static analysis report of a JAR file to standard output.
 ///
 /// **Why it exists:** Provides developers with a high-level overview of a JAR's
@@ -38,44 +38,43 @@ pub fn inspect_jar(path: &str) {
     names.sort_unstable(); // For deterministic parsing in tests
 
     for name in names {
-        if name.ends_with(".class") {
-            if let Ok(class_bytes) = zip.read_entry(name) {
-                if let Ok(cf) = parse(&class_bytes) {
-                    total_classes += 1;
-                    total_fields += cf.fields.len();
-                    total_methods += cf.methods.len();
+        if !name.ends_with(".class") {
+            continue;
+        }
+        let Ok(class_bytes) = zip.read_entry(name) else { continue; };
+        let Ok(cf) = parse(&class_bytes) else { continue; };
 
-                    let class_name = name.replace(".class", "").replace('/', ".");
+        total_classes += 1;
+        total_fields += cf.fields.len();
+        total_methods += cf.methods.len();
 
-                    for method in &cf.methods {
-                        let method_name = cf
-                            .constant_pool
-                            .get(method.name_index.0 as usize)
-                            .and_then(|e| e.as_ref())
-                            .and_then(|e| {
-                                if let duke_classfile::CpEntry::Utf8(s) = e {
-                                    Some(s)
-                                } else {
-                                    None
-                                }
-                            })
-                            .map_or("<unknown>", std::string::String::as_str);
+        let class_name = name.replace(".class", "").replace('/', ".");
 
-                        for attr in &method.attributes {
-                            if let AttributeData::Code(code) = &attr.data {
-                                if let Ok(instructions) = decode(&code.code) {
-                                    total_instructions += instructions.len();
-                                    let comp = cyclomatic_complexity(&instructions);
-                                    total_complexity += comp;
-
-                                    if comp > max_complexity {
-                                        max_complexity = comp;
-                                        max_complex_method = format!("{class_name}::{method_name}");
-                                    }
-                                }
-                            }
-                        }
+        for method in &cf.methods {
+            let method_name = cf
+                .constant_pool
+                .get(method.name_index.0 as usize)
+                .and_then(|e| e.as_ref())
+                .and_then(|e| {
+                    if let duke_classfile::CpEntry::Utf8(s) = e {
+                        Some(s)
+                    } else {
+                        None
                     }
+                })
+                .map_or("<unknown>", std::string::String::as_str);
+
+            for attr in &method.attributes {
+                let AttributeData::Code(code) = &attr.data else { continue; };
+                let Ok(instructions) = decode(&code.code) else { continue; };
+
+                total_instructions += instructions.len();
+                let comp = cyclomatic_complexity(&instructions);
+                total_complexity += comp;
+
+                if comp > max_complexity {
+                    max_complexity = comp;
+                    max_complex_method = format!("{class_name}::{method_name}");
                 }
             }
         }


### PR DESCRIPTION
🚮 **Smell:** Several functions in `duke/src/audit.rs`, `duke/src/dead_code.rs`, and `duke/src/inspect.rs` suffered from deeply nested "Pyramids of Doom" due to multiple layers of `if let` and `if` statements wrapped around loop iterations. This made the logic difficult to read and track.

✨ **Solution:** Refactored the deeply nested `if let` blocks into flat `let else` guard clauses with `continue` statements. The `#[allow(clippy::collapsible_if)]` attributes that were present to suppress warnings about the original nesting have also been removed, as they are no longer needed.

🧼 **Benefit:** Drastically improves readability by keeping the logic flat. It reduces cognitive load by bringing the "happy path" code back to a manageable indentation level while early-bailing out of iterations that don't match the expected patterns.

🛡️ **Verification:** Tests passed. Logic remains identical (zero behavior change).


---
*PR created automatically by Jules for task [8602219651436811865](https://jules.google.com/task/8602219651436811865) started by @madmax983*