### PR TITLE
🛡️ Sentry: [test coverage improvement] wide instruction mnemonics

### DIFF
--- a/crates/duke-bytecode/src/instruction.rs
+++ b/crates/duke-bytecode/src/instruction.rs
@@ -1567,4 +1567,18 @@ mod tests {
         assert!(!Instruction::Ifeq(0).is_unconditional_jump());
         assert!(!Instruction::Nop.is_unconditional_jump());
     }
+
+    #[test]
+    fn test_wide_instruction_mnemonics() {
+        assert_eq!(Instruction::IstoreW(0).mnemonic(), "wide istore");
+        assert_eq!(Instruction::LstoreW(0).mnemonic(), "wide lstore");
+        assert_eq!(Instruction::FstoreW(0).mnemonic(), "wide fstore");
+        assert_eq!(Instruction::DstoreW(0).mnemonic(), "wide dstore");
+        assert_eq!(Instruction::AstoreW(0).mnemonic(), "wide astore");
+        assert_eq!(Instruction::RetW(0).mnemonic(), "wide ret");
+        assert_eq!(
+            Instruction::IincW { index: 0, value: 0 }.mnemonic(),
+            "wide iinc"
+        );
+    }
 }


### PR DESCRIPTION
This PR adds test coverage for the wide instruction variants in the `duke-bytecode` crate.

Specifically, it verifies that the `.mnemonic()` method correctly returns the expected string values for instructions like `wide istore`, `wide lstore`, `wide iinc`, etc. This addresses a coverage gap in the `Instruction` enum's logic.

---
*PR created automatically by Jules for task [15747478101770470304](https://jules.google.com/task/15747478101770470304) started by @madmax983*