### PR TITLE
⚒️ Forge: [Refactor jar_diff.rs guard clauses]

### DIFF
--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")
@@ -151,25 +148,28 @@ fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
 
     for entry_name in class_entries {
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            #[allow(clippy::collapsible_if)]
-            if let Ok(cf) = parse(&bytes) {
-                let class_name = resolve_class_name(&cf, cf.this_class);
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
+        let Ok(cf) = parse(&bytes) else {
+            continue;
+        };
 
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{class_name}::{name_str}{desc_str}");
+        let class_name = resolve_class_name(&cf, cf.this_class);
 
-                    let mut hasher = DefaultHasher::new();
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            code.code.hash(&mut hasher);
-                        }
-                    }
-                    method_hashes.insert(full_name, hasher.finish());
-                }
+        for method in &cf.methods {
+            let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+            let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+            let full_name = format!("{class_name}::{name_str}{desc_str}");
+
+            let mut hasher = DefaultHasher::new();
+            for attr in &method.attributes {
+                let AttributeData::Code(code) = &attr.data else {
+                    continue;
+                };
+                code.code.hash(&mut hasher);
             }
+            method_hashes.insert(full_name, hasher.finish());
         }
     }
     method_hashes


### PR DESCRIPTION
⚒️ Forge: [Refactor jar_diff.rs guard clauses]

**🚮 Smell:** The `load_jar_methods` function in `duke/src/jar_diff.rs` contained deeply nested `if let` and `if Ok()` blocks (a "Pyramid of Doom") that made the logic difficult to read and maintain. It also contained an obsolete `#[allow(clippy::collapsible_if)]` directive, an unresolvable import (`duke_classfile::types`), and missing type annotations in closures.

**✨ Solution:** Flattened the nested `if` structures using let-else guard clauses (`let Ok(...) = ... else { continue; };`). Removed the unneeded `#[allow(clippy::collapsible_if)]` attribute. Fixed the `duke_classfile` imports to bring `AttributeData`, `CpEntry`, and `CpIndex` directly from the crate root instead of `types`. Added missing explicit type annotations (`|slot: &Option<CpEntry>|`) to closures for robust compilation across feature flags.

**🧼 Benefit:** Dramatically improves code readability and clarity by eliminating deep nesting. The logic flow is now flat and easy to follow. Ensures strict adherence to idiomatic Rust patterns. Resolves compilation errors under certain feature flags.

**🛡️ Verification:** Ran `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test`. All checks and tests passed cleanly. No runtime logic was changed.

---
*PR created automatically by Jules for task [15749298189078930800](https://jules.google.com/task/15749298189078930800) started by @madmax983*