### PR TITLE
⚒️ Forge: Flatten Pyramids of Doom

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**[Flatten Nested Loop Blocks]
+**Learning:** Functions in `scan.rs`, `search.rs`, `simulate.rs`, `jar_diff.rs` and `native.rs` had "Pyramids of Doom" using nested `if let` matching inside loops, and disabling the `clippy::collapsible_if` lint to silence warnings. This created excessive nesting that hurt readability.
+**Action:** Replace nested `if let` blocks inside loops with idiomatic let-else pattern guard clauses (`let Ok(val) = result else { continue; };`). This dramatically flattens the structure and removes the need for `#[allow(clippy::collapsible_if)]`.

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -5656,19 +5656,14 @@ pub(crate) fn native_stream_collect(
         joined.push_str(&prefix);
         let mut first = true;
         for s in &elems {
-            #[allow(clippy::collapsible_if)]
-            if let Slot::Reference(Some(r)) = s {
-                #[allow(clippy::collapsible_if)]
-                if let Ok(obj) = heap.get(*r) {
-                    if let Some(s_val) = &obj.string_value {
-                        if !first {
-                            joined.push_str(&delim);
-                        }
-                        joined.push_str(s_val);
-                        first = false;
-                    }
-                }
+            let Slot::Reference(Some(r)) = s else { continue; };
+            let Ok(obj) = heap.get(*r) else { continue; };
+            let Some(s_val) = &obj.string_value else { continue; };
+            if !first {
+                joined.push_str(&delim);
             }
+            joined.push_str(s_val);
+            first = false;
         }
         joined.push_str(&suffix);
 

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -3,8 +3,7 @@
 
 #[cfg(feature = "nova")]
 use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    parse, AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -151,25 +150,26 @@ fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
 
     for entry_name in class_entries {
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            #[allow(clippy::collapsible_if)]
-            if let Ok(cf) = parse(&bytes) {
-                let class_name = resolve_class_name(&cf, cf.this_class);
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
+        let Ok(cf) = parse(&bytes) else {
+            continue;
+        };
+        let class_name = resolve_class_name(&cf, cf.this_class);
 
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{class_name}::{name_str}{desc_str}");
+        for method in &cf.methods {
+            let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+            let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+            let full_name = format!("{class_name}::{name_str}{desc_str}");
 
-                    let mut hasher = DefaultHasher::new();
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            code.code.hash(&mut hasher);
-                        }
-                    }
-                    method_hashes.insert(full_name, hasher.finish());
+            let mut hasher = DefaultHasher::new();
+            for attr in &method.attributes {
+                if let AttributeData::Code(code) = &attr.data {
+                    code.code.hash(&mut hasher);
                 }
             }
+            method_hashes.insert(full_name, hasher.finish());
         }
     }
     method_hashes

--- a/duke/src/scan.rs
+++ b/duke/src/scan.rs
@@ -193,24 +193,26 @@ pub fn dump_jar_scan(jar_path: &str) {
             continue;
         }
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        #[allow(clippy::collapsible_if)]
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            if let Ok(cf) = parse(&bytes) {
-                total_classes += 1;
-                let matches = scan_classfile(&cf);
-                if !matches.is_empty() {
-                    total_matches += matches.len();
-                    println!("⚠️  In class '{class_name_internal}':");
-                    for m in matches {
-                        println!(
-                            "    [{}] {}::{} ({})",
-                            m.rule.severity, m.rule.class_name, m.rule.method_name, m.location
-                        );
-                        println!("      Reason: {}", m.rule.description);
-                    }
-                    println!();
-                }
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
+        let Ok(cf) = parse(&bytes) else {
+            continue;
+        };
+
+        total_classes += 1;
+        let matches = scan_classfile(&cf);
+        if !matches.is_empty() {
+            total_matches += matches.len();
+            println!("⚠️  In class '{class_name_internal}':");
+            for m in matches {
+                println!(
+                    "    [{}] {}::{} ({})",
+                    m.rule.severity, m.rule.class_name, m.rule.method_name, m.location
+                );
+                println!("      Reason: {}", m.rule.description);
             }
+            println!();
         }
     }
 

--- a/duke/src/search.rs
+++ b/duke/src/search.rs
@@ -1,6 +1,6 @@
 use duke_bytecode::decode;
 use duke_classfile::{
-    parse, {AttributeData, CpEntry, CpIndex},
+    parse, AttributeData, CpEntry, CpIndex,
 };
 use std::process;
 
@@ -55,25 +55,26 @@ pub fn dump_search(path: &str, query: &str) {
         let full_name = format!("{name_str}{desc_str}");
 
         for attr in &method.attributes {
-            if let AttributeData::Code(code) = &attr.data {
-                #[allow(clippy::collapsible_if)]
-                if let Ok(instructions) = decode(&code.code) {
-                    let mut found_in_method = false;
-                    for (pc, instr) in instructions {
-                        let mnemonic = instr.mnemonic().to_lowercase();
-                        if mnemonic.contains(&query_lower) {
-                            if !found_in_method {
-                                println!("Method: {full_name}");
-                                found_in_method = true;
-                                found_any = true;
-                            }
-                            println!("  {pc:>4}: {mnemonic}");
-                        }
+            let AttributeData::Code(code) = &attr.data else {
+                continue;
+            };
+            let Ok(instructions) = decode(&code.code) else {
+                continue;
+            };
+            let mut found_in_method = false;
+            for (pc, instr) in instructions {
+                let mnemonic = instr.mnemonic().to_lowercase();
+                if mnemonic.contains(&query_lower) {
+                    if !found_in_method {
+                        println!("Method: {full_name}");
+                        found_in_method = true;
+                        found_any = true;
                     }
-                    if found_in_method {
-                        println!();
-                    }
+                    println!("  {pc:>4}: {mnemonic}");
                 }
+            }
+            if found_in_method {
+                println!();
             }
         }
     }

--- a/duke/src/simulate.rs
+++ b/duke/src/simulate.rs
@@ -32,16 +32,17 @@ pub fn dump_simulate(path: &str, method_name: &str) {
     if let Some(target) = target {
         println!("Simulating execution of method '{method_name}'...");
         for attr in &target.attributes {
-            #[allow(clippy::collapsible_if)]
-            if let AttributeData::Code(code) = &attr.data {
-                if let Ok(decoded) = decode(&code.code) {
-                    println!("--- Instruction Trace ---");
-                    for (pc, instr) in decoded {
-                        println!("PC {pc:>3}: Executing {}", instr.mnemonic());
-                    }
-                    println!("--- End Trace ---");
-                }
+            let AttributeData::Code(code) = &attr.data else {
+                continue;
+            };
+            let Ok(decoded) = decode(&code.code) else {
+                continue;
+            };
+            println!("--- Instruction Trace ---");
+            for (pc, instr) in decoded {
+                println!("PC {pc:>3}: Executing {}", instr.mnemonic());
             }
+            println!("--- End Trace ---");
         }
     } else {
         println!("duke: method '{method_name}' not found");


### PR DESCRIPTION
🚮 **Smell:** Several core files (`native.rs`, `jar_diff.rs`, `scan.rs`, `search.rs`, and `simulate.rs`) contained deeply nested `if let` matching inside loops (Pyramids of Doom). To suppress compiler warnings about this nesting, `#[allow(clippy::collapsible_if)]` attributes were sprinkled throughout, hiding the structural issue rather than fixing it.
✨ **Solution:** Refactored the deeply nested `if let` blocks using idiomatic Rust guard clauses (`let Ok(val) = result else { continue; };`). Also removed the obsolete `#[allow(clippy::collapsible_if)]` attributes. Fixed nested braces inside import statements broken during refactor. 
🧼 **Benefit:** Dramatically flattens the code structure, reducing cognitive load and making the "happy path" logic strictly left-aligned.
🛡️ **Verification:** Tests passed. `cargo clippy --all-targets --all-features -- -D warnings` passed cleanly. No logic was changed, only control flow restructuring.

---
*PR created automatically by Jules for task [17343702649990789827](https://jules.google.com/task/17343702649990789827) started by @madmax983*