### PR TITLE
⚒️ Forge: Refactor jar_diff to resolve type inference and nesting

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**Refactoring `jar_diff.rs` Closure Type Inference and Nesting**
+**Learning:** Chaining `.and_then` closures on nested Options (`Option<Option<T>>`) can lead to type inference failures (`E0282`) and decreased readability (Pyramid of Doom), especially when compiler features vary.
+**Action:** Replace chained `.and_then` calls on nested options with explicit `let Some(Some(...)) = ... else { return ... };` guard clauses to provide explicit type constraints to the compiler and flatten control flow.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -16,16 +13,10 @@ use std::path::Path;
 #[cfg(not(tarpaulin_include))]
 #[allow(unexpected_cfgs)]
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
-    cf.constant_pool
-        .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
-        .and_then(|entry| {
-            if let CpEntry::Utf8(s) = entry {
-                Some(s.as_str())
-            } else {
-                None
-            }
-        })
+    let Some(Some(CpEntry::Utf8(s))) = cf.constant_pool.get(idx.0 as usize) else {
+        return None;
+    };
+    Some(s.as_str())
 }
 
 #[cfg(feature = "nova")]
@@ -35,17 +26,14 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     if idx.0 == 0 {
         return "<none>".to_string();
     }
-    let class_entry = cf
-        .constant_pool
-        .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
-    if let Some(CpEntry::Class { name_index }) = class_entry {
-        cp_str(cf, *name_index)
-            .unwrap_or("<invalid utf8>")
-            .to_string()
-    } else {
-        "<not a class ref>".to_string()
-    }
+
+    let Some(Some(CpEntry::Class { name_index })) = cf.constant_pool.get(idx.0 as usize) else {
+        return "<not a class ref>".to_string();
+    };
+
+    cp_str(cf, *name_index)
+        .unwrap_or("<invalid utf8>")
+        .to_string()
 }
 
 #[cfg(feature = "nova")]


### PR DESCRIPTION
🚮 Smell: The `cp_str` and `resolve_class_name` functions in `duke/src/jar_diff.rs` used chained `.and_then()` closures on nested options. This caused type inference errors (`E0282`) and deeply nested logic (Pyramid of Doom). Furthermore, the imports were incorrectly referencing a non-existent `types` module.

✨ Solution: Refactored both functions to use idiomatic `let Some(Some(...)) = ... else { ... };` guard clauses, explicitly resolving the type inference issues without changing behavior. Corrected the `use` statement at the top of the file to import the re-exported types directly from `duke_classfile`. Documented the learning in `.jules/forge.md`.

🧼 Benefit: Dramatically improves readability by flattening control flow, eliminates the compilation errors, and strictly adheres to idiomatic Rust error/option handling.

🛡️ Verification: Tests passed (`cargo test --all-targets --all-features`). Lints passed (`cargo clippy --all-targets --all-features -- -D warnings`). No logic was changed.

---
*PR created automatically by Jules for task [6251538370456906089](https://jules.google.com/task/6251538370456906089) started by @madmax983*