### PR TITLE
⚒️ Forge: Flatten nested options to resolve E0282

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,6 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+**Flatten Nested Options (E0282)**
+**Learning:** Chaining `.and_then()` closures on nested options (`Option<Option<T>>`), such as retrieving a slot from a constant pool and then extracting its inner reference, can lead to type inference failures (`E0282: type annotations needed`) because the compiler cannot infer the intermediate closure types without explicit annotations.
+**Action:** Replace `and_then` chains operating on nested options with a flat `let Some(Some(Variant(inner))) = ... else { return ... };` guard clause. This resolves the type ambiguity naturally through pattern matching, reduces nesting, and improves readability.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -16,16 +13,10 @@ use std::path::Path;
 #[cfg(not(tarpaulin_include))]
 #[allow(unexpected_cfgs)]
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
-    cf.constant_pool
-        .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
-        .and_then(|entry| {
-            if let CpEntry::Utf8(s) = entry {
-                Some(s.as_str())
-            } else {
-                None
-            }
-        })
+    let Some(Some(CpEntry::Utf8(s))) = cf.constant_pool.get(idx.0 as usize) else {
+        return None;
+    };
+    Some(s.as_str())
 }
 
 #[cfg(feature = "nova")]
@@ -35,17 +26,12 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     if idx.0 == 0 {
         return "<none>".to_string();
     }
-    let class_entry = cf
-        .constant_pool
-        .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
-    if let Some(CpEntry::Class { name_index }) = class_entry {
-        cp_str(cf, *name_index)
-            .unwrap_or("<invalid utf8>")
-            .to_string()
-    } else {
-        "<not a class ref>".to_string()
-    }
+    let Some(Some(CpEntry::Class { name_index })) = cf.constant_pool.get(idx.0 as usize) else {
+        return "<not a class ref>".to_string();
+    };
+    cp_str(cf, *name_index)
+        .unwrap_or("<invalid utf8>")
+        .to_string()
 }
 
 #[cfg(feature = "nova")]


### PR DESCRIPTION
🚮 **Smell:** Nested `.and_then()` closures in `duke/src/jar_diff.rs` were operating on `Option<Option<CpEntry>>` types from the constant pool. This caused an `E0282: type annotations needed` compilation error because the compiler could not infer the intermediate closure types without explicit annotations. The previous `types::` import was also invalid.

✨ **Solution:** Extracted the deeply nested and broken `and_then` chain logic and replaced them with single-line `let Some(Some(Variant(inner))) = ... else { return ... };` guard clauses. Corrected the invalid import to use the top-level exported structures.

🧼 **Benefit:** Eliminates the compiler error naturally by utilizing explicit pattern matching. Dramatically flattens the code structure, reducing visual noise and the "Pyramid of Doom" while keeping the code safe and zero-cost.

🛡️ **Verification:** Tests passed. No logic changed. `cargo clippy --all-targets --all-features` and `cargo test --workspace` execute successfully. Learning added to `.jules/forge.md`.

---
*PR created automatically by Jules for task [1779333875135181552](https://jules.google.com/task/1779333875135181552) started by @madmax983*