### PR TITLE
test(telemetry): increase coverage for missing error and formatting branches

### DIFF
--- a/crates/duke-telemetry/src/helpers.rs
+++ b/crates/duke-telemetry/src/helpers.rs
@@ -60,6 +60,138 @@ pub mod ser_helpers {
 #[cfg(test)]
 #[cfg(feature = "telemetry")]
 mod tests {
+    struct FailingSerializer;
+    impl serde::Serializer for FailingSerializer {
+        type Ok = ();
+        type Error = serde::de::value::Error;
+        type SerializeSeq = serde::ser::Impossible<(), Self::Error>;
+        type SerializeTuple = serde::ser::Impossible<(), Self::Error>;
+        type SerializeTupleStruct = serde::ser::Impossible<(), Self::Error>;
+        type SerializeTupleVariant = serde::ser::Impossible<(), Self::Error>;
+        type SerializeMap = serde::ser::Impossible<(), Self::Error>;
+        type SerializeStruct = serde::ser::Impossible<(), Self::Error>;
+        type SerializeStructVariant = serde::ser::Impossible<(), Self::Error>;
+        fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_some<T: ?Sized + Serialize>(self, _v: &T) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_unit_variant(
+            self,
+            _n: &'static str,
+            _vi: u32,
+            _va: &'static str,
+        ) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_newtype_struct<T: ?Sized + Serialize>(
+            self,
+            _name: &'static str,
+            _v: &T,
+        ) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_newtype_variant<T: ?Sized + Serialize>(
+            self,
+            _n: &'static str,
+            _vi: u32,
+            _va: &'static str,
+            _v: &T,
+        ) -> Result<Self::Ok, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_tuple_struct(
+            self,
+            _name: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_tuple_variant(
+            self,
+            _n: &'static str,
+            _vi: u32,
+            _va: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+            Err(serde::de::Error::custom("map err"))
+        }
+        fn serialize_struct(
+            self,
+            _name: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeStruct, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+        fn serialize_struct_variant(
+            self,
+            _n: &'static str,
+            _vi: u32,
+            _va: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeStructVariant, Self::Error> {
+            Err(serde::de::Error::custom("err"))
+        }
+    }
+
     use super::ser_helpers::*;
     use serde::Serialize;
     use std::collections::{HashMap, HashSet};
@@ -295,144 +427,17 @@ mod tests {
     #[test]
     #[allow(clippy::too_many_lines)]
     fn test_sorted_set_error() {
-        struct FailingSerializer;
-        impl serde::Serializer for FailingSerializer {
-            type Ok = ();
-            type Error = serde::de::value::Error;
-            type SerializeSeq = serde::ser::Impossible<(), Self::Error>;
-            type SerializeTuple = serde::ser::Impossible<(), Self::Error>;
-            type SerializeTupleStruct = serde::ser::Impossible<(), Self::Error>;
-            type SerializeTupleVariant = serde::ser::Impossible<(), Self::Error>;
-            type SerializeMap = serde::ser::Impossible<(), Self::Error>;
-            type SerializeStruct = serde::ser::Impossible<(), Self::Error>;
-            type SerializeStructVariant = serde::ser::Impossible<(), Self::Error>;
-            fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_some<T: ?Sized + Serialize>(
-                self,
-                _v: &T,
-            ) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_unit_variant(
-                self,
-                _n: &'static str,
-                _vi: u32,
-                _va: &'static str,
-            ) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_newtype_struct<T: ?Sized + Serialize>(
-                self,
-                _name: &'static str,
-                _v: &T,
-            ) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_newtype_variant<T: ?Sized + Serialize>(
-                self,
-                _n: &'static str,
-                _vi: u32,
-                _va: &'static str,
-                _v: &T,
-            ) -> Result<Self::Ok, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_tuple_struct(
-                self,
-                _name: &'static str,
-                _len: usize,
-            ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_tuple_variant(
-                self,
-                _n: &'static str,
-                _vi: u32,
-                _va: &'static str,
-                _len: usize,
-            ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-                Err(serde::de::Error::custom("map err"))
-            }
-            fn serialize_struct(
-                self,
-                _name: &'static str,
-                _len: usize,
-            ) -> Result<Self::SerializeStruct, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-            fn serialize_struct_variant(
-                self,
-                _n: &'static str,
-                _vi: u32,
-                _va: &'static str,
-                _len: usize,
-            ) -> Result<Self::SerializeStructVariant, Self::Error> {
-                Err(serde::de::Error::custom("err"))
-            }
-        }
-
         let mut set = std::collections::HashSet::new();
         set.insert("a".to_string());
         let res = super::ser_helpers::sorted_set(&set, FailingSerializer);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_keyed_map_error_serialize_map() {
+        let mut map = std::collections::HashMap::new();
+        map.insert(1, "one");
+        let res = super::ser_helpers::keyed_map(&map, FailingSerializer, |k| format!("key_{k}"));
         assert!(res.is_err());
     }
 }

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -598,4 +598,73 @@ mod tests {
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("java/lang/Exception"));
     }
+
+    #[test]
+    fn test_print_report_coverage() {
+        let mut store = crate::TelemetryStore::default();
+        let mut buf = Vec::new();
+        store.print_report(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("No class initialization events recorded."));
+        assert!(s.contains("No exception flow events recorded."));
+
+        store.bytecode_cost.record("iadd", "Foo", "bar", 10, 100);
+        store
+            .object_lineage
+            .record("java/lang/String", "Foo", 10, "bar");
+        store
+            .class_init_dag
+            .record("java/lang/String", "java/lang/System", 500);
+        let idx = store
+            .exception_flow
+            .record_throw("java/lang/Exception", "Foo", "bar", 10);
+        store.exception_flow.record_catch(idx, "Foo", "bar", 20);
+        store
+            .dispatch_resolution
+            .record("Foo", 42, "java/lang/String", true);
+        store
+            .native_boundary
+            .record_call("java/lang/String", "intern", 100, true);
+
+        let mut buf2 = Vec::new();
+        store.print_report(&mut buf2).unwrap();
+        let s2 = String::from_utf8(buf2).unwrap();
+        assert!(s2.contains("iadd"));
+        assert!(s2.contains("java/lang/String (triggered by: java/lang/System, 500ns)"));
+        assert!(s2.contains("java/lang/Exception"));
+        assert!(s2.contains("calls=1"));
+        assert!(s2.contains("errors=1"));
+    }
+
+    #[test]
+    fn test_to_markdown_report_coverage() {
+        let mut store = crate::TelemetryStore::default();
+        let s = store.to_markdown_report();
+        assert!(s.contains("No class initialization events recorded."));
+        assert!(s.contains("No exception flow events recorded."));
+
+        store.bytecode_cost.record("iadd", "Foo", "bar", 10, 100);
+        store
+            .object_lineage
+            .record("java/lang/String", "Foo", 10, "bar");
+        store
+            .class_init_dag
+            .record("java/lang/String", "java/lang/System", 500);
+        let idx = store
+            .exception_flow
+            .record_throw("java/lang/Exception", "Foo", "bar", 10);
+        store.exception_flow.record_catch(idx, "Foo", "bar", 20);
+        store
+            .dispatch_resolution
+            .record("Foo", 42, "java/lang/String", true);
+        store
+            .native_boundary
+            .record_call("java/lang/String", "intern", 100, true);
+
+        let s2 = store.to_markdown_report();
+        assert!(s2.contains("`iadd`"));
+        assert!(s2.contains("```mermaid"));
+        assert!(s2.contains("`java/lang/Exception`"));
+        assert!(s2.contains("`java/lang/String.intern`"));
+    }
 }


### PR DESCRIPTION
test(telemetry): increase coverage for missing error and formatting branches

🎯 Target: helpers.rs and lib.rs (Telemetry reporting and serialization helpers)
💣 Risk: Edge cases in telemetry output formatting and custom Serde error mapping were not exercised, potentially allowing panics or garbled telemetry on error to slip through.
🧪 Strategy: Extracted the FailingSerializer mock to be reusable within the tests module and implemented new tests targeting keyed_map failing on initialization. Also added fully populated table-driven style assertions for print_report and to_markdown_report.
🔬 Verification: Run cargo test -p duke-telemetry

---
*PR created automatically by Jules for task [7205407809642637042](https://jules.google.com/task/7205407809642637042) started by @madmax983*