### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,6 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+## 2025-06-13 - [Visibility Constraints in Doctests]
+**Confusion:** I attempted to add doctests to the internal helper functions `resolve_attributes` and `cp_utf8` within `crates/duke-classfile/src/parser.rs`, however, because the `parser` module is `pub(crate)`, they failed to compile when rustdoc attempted to run them due to `E0603 module parser is private`.
+**Clarification:** I rewrote the doctest code blocks to use `/// \`\`\`ignore` to show usage examples for private functions without having the tests break the build.

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -406,9 +406,40 @@ fn parse_attribute(c: &mut Cursor<'_>, _cp_len: usize) -> Result<AttributeInfo> 
 // Post-parse attribute resolution (requires constant pool string lookup)
 // ---------------------------------------------------------------------------
 
-/// Resolve raw attributes into typed forms using the constant pool.
+/// Resolves generic `AttributeData::Raw` bytes into strongly-typed `AttributeData` variants.
 ///
-/// Called after the whole class file is parsed, when we have the full CP.
+/// The JVM `.class` format stores attributes as raw byte arrays along with a name index
+/// pointing to the constant pool. Because a constant pool is required to resolve the name
+/// of an attribute (e.g., `"Code"`, `"ConstantValue"`), and because the constant pool itself
+/// is parsed sequentially before attributes, this function serves as a crucial secondary pass.
+/// It takes the fully constructed constant pool and applies it to the unparsed attributes,
+/// converting them from raw bytes into actionable, typed Rust structs.
+///
+/// # Errors
+/// Returns an error if an attribute name index points to an invalid or missing constant pool entry,
+/// or if the structural decoding of a known attribute fails (e.g., truncated data).
+///
+/// # Examples
+/// ```ignore
+/// use duke_classfile::{AttributeInfo, AttributeData, CpEntry, CpIndex};
+/// use duke_classfile::parser::resolve_attributes;
+///
+/// // Create a dummy constant pool with the string "ConstantValue" at index 1
+/// let pool = vec![None, Some(CpEntry::Utf8("ConstantValue".to_string()))];
+///
+/// // Create a raw attribute pointing to the "ConstantValue" name index
+/// // The raw data (0, 4) corresponds to a constant value index of 4
+/// let mut attrs = vec![
+///     AttributeInfo {
+///         name_index: CpIndex(1),
+///         data: AttributeData::Raw(vec![0x00, 0x04])
+///     }
+/// ];
+///
+/// resolve_attributes(&mut attrs, &pool).unwrap();
+/// assert!(matches!(attrs[0].data, AttributeData::ConstantValue { constant_value_index: CpIndex(4) }));
+/// ```
+///
 /// ⚡ Bolt: Pre-allocates vectors for known attribute table sizes to eliminate intermediate heap allocations.
 pub fn resolve_attributes(attrs: &mut [AttributeInfo], pool: &[Option<CpEntry>]) -> Result<()> {
     for attr in attrs.iter_mut() {
@@ -614,7 +645,31 @@ fn parse_code_attribute(c: &mut Cursor<'_>) -> Result<CodeAttribute> {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Look up a UTF-8 string in the constant pool.
+/// Looks up and retrieves a string from the constant pool using a `CpIndex`.
+///
+/// The JVM constant pool frequently stores names, descriptors, and string literals as `CONSTANT_Utf8_info`
+/// entries. This function provides a safe, ergonomic way to extract these string values by their index,
+/// handling the complexities of 1-based indexing, wide characters, and phantom slots left by long/double constants.
+///
+/// # Errors
+/// Returns `Error::CpIndexZero` if the index is `0` (which is invalid in the JVM constant pool).
+/// Returns `Error::CpPhantomSlot` if the index points to a phantom slot left by an 8-byte constant.
+/// Returns `Error::CpIndexOutOfBounds` if the index is larger than the pool or doesn't contain a `Utf8` variant.
+///
+/// # Examples
+/// ```ignore
+/// use duke_classfile::{CpEntry, CpIndex};
+/// use duke_classfile::parser::cp_utf8;
+///
+/// // A valid JVM constant pool is 1-indexed, so index 0 is always None.
+/// let pool = vec![None, Some(CpEntry::Utf8("java/lang/Object".to_string()))];
+///
+/// let name = cp_utf8(&pool, CpIndex(1)).unwrap();
+/// assert_eq!(name, "java/lang/Object");
+///
+/// // Looking up index 0 is an error.
+/// assert!(cp_utf8(&pool, CpIndex(0)).is_err());
+/// ```
 pub fn cp_utf8(pool: &[Option<CpEntry>], idx: CpIndex) -> Result<&str> {
     let i = idx.0 as usize;
     if i == 0 {

--- a/crates/duke-classfile/tests/havoc_classfile_proptest.rs
+++ b/crates/duke-classfile/tests/havoc_classfile_proptest.rs
@@ -1,3 +1,5 @@
+//! Tests for classfile parsing using proptest.
+
 use proptest::prelude::*;
 
 proptest! {

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};


### PR DESCRIPTION
- 📖 Chapter: Proptest classfile testing and internal parsing logic.
- 🔦 Insight: Added missing docs to `resolve_attributes` and `cp_utf8` in `crates/duke-classfile/src/parser.rs`. Used `/// ```ignore` to demonstrate examples for internal `pub(crate)` modules without breaking the build due to `E0603 module parser is private` visibility constraints. Also added top-level docs to the proptest file and fixed imports in `duke/src/jar_diff.rs`.
- 🧪 Example: "Added doc comments outlining errors and providing ignored examples."

---
*PR created automatically by Jules for task [7805353996391337951](https://jules.google.com/task/7805353996391337951) started by @madmax983*