### PR TITLE
⚡ Bolt: Eliminate intermediate string allocations in format padding

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,6 @@
 **Trust the Iterator: .collect() is Optimized**
 **Learning:** In Rust, `.collect::<Vec<_>>()` called on an `ExactSizeIterator` (which `slice.iter().map()` implements) already knows the exact number of elements. The standard library heavily optimizes this via the `TrustedLen` trait to allocate the precise capacity upfront and completely bypass bounds checks during insertion.
 **Action:** Do not manually replace `.collect::<Vec<_>>()` with `Vec::with_capacity` and a `for` loop, as it re-introduces bounds checks on every push, making the "optimization" unidiomatic and a micro-regression.
+**Eliminate Intermediate String Allocations with `reserve_exact` and `repeat_n`**
+**Learning:** When using `format!` with `" ".repeat(pad)` to right-justify or left-justify strings, multiple intermediate heap allocations occur (one for the repeated string, one for the format macro).
+**Action:** Replace `format!("{s}{}", " ".repeat(pad))` with an in-place `s.reserve_exact(pad); s.extend(std::iter::repeat_n(' ', pad));` to eliminate all intermediate allocations and reuse the existing string buffer. Use `std::iter::repeat_n` instead of `.take()` to satisfy clippy.

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -16156,7 +16156,7 @@ pub(crate) fn native_string_concat(
 
 /// Formats a single boxed slot value using the given format specifier.
 /// Apply width/alignment/flags to an already-formatted value string.
-fn apply_format_width(s: String, width: usize, left_align: bool, zero_pad: bool) -> String {
+fn apply_format_width(mut s: String, width: usize, left_align: bool, zero_pad: bool) -> String {
     // Havoc: bounds check width to prevent OOM
     let max_width = 1024 * 1024 * 128; // 128 MB
     let width = width.min(max_width);
@@ -16165,18 +16165,29 @@ fn apply_format_width(s: String, width: usize, left_align: bool, zero_pad: bool)
         return s;
     }
     let pad = width - s.len();
+
+    // ⚡ Bolt: Eliminate intermediate String allocation and format! macro overhead
     if left_align {
-        format!("{s}{}", " ".repeat(pad))
+        s.reserve_exact(pad);
+        s.extend(std::iter::repeat_n(' ', pad));
+        s
     } else if zero_pad {
-        // zero-pad: insert zeros after optional sign
+        let mut out = String::with_capacity(width);
         if s.starts_with('-') || s.starts_with('+') {
             let (sign, rest) = s.split_at(1);
-            format!("{sign}{}{rest}", "0".repeat(pad))
+            out.push_str(sign);
+            out.extend(std::iter::repeat_n('0', pad));
+            out.push_str(rest);
         } else {
-            format!("{}{s}", "0".repeat(pad))
+            out.extend(std::iter::repeat_n('0', pad));
+            out.push_str(&s);
         }
+        out
     } else {
-        format!("{}{s}", " ".repeat(pad))
+        let mut out = String::with_capacity(width);
+        out.extend(std::iter::repeat_n(' ', pad));
+        out.push_str(&s);
+        out
     }
 }
 


### PR DESCRIPTION
💡 What: Refactored `apply_format_width` in `crates/duke-interpreter/src/native.rs` to replace `format!("{s}{}", " ".repeat(pad))` with `String::with_capacity` and `String::extend(std::iter::repeat_n(...))`. For left-alignment, it reuses the original string buffer by reserving exact capacity and extending it in-place.
🎯 Why: String padding was previously generating an intermediate string via `" ".repeat(pad)` and then evaluating a `format!` macro overhead, unnecessarily allocating memory and slowing down execution on format paths.
📊 Impact: Eliminates multiple intermediate heap allocations when formatting text output.
🔬 Measurement: Run the test suite and verify no regressions exist, or run benchmarks that format padded strings to see fewer heap allocations.

---
*PR created automatically by Jules for task [11599428395644196471](https://jules.google.com/task/11599428395644196471) started by @madmax983*