### PR TITLE
⚒️ Forge: [Refactor Cursor::read_u* bound checks]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**Extract Bounds Checking for Byte Sequencing**
+**Learning:** The `Cursor::read_u*` methods in `parser.rs` used chained sequential `read_u8()` calls. This creates unnecessary nesting and multiple bound checks for a single integer parsing operation.
+**Action:** Replace chained `read_u8()` calls with a single upfront slice-based bounds check (e.g., `self.pos + n > self.data.len()`) to improve clarity and reduce sequential call overhead.

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -63,9 +63,12 @@ impl<'a> Cursor<'a> {
     }
 
     fn read_u16(&mut self) -> Result<u16> {
-        let hi = u16::from(self.read_u8()?);
-        let lo = u16::from(self.read_u8()?);
-        Ok((hi << 8) | lo)
+        if self.pos + 2 > self.data.len() {
+            return Err(Error::UnexpectedEof { offset: self.pos });
+        }
+        let bytes = [self.data[self.pos], self.data[self.pos + 1]];
+        self.pos += 2;
+        Ok(u16::from_be_bytes(bytes))
     }
 
     #[allow(dead_code)]
@@ -74,9 +77,17 @@ impl<'a> Cursor<'a> {
     }
 
     fn read_u32(&mut self) -> Result<u32> {
-        let hi = u32::from(self.read_u16()?);
-        let lo = u32::from(self.read_u16()?);
-        Ok((hi << 16) | lo)
+        if self.pos + 4 > self.data.len() {
+            return Err(Error::UnexpectedEof { offset: self.pos });
+        }
+        let bytes = [
+            self.data[self.pos],
+            self.data[self.pos + 1],
+            self.data[self.pos + 2],
+            self.data[self.pos + 3],
+        ];
+        self.pos += 4;
+        Ok(u32::from_be_bytes(bytes))
     }
 
     fn read_i32(&mut self) -> Result<i32> {
@@ -84,9 +95,21 @@ impl<'a> Cursor<'a> {
     }
 
     fn read_u64(&mut self) -> Result<u64> {
-        let hi = u64::from(self.read_u32()?);
-        let lo = u64::from(self.read_u32()?);
-        Ok((hi << 32) | lo)
+        if self.pos + 8 > self.data.len() {
+            return Err(Error::UnexpectedEof { offset: self.pos });
+        }
+        let bytes = [
+            self.data[self.pos],
+            self.data[self.pos + 1],
+            self.data[self.pos + 2],
+            self.data[self.pos + 3],
+            self.data[self.pos + 4],
+            self.data[self.pos + 5],
+            self.data[self.pos + 6],
+            self.data[self.pos + 7],
+        ];
+        self.pos += 8;
+        Ok(u64::from_be_bytes(bytes))
     }
 
     fn read_i64(&mut self) -> Result<i64> {

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};

--- a/pr_details.txt
+++ b/pr_details.txt
@@ -1,6 +1,6 @@
-Title: 🛡️ Sentry: [test coverage improvement]
-Body:
-🎯 Target: `duke_loader::ZipReader::read_entry_info`, `duke_loader::parse_central_directory`, and `duke_telemetry::ser_helpers`.
-💣 Risk: Edge cases where zip central directories have truncated entries or mismatched local header offsets, and missing telemetry map empty paths could panic or fail implicitly if refactored.
-🧪 Strategy: Added specific inline tests inside `crates/duke-loader/src/zip.rs` to reach missing branches of Zip Format errors (e.g. truncated `filename_len`, exceeded `uncompressed_size`). Added tests in `crates/duke-telemetry/src/helpers.rs` for empty map serialization. Added an empty check for `print_report`.
-🔭 Verification: `cargo test -p duke-loader` and `cargo test -p duke-telemetry`
+Title: "⚒️ Forge: [Refactor Cursor::read_u* bound checks]"
+Description:
+🚮 Smell: The `read_u16`, `read_u32`, and `read_u64` methods in `crates/duke-classfile/src/parser.rs` used chained `self.read_u8()?` calls to parse multi-byte integers. This is inefficient as it incurs sequential bounds checks on every single byte.
+✨ Solution: Extracted the bounds checking into a single upfront slice-based bound check for the total bytes needed, and then directly instantiated the primitive types using `u*::from_be_bytes(bytes)`. This eliminates redundant checks and matches idiomatic Rust byte extraction.
+🧼 Benefit: Reduces runtime sequential call overhead, flattening the parsing logic and directly expressing the bounds requirements for multi-byte reads.
+🛡️ Verification: Tests passed. No logic changed.


### PR DESCRIPTION
🚮 Smell: The `read_u16`, `read_u32`, and `read_u64` methods in `crates/duke-classfile/src/parser.rs` used chained `self.read_u8()?` calls to parse multi-byte integers. This is inefficient as it incurs sequential bounds checks on every single byte.
✨ Solution: Extracted the bounds checking into a single upfront slice-based bound check for the total bytes needed, and then directly instantiated the primitive types using `u*::from_be_bytes(bytes)`. This eliminates redundant checks and matches idiomatic Rust byte extraction. Fixed the syntax error in `duke/src/jar_diff.rs`.
🧼 Benefit: Reduces runtime sequential call overhead, flattening the parsing logic and directly expressing the bounds requirements for multi-byte reads.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [4398780490684736112](https://jules.google.com/task/4398780490684736112) started by @madmax983*