### PR TITLE
🛡️ Sentry: [test coverage improvement] duke-telemetry loop bound constraints

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -47,3 +47,6 @@
 ## 2024-05-24 - Testing ReentrantReadWriteLock Native Operations
 **Learning:** Found several native functions implementing `ReentrantReadWriteLock` and `PriorityQueue` operations missing test coverage in `duke-interpreter`. Adding dummy tests correctly executes these logic branches without needing fully mocked multi-threading scenarios.
 **Action:** Add inline unit tests using a mocked heap and manually setting up the `obj_ref` payload.
+## 2024-05-24 - Testing Format and Serialization Output Gaps
+**Learning:** Functions that generate user-facing outputs might fail testing because error flows only occur when standard types wrap custom objects. Also, format outputs (like testing empty reports vs populated reports) requires full mock states or testing for length boundaries inside iterator consumers like `take(10)`. To properly test the `take(10)` loop truncation, we need to populate test stores with more than 10 unique elements (e.g. 15) and assert that exactly 10 output lines are produced in addition to headers.
+**Action:** Add specific unit tests that push loops and iterators past their cutoff bounds (like `take(10)`) to verify the correct truncation behavior. Use dynamic values or `Box::leak` if unique `&'static str` arguments are required.

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -598,4 +598,140 @@ mod tests {
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("java/lang/Exception"));
     }
+
+    #[test]
+    fn test_print_bytecode_cost_with_more_than_10() {
+        let mut store = crate::TelemetryStore::default();
+        for i in 0..15 {
+            store.bytecode_cost.record(
+                Box::leak(format!("iadd{i}").into_boxed_str()),
+                "Foo",
+                "bar",
+                10,
+                100,
+            );
+        }
+        let mut buf = Vec::new();
+        store.print_bytecode_cost(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("iadd"));
+        let line_count = s.lines().count();
+        // 1 header + 10 lines + 1 empty trailing line
+        assert_eq!(line_count, 12);
+    }
+
+    #[test]
+    fn test_markdown_bytecode_cost_with_more_than_10() {
+        let mut store = crate::TelemetryStore::default();
+        for i in 0..15 {
+            store.bytecode_cost.record(
+                Box::leak(format!("iadd{i}").into_boxed_str()),
+                "Foo",
+                "bar",
+                10,
+                100,
+            );
+        }
+        let mut out = String::new();
+        store.markdown_bytecode_cost(&mut out);
+        let line_count = out.lines().count();
+        // 1 header + 1 empty + 1 table header + 1 separator + 10 items + 1 empty
+        assert_eq!(line_count, 15);
+    }
+
+    #[test]
+    fn test_print_object_lineage_with_more_than_10() {
+        let mut store = crate::TelemetryStore::default();
+        for i in 0..15 {
+            store
+                .object_lineage
+                .record("java/lang/String", "Foo", i, "bar");
+        }
+        let mut buf = Vec::new();
+        store.print_object_lineage(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("java/lang/String"));
+        let line_count = s.lines().count();
+        assert_eq!(line_count, 12);
+    }
+
+    #[test]
+    fn test_markdown_object_lineage_with_more_than_10() {
+        let mut store = crate::TelemetryStore::default();
+        for i in 0..15 {
+            store
+                .object_lineage
+                .record("java/lang/String", "Foo", i, "bar");
+        }
+        let mut out = String::new();
+        store.markdown_object_lineage(&mut out);
+        let line_count = out.lines().count();
+        assert_eq!(line_count, 15);
+    }
+
+    #[test]
+    fn test_print_dispatch_resolution_with_more_than_10() {
+        let mut store = crate::TelemetryStore::default();
+        for i in 0..15 {
+            store.dispatch_resolution.record(
+                "Foo",
+                u16::try_from(i).unwrap(),
+                "java/lang/String",
+                true,
+            );
+        }
+        let mut buf = Vec::new();
+        store.print_dispatch_resolution(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("Foo"));
+        let line_count = s.lines().count();
+        assert_eq!(line_count, 12);
+    }
+
+    #[test]
+    fn test_markdown_dispatch_resolution_with_more_than_10() {
+        let mut store = crate::TelemetryStore::default();
+        for i in 0..15 {
+            store.dispatch_resolution.record(
+                "Foo",
+                u16::try_from(i).unwrap(),
+                "java/lang/String",
+                true,
+            );
+        }
+        let mut out = String::new();
+        store.markdown_dispatch_resolution(&mut out);
+        let line_count = out.lines().count();
+        assert_eq!(line_count, 15);
+    }
+
+    #[test]
+    fn test_print_native_boundary_with_more_than_10() {
+        let mut store = crate::TelemetryStore::default();
+        for i in 0..15 {
+            store
+                .native_boundary
+                .record_call("java/lang/String", &format!("intern{i}"), 100, true);
+        }
+        let mut buf = Vec::new();
+        store.print_native_boundary(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("java/lang/String"));
+        let line_count = s.lines().count();
+        assert_eq!(line_count, 12);
+    }
+
+    #[test]
+    fn test_markdown_native_boundary_with_more_than_10() {
+        let mut store = crate::TelemetryStore::default();
+        for i in 0..15 {
+            store
+                .native_boundary
+                .record_call("java/lang/String", &format!("intern{i}"), 100, true);
+        }
+        let mut out = String::new();
+        store.markdown_native_boundary(&mut out);
+        let line_count = out.lines().count();
+        assert_eq!(line_count, 15);
+    }
 }


### PR DESCRIPTION
* 🎯 Target: `duke-telemetry::TelemetryStore` formatting methods (`print_*` and `markdown_*`).
* 💣 Risk: Formatters use `.take(10)` iterators to limit output, but this truncation logic was previously untested. Regressions could lead to overly verbose logging output, degrading VM reporting performance.
* 🧪 Strategy: Wrote new `#[test]` functions that populate the telemetry store with 15 unique elements and verified the output strings contained exactly 10 data lines (plus expected headers).
* 🔬 Verification: Run `cargo test -p duke-telemetry --all-features`.

---
*PR created automatically by Jules for task [12918299960690370509](https://jules.google.com/task/12918299960690370509) started by @madmax983*