### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -47,3 +47,7 @@
 ## 2024-05-24 - Testing ReentrantReadWriteLock Native Operations
 **Learning:** Found several native functions implementing `ReentrantReadWriteLock` and `PriorityQueue` operations missing test coverage in `duke-interpreter`. Adding dummy tests correctly executes these logic branches without needing fully mocked multi-threading scenarios.
 **Action:** Add inline unit tests using a mocked heap and manually setting up the `obj_ref` payload.
+
+## 2024-05-18 - Mid-iteration serialization failures in Serde Maps
+**Learning:** Testing `serde::ser::SerializeMap` failure states requires a custom mocked serializer that allows initial iterations to succeed before deliberately failing. Simply using a serializer that returns `Err` on map entry setup is insufficient, as it doesn't exercise the logic inside the iteration loop where `serialize_key` or `serialize_value` might fail after some successful iterations.
+**Action:** Use an internal state counter (e.g., `std::cell::Cell<usize>`) within the mock serializer implementation to control exactly which iteration should trigger the `serde::de::Error::custom` error.

--- a/crates/duke-telemetry/src/helpers.rs
+++ b/crates/duke-telemetry/src/helpers.rs
@@ -435,4 +435,194 @@ mod tests {
         let res = super::ser_helpers::sorted_set(&set, FailingSerializer);
         assert!(res.is_err());
     }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn test_keyed_map_mid_iteration_error() {
+        struct FailingMidSerializer {
+            calls: std::cell::Cell<usize>,
+        }
+        impl serde::Serializer for FailingMidSerializer {
+            type Ok = ();
+            type Error = serde::de::value::Error;
+            type SerializeSeq = serde::ser::Impossible<(), Self::Error>;
+            type SerializeTuple = serde::ser::Impossible<(), Self::Error>;
+            type SerializeTupleStruct = serde::ser::Impossible<(), Self::Error>;
+            type SerializeTupleVariant = serde::ser::Impossible<(), Self::Error>;
+            type SerializeMap = FailingMidMapSerializer;
+            type SerializeStruct = serde::ser::Impossible<(), Self::Error>;
+            type SerializeStructVariant = serde::ser::Impossible<(), Self::Error>;
+
+            fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_some<T: ?Sized + Serialize>(
+                self,
+                _v: &T,
+            ) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_unit_variant(
+                self,
+                _n: &'static str,
+                _vi: u32,
+                _va: &'static str,
+            ) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_newtype_struct<T: ?Sized + Serialize>(
+                self,
+                _name: &'static str,
+                _v: &T,
+            ) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_newtype_variant<T: ?Sized + Serialize>(
+                self,
+                _n: &'static str,
+                _vi: u32,
+                _va: &'static str,
+                _v: &T,
+            ) -> Result<Self::Ok, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_tuple_struct(
+                self,
+                _name: &'static str,
+                _len: usize,
+            ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_tuple_variant(
+                self,
+                _n: &'static str,
+                _vi: u32,
+                _va: &'static str,
+                _len: usize,
+            ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+                Ok(FailingMidMapSerializer { calls: self.calls })
+            }
+            fn serialize_struct(
+                self,
+                _name: &'static str,
+                _len: usize,
+            ) -> Result<Self::SerializeStruct, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+            fn serialize_struct_variant(
+                self,
+                _n: &'static str,
+                _vi: u32,
+                _va: &'static str,
+                _len: usize,
+            ) -> Result<Self::SerializeStructVariant, Self::Error> {
+                Err(serde::de::Error::custom("err"))
+            }
+        }
+
+        struct FailingMidMapSerializer {
+            calls: std::cell::Cell<usize>,
+        }
+        impl serde::ser::SerializeMap for FailingMidMapSerializer {
+            type Ok = ();
+            type Error = serde::de::value::Error;
+            fn serialize_key<T: ?Sized + Serialize>(
+                &mut self,
+                _key: &T,
+            ) -> Result<(), Self::Error> {
+                let c = self.calls.get();
+                if c >= 1 {
+                    Err(serde::de::Error::custom("mid iteration error key"))
+                } else {
+                    Ok(())
+                }
+            }
+            fn serialize_value<T: ?Sized + Serialize>(
+                &mut self,
+                _value: &T,
+            ) -> Result<(), Self::Error> {
+                let c = self.calls.get();
+                if c >= 1 {
+                    Err(serde::de::Error::custom("mid iteration error val"))
+                } else {
+                    self.calls.set(c + 1);
+                    Ok(())
+                }
+            }
+            fn end(self) -> Result<Self::Ok, Self::Error> {
+                Ok(())
+            }
+        }
+
+        let mut map = std::collections::HashMap::new();
+        map.insert(1, Dummy { val: 1 });
+        map.insert(2, Dummy { val: 2 });
+        map.insert(3, Dummy { val: 3 });
+
+        let res = super::ser_helpers::keyed_map(
+            &map,
+            FailingMidSerializer {
+                calls: std::cell::Cell::new(0),
+            },
+            |k| format!("key_{k}"),
+        );
+        assert!(res.is_err());
+    }
 }

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -598,4 +598,45 @@ mod tests {
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("java/lang/Exception"));
     }
+
+    #[test]
+    fn test_print_dispatch_resolution_populated() {
+        let mut store = crate::TelemetryStore::default();
+        store
+            .dispatch_resolution
+            .record("Foo", 42, "java/lang/String", true);
+        let mut buf = Vec::new();
+        store.print_dispatch_resolution(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("Foo"));
+        assert!(s.contains("cp42"));
+    }
+
+    #[test]
+    fn test_print_native_boundary_populated() {
+        let mut store = crate::TelemetryStore::default();
+        store
+            .native_boundary
+            .record_call("java/lang/String", "intern", 100, true);
+        let mut buf = Vec::new();
+        store.print_native_boundary(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("java/lang/String.intern"));
+    }
+
+    #[test]
+    fn test_markdown_exception_flow_empty() {
+        let store = crate::TelemetryStore::default();
+        let mut s = String::new();
+        store.markdown_exception_flow(&mut s);
+        assert!(s.contains("No exception flow events recorded."));
+    }
+
+    #[test]
+    fn test_markdown_class_init_dag_empty() {
+        let store = crate::TelemetryStore::default();
+        let mut s = String::new();
+        store.markdown_class_init_dag(&mut s);
+        assert!(s.contains("No class initialization events recorded."));
+    }
 }


### PR DESCRIPTION
* 🎯 Target: `duke-telemetry::lib` and `duke-telemetry::helpers`
* 💣 Risk: Prevents regressions in markdown rendering output for unpopulated data, protects dispatch and native call output format, and ensures keyed map serializers properly propagate iteration failures.
* 🧪 Strategy: Added populated structural tests for `dispatch_resolution` and `native_boundary` prints, empty state tests for markdown outputs, and a mid-iteration mock serializer test for `keyed_map`.
* 🔬 Verification: `cargo test -p duke-telemetry`

---
*PR created automatically by Jules for task [7600402700032977467](https://jules.google.com/task/7600402700032977467) started by @madmax983*