### PR TITLE
⚒️ Forge: refactor deeply nested logic with guard clauses and chained options

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,14 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+**Refactoring nested match blocks with guard clauses**
+**Learning:** In `duke-classfile/src/parser.rs`, I noticed deep nesting caused by sequential `match` blocks when unpacking `AttributeData`.
+**Action:** Used `let else` guard clauses to handle early returns/continues, which effectively flattens the execution flow and drastically improves code readability without altering behavior. This aligns with the "guard clauses" move.
+
+**Option handling with Iterator extend**
+**Learning:** In `duke-bytecode/src/instruction.rs`, there were multiple instances of `if let Some(x) = y { targets.push(x) }` which added unnecessary branching and lines of code.
+**Action:** Replaced these blocks with `targets.extend(next_pc)` (and mapped `Option`s), leveraging the fact that `Option` implements `IntoIterator`. This makes the code shorter and more idiomatic.
+
+**Removing unnecessary Result wrappers**
+**Learning:** In `duke-bytecode/src/decoder.rs`, `decode_conversion_op` returned a `Result<Instruction>` even though it could only ever succeed (all variants matched explicitly to valid instructions), requiring `#[allow(clippy::unnecessary_wraps)]`.
+**Action:** Changed the signature to return `Instruction` directly, removed the `clippy` suppression, and handled the `Ok()` wrapping at the call site in `decode_one`.


### PR DESCRIPTION
🚮 **Smell:** The codebase had deep nesting caused by sequential `match` blocks when unpacking `AttributeData` in `duke-classfile/src/parser.rs`, and manual `if let Some(x) = y` statements in `duke-bytecode/src/instruction.rs` instead of utilizing iterator extensions, resulting in unnecessary branching. Furthermore, `decode_conversion_op` in `duke-bytecode/src/decoder.rs` used unnecessary `Result` wrappers leading to clutter and `clippy` suppression directives.
✨ **Solution:** 
- In `duke-classfile/src/parser.rs`, used `let else` guard clauses to safely flatten deep nesting when matching `AttributeData`.
- In `duke-bytecode/src/instruction.rs`, refactored `if let Some(next) = next_pc` blocks using `.extend(next_pc)` leveraging `Option`'s implementation of `IntoIterator`.
- Changed the signature of `decode_conversion_op` in `duke-bytecode/src/decoder.rs` to directly return `Instruction`, handling the `Result` wrap explicitly at the call site, allowing the removal of `#[allow(clippy::unnecessary_wraps)]`.
🧼 **Benefit:** Refactoring logic heavily flattens nested conditional logic, removing boilerplate, saving screen space and avoiding pyramids of doom. Uses Idiomatic Rust by leveraging standard traits like `IntoIterator` on `Option`.
🛡️ **Verification:** Tests passed. Verified locally utilizing `cargo test --all-targets --all-features` and `cargo clippy --all-targets --all-features -- -D warnings`. No runtime behavior was changed.

---
*PR created automatically by Jules for task [18423872442426703243](https://jules.google.com/task/18423872442426703243) started by @madmax983*