### PR TITLE
🌟 Nova: Basic Block Structural Diffing

### DIFF
--- a/crates/duke-bytecode/src/diff.rs
+++ b/crates/duke-bytecode/src/diff.rs
@@ -51,7 +51,9 @@ pub fn compare_blocks(old_blocks: &[BasicBlock], new_blocks: &[BasicBlock]) -> V
             (Some(old_b), Some(new_b)) => {
                 // Same start PC, compare contents
                 if old_b.instructions == new_b.instructions {
-                    diffs.push(BlockDiff::Identical { block: (*old_b).clone() });
+                    diffs.push(BlockDiff::Identical {
+                        block: (*old_b).clone(),
+                    });
                 } else {
                     diffs.push(BlockDiff::Modified {
                         old_block: (*old_b).clone(),
@@ -60,10 +62,14 @@ pub fn compare_blocks(old_blocks: &[BasicBlock], new_blocks: &[BasicBlock]) -> V
                 }
             }
             (Some(old_b), None) => {
-                diffs.push(BlockDiff::Removed { block: (*old_b).clone() });
+                diffs.push(BlockDiff::Removed {
+                    block: (*old_b).clone(),
+                });
             }
             (None, Some(new_b)) => {
-                diffs.push(BlockDiff::Added { block: (*new_b).clone() });
+                diffs.push(BlockDiff::Added {
+                    block: (*new_b).clone(),
+                });
             }
             (None, None) => unreachable!(),
         }

--- a/crates/duke-bytecode/src/diff.rs
+++ b/crates/duke-bytecode/src/diff.rs
@@ -1,0 +1,151 @@
+//! Structural diffing of basic blocks.
+//!
+//! This module provides functionality to compare two sequences of basic blocks,
+//! determining which blocks were added, removed, modified, or remain identical.
+//! This gives semantic meaning to changes rather than simple bytecode hash diffs.
+
+use crate::basic_block::BasicBlock;
+
+/// Represents the structural difference between basic blocks.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum BlockDiff {
+    /// The block is identical in both sequences.
+    Identical { block: BasicBlock },
+    /// The block exists in the new sequence but not the old.
+    Added { block: BasicBlock },
+    /// The block exists in the old sequence but not the new.
+    Removed { block: BasicBlock },
+    /// The block exists in both but its instructions have changed.
+    Modified {
+        old_block: BasicBlock,
+        new_block: BasicBlock,
+    },
+}
+
+/// Compares two sequences of basic blocks to produce a sequence of block differences.
+///
+/// This simple algorithm attempts to align blocks by their `start_pc`.
+/// For a more robust diff, sequence alignment algorithms (like Myers Diff) could be used.
+#[must_use]
+pub fn compare_blocks(old_blocks: &[BasicBlock], new_blocks: &[BasicBlock]) -> Vec<BlockDiff> {
+    let mut diffs = Vec::new();
+
+    // Create maps from start_pc to Block for quick lookup
+    let mut old_map = std::collections::HashMap::new();
+    for block in old_blocks {
+        old_map.insert(block.start_pc, block);
+    }
+
+    let mut new_map = std::collections::HashMap::new();
+    for block in new_blocks {
+        new_map.insert(block.start_pc, block);
+    }
+
+    // To ensure a somewhat ordered output, gather all unique start PCs
+    let mut all_pcs: std::collections::BTreeSet<usize> = std::collections::BTreeSet::new();
+    all_pcs.extend(old_map.keys());
+    all_pcs.extend(new_map.keys());
+
+    for pc in all_pcs {
+        match (old_map.get(&pc), new_map.get(&pc)) {
+            (Some(old_b), Some(new_b)) => {
+                // Same start PC, compare contents
+                if old_b.instructions == new_b.instructions {
+                    diffs.push(BlockDiff::Identical { block: (*old_b).clone() });
+                } else {
+                    diffs.push(BlockDiff::Modified {
+                        old_block: (*old_b).clone(),
+                        new_block: (*new_b).clone(),
+                    });
+                }
+            }
+            (Some(old_b), None) => {
+                diffs.push(BlockDiff::Removed { block: (*old_b).clone() });
+            }
+            (None, Some(new_b)) => {
+                diffs.push(BlockDiff::Added { block: (*new_b).clone() });
+            }
+            (None, None) => unreachable!(),
+        }
+    }
+
+    diffs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::instruction::Instruction;
+
+    #[test]
+    fn test_compare_blocks_identical() {
+        let b1 = BasicBlock {
+            start_pc: 0,
+            end_pc: 2,
+            instructions: vec![(0, Instruction::Iconst0)],
+        };
+        let b2 = BasicBlock {
+            start_pc: 0,
+            end_pc: 2,
+            instructions: vec![(0, Instruction::Iconst0)],
+        };
+        let diffs = compare_blocks(std::slice::from_ref(&b1), std::slice::from_ref(&b2));
+        assert_eq!(diffs.len(), 1);
+        assert!(matches!(diffs[0], BlockDiff::Identical { .. }));
+    }
+
+    #[test]
+    fn test_compare_blocks_added() {
+        let b1 = BasicBlock {
+            start_pc: 0,
+            end_pc: 2,
+            instructions: vec![(0, Instruction::Iconst0)],
+        };
+        let b2 = BasicBlock {
+            start_pc: 2,
+            end_pc: 4,
+            instructions: vec![(2, Instruction::Ireturn)],
+        };
+        let diffs = compare_blocks(std::slice::from_ref(&b1), &[b1.clone(), b2]);
+        assert_eq!(diffs.len(), 2);
+
+        let has_added = diffs.iter().any(|d| matches!(d, BlockDiff::Added { .. }));
+        assert!(has_added, "Expected an Added diff");
+    }
+
+    #[test]
+    fn test_compare_blocks_removed() {
+        let b1 = BasicBlock {
+            start_pc: 0,
+            end_pc: 2,
+            instructions: vec![(0, Instruction::Iconst0)],
+        };
+        let b2 = BasicBlock {
+            start_pc: 2,
+            end_pc: 4,
+            instructions: vec![(2, Instruction::Ireturn)],
+        };
+        let diffs = compare_blocks(&[b1.clone(), b2], std::slice::from_ref(&b1));
+        assert_eq!(diffs.len(), 2);
+
+        let has_removed = diffs.iter().any(|d| matches!(d, BlockDiff::Removed { .. }));
+        assert!(has_removed, "Expected a Removed diff");
+    }
+
+    #[test]
+    fn test_compare_blocks_modified() {
+        let b1 = BasicBlock {
+            start_pc: 0,
+            end_pc: 2,
+            instructions: vec![(0, Instruction::Iconst0)],
+        };
+        let b2 = BasicBlock {
+            start_pc: 0,
+            end_pc: 2,
+            instructions: vec![(0, Instruction::Iconst1)],
+        };
+        let diffs = compare_blocks(&[b1], &[b2]);
+        assert_eq!(diffs.len(), 1);
+        assert!(matches!(diffs[0], BlockDiff::Modified { .. }));
+    }
+}

--- a/crates/duke-bytecode/src/lib.rs
+++ b/crates/duke-bytecode/src/lib.rs
@@ -13,6 +13,8 @@ pub(crate) mod basic_block;
 pub(crate) mod call_graph;
 pub(crate) mod cfg;
 pub(crate) mod decoder;
+#[cfg(feature = "nova")]
+pub(crate) mod diff;
 pub(crate) mod error;
 pub(crate) mod instruction;
 pub(crate) mod opcodes;
@@ -29,6 +31,8 @@ pub use call_graph::generate_mermaid_call_graph;
 pub use cfg::generate_basic_block_cfg;
 pub use cfg::{cyclomatic_complexity, generate_mermaid_cfg};
 pub use decoder::decode;
+#[cfg(feature = "nova")]
+pub use diff::{BlockDiff, compare_blocks};
 pub use error::{DecodeError, Error, Result, VerifyError};
 pub use instruction::{ArrayType, Instruction};
 #[cfg(feature = "nova")]

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,9 +2,9 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
+use duke_bytecode::{BlockDiff, build_basic_blocks, compare_blocks, decode};
 #[cfg(feature = "nova")]
-use duke_bytecode::{build_basic_blocks, compare_blocks, decode, BlockDiff};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -149,9 +149,16 @@ fn print_method_diff(m: &str, old_code: &[u8], new_code: &[u8]) {
                 BlockDiff::Removed { block } => {
                     println!("    - Block @ PC {}", block.start_pc);
                 }
-                BlockDiff::Modified { old_block, new_block } => {
-                    println!("    ~ Block @ PC {} modified ({} instrs -> {} instrs)",
-                        old_block.start_pc, old_block.instructions.len(), new_block.instructions.len());
+                BlockDiff::Modified {
+                    old_block,
+                    new_block,
+                } => {
+                    println!(
+                        "    ~ Block @ PC {} modified ({} instrs -> {} instrs)",
+                        old_block.start_pc,
+                        old_block.instructions.len(),
+                        new_block.instructions.len()
+                    );
                 }
                 BlockDiff::Identical { .. } => {}
             }

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,14 +2,12 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
+#[cfg(feature = "nova")]
+use duke_bytecode::{build_basic_blocks, compare_blocks, decode, BlockDiff};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
-use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::Path;
 
 #[cfg(feature = "nova")]
@@ -124,7 +122,7 @@ pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
     if !modified.is_empty() {
         println!("--- Top 10 Modified Methods ---");
         for m in modified.iter().take(10) {
-            println!("  ~ {m}");
+            print_method_diff(m, map1.get(m).unwrap(), map2.get(m).unwrap());
         }
         if modified.len() > 10 {
             println!("  ... and {} more", modified.len() - 10);
@@ -136,7 +134,35 @@ pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
 #[cfg(feature = "nova")]
 #[cfg(not(tarpaulin_include))]
 #[allow(unexpected_cfgs)]
-fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
+fn print_method_diff(m: &str, old_code: &[u8], new_code: &[u8]) {
+    println!("  ~ {m}");
+    if let (Ok(old_instrs), Ok(new_instrs)) = (decode(old_code), decode(new_code)) {
+        let old_blocks = build_basic_blocks(&old_instrs);
+        let new_blocks = build_basic_blocks(&new_instrs);
+        let block_diffs = compare_blocks(&old_blocks, &new_blocks);
+
+        for diff in block_diffs {
+            match diff {
+                BlockDiff::Added { block } => {
+                    println!("    + Block @ PC {}", block.start_pc);
+                }
+                BlockDiff::Removed { block } => {
+                    println!("    - Block @ PC {}", block.start_pc);
+                }
+                BlockDiff::Modified { old_block, new_block } => {
+                    println!("    ~ Block @ PC {} modified ({} instrs -> {} instrs)",
+                        old_block.start_pc, old_block.instructions.len(), new_block.instructions.len());
+                }
+                BlockDiff::Identical { .. } => {}
+            }
+        }
+    }
+}
+
+#[cfg(feature = "nova")]
+#[cfg(not(tarpaulin_include))]
+#[allow(unexpected_cfgs)]
+fn load_jar_methods(jar_path: &str) -> HashMap<String, Vec<u8>> {
     let Ok(loader) = ZipLoader::open(Path::new(jar_path)) else {
         return HashMap::new(); // If we cannot load, treat as empty
     };
@@ -161,13 +187,13 @@ fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
                     let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
                     let full_name = format!("{class_name}::{name_str}{desc_str}");
 
-                    let mut hasher = DefaultHasher::new();
+                    let mut code_bytes = Vec::new();
                     for attr in &method.attributes {
                         if let AttributeData::Code(code) = &attr.data {
-                            code.code.hash(&mut hasher);
+                            code_bytes.clone_from(&code.code);
                         }
                     }
-                    method_hashes.insert(full_name, hasher.finish());
+                    method_hashes.insert(full_name, code_bytes);
                 }
             }
         }


### PR DESCRIPTION
💡 **The Spark:** "I noticed we can compare JAR methods but we only know *if* they changed, not *how* they changed. What if we diffed the CFG structure directly?"
🚀 **The Feature:** "Implemented `BlockDiff` structural comparison in `duke-bytecode` and wired it into `duke jar-diff`."
🔮 **The Potential:** "Could be used for semantic patching analysis, compiler optimization verification, and de-obfuscation."
⚠️ **Risk:** "Low. Isolated under the `nova` feature flag."

---
*PR created automatically by Jules for task [16155519302664852440](https://jules.google.com/task/16155519302664852440) started by @madmax983*