### PR TITLE
⚡ Bolt: Remove HashMap allocation in CFG generation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,6 @@
 **Trust the Iterator: .collect() is Optimized**
 **Learning:** In Rust, `.collect::<Vec<_>>()` called on an `ExactSizeIterator` (which `slice.iter().map()` implements) already knows the exact number of elements. The standard library heavily optimizes this via the `TrustedLen` trait to allocate the precise capacity upfront and completely bypass bounds checks during insertion.
 **Action:** Do not manually replace `.collect::<Vec<_>>()` with `Vec::with_capacity` and a `for` loop, as it re-introduces bounds checks on every push, making the "optimization" unidiomatic and a micro-regression.
+**[Title: HashMap allocation replaced with binary_search_by_key on sorted slice]
+**Learning:** `HashMap::new()` causes dynamic reallocation as items are inserted. Pre-allocating capacity avoids this. However, if the underlying collection is already naturally sorted by the lookup key, you can eliminate the map entirely and use `binary_search_by_key()`.
+**Action:** Always check if a collection is naturally sorted before creating an indexing `HashMap`. Use `binary_search` for $O(\log N)$ allocation-free lookups.


### PR DESCRIPTION
💡 **What**: Replaced a temporary indexing `HashMap` with `binary_search_by_key` directly on the `blocks` slice in `duke_bytecode::cfg::generate_basic_block_cfg`.
🎯 **Why**: Generating a CFG allocated and populated an $O(N)$ `HashMap` purely to perform an $O(1)$ block existence check. Since `build_basic_blocks` guarantees the blocks are emitted in sorted order by `start_pc`, the map was redundant. 
📊 **Impact**: Reduces heap allocations by 1 per CFG generation call, removing iteration/hashing overhead in favor of a fast, allocation-free $O(\log N)$ array lookup.
🔬 **Measurement**: Run `cargo test -p duke-bytecode` to verify logic consistency.

---
*PR created automatically by Jules for task [16547010466408443813](https://jules.google.com/task/16547010466408443813) started by @madmax983*