### PR TITLE
🗺️ Atlas: [jar_diff dependency]

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -7,3 +7,6 @@
 **[Encapsulate `duke_classfile` Facade]**
 **Tangle:** The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types, and `duke-telemetry` exposed internal serialization helpers via `pub mod ser_helpers`. This creates confusing, leaky abstractions and redundant paths.
 **Blueprint:** Encapsulated both modules. In `duke_classfile`, replaced `pub mod types` with direct `pub use` statements at the crate root, eliminating the `types` namespace from the public API entirely. In `duke_telemetry`, reduced `ser_helpers` visibility to `pub(crate)`.
+**[jar_diff dependency]**
+**Tangle:** `duke/src/jar_diff.rs` attempted to import types like `AttributeData`, `CpEntry`, `CpIndex` through the `types` module of `duke_classfile`, which doesn't exist. It also had a closure inference issue due to missing type hints on `Option<CpEntry>`.
+**Blueprint:** Removed the `types::` prefix for `duke_classfile` imports since they're exported at the crate root, and explicitly typed the closures `|slot: &Option<CpEntry>|` and `|s: &Option<CpEntry>|` resolving the inference problem.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
🕸️ Tangle: The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types. This created leaky abstractions, and its recent removal broke `jar_diff.rs`. Additionally, closure parameters lost type inference without it.
📐 Blueprint: Encapsulated the module and removed `types::` prefix for `duke_classfile` imports in `jar_diff.rs` since they are now correctly exported at the crate root. Explicitly typed the closures `|slot: &Option<CpEntry>|` and `|s: &Option<CpEntry>|` to resolve the inference problem.
🧱 Stability: Enforced clear module boundaries and improved type stability for closures.
🔬 Verification: Builds successfully, strict separation enforced.

---
*PR created automatically by Jules for task [18445481512169506604](https://jules.google.com/task/18445481512169506604) started by @madmax983*