### PR TITLE
⚡ Bolt: [performance improvement] Replace HashMap/BTreeSet allocations with binary searches in CFG

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,11 @@
 **Trust the Iterator: .collect() is Optimized**
 **Learning:** In Rust, `.collect::<Vec<_>>()` called on an `ExactSizeIterator` (which `slice.iter().map()` implements) already knows the exact number of elements. The standard library heavily optimizes this via the `TrustedLen` trait to allocate the precise capacity upfront and completely bypass bounds checks during insertion.
 **Action:** Do not manually replace `.collect::<Vec<_>>()` with `Vec::with_capacity` and a `for` loop, as it re-introduces bounds checks on every push, making the "optimization" unidiomatic and a micro-regression.
+
+**[Replace BTreeSet with Sorted Vecs]
+**Learning:** For collections built once and queried multiple times (like basic block leaders), `BTreeSet` introduces unnecessary heap allocations for every single node.
+**Action:** Use a `Vec` and manually push elements, followed by `sort_unstable()` and `dedup()`. Querying can then be done safely and efficiently via `binary_search()`.
+
+**[Safe Binary Search Replacements for HashMaps]
+**Learning:** Replacing an O(1) `HashMap` lookup with an O(log N) `binary_search_by_key` on a slice eliminates expensive hashing and allocations, but introduces a severe maintainability hazard if the slice ordering is ever broken silently by future refactoring.
+**Action:** When replacing a `HashMap` lookup with a slice `binary_search` optimization, always add a `debug_assert!(slice.windows(2).all(|w| w[0] < w[1]))` immediately prior to the loop. This documents the structural invariant for future maintainers and actively enforces it during test runs without slowing down release builds.

--- a/crates/duke-bytecode/src/basic_block.rs
+++ b/crates/duke-bytecode/src/basic_block.rs
@@ -5,8 +5,6 @@
 //! code sequence with no branches in except to the entry and no branches out
 //! except at the exit.
 
-use std::collections::BTreeSet;
-
 use crate::Instruction;
 
 /// A basic block of JVM bytecode.
@@ -76,9 +74,9 @@ pub fn build_basic_blocks(instructions: &[(usize, Instruction)]) -> Vec<BasicBlo
 }
 
 #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
-fn find_leaders(instructions: &[(usize, Instruction)]) -> BTreeSet<usize> {
-    let mut leaders = BTreeSet::new();
-    leaders.insert(instructions[0].0);
+fn find_leaders(instructions: &[(usize, Instruction)]) -> Vec<usize> {
+    let mut leaders = Vec::new();
+    leaders.push(instructions[0].0);
 
     for (i, (pc, instr)) in instructions.iter().enumerate() {
         let is_branch_or_return = instr.is_conditional_branch()
@@ -88,27 +86,26 @@ fn find_leaders(instructions: &[(usize, Instruction)]) -> BTreeSet<usize> {
 
         // Target of any jump or branch is a leader
         for target in instr.control_flow_targets(*pc, None) {
-            leaders.insert(target);
+            leaders.push(target);
         }
 
         // The instruction immediately following any jump, branch, or return is a leader
         if is_branch_or_return && i + 1 < instructions.len() {
-            leaders.insert(instructions[i + 1].0);
+            leaders.push(instructions[i + 1].0);
         }
     }
+    leaders.sort_unstable();
+    leaders.dedup();
     leaders
 }
 
-fn construct_blocks(
-    instructions: &[(usize, Instruction)],
-    leaders: &BTreeSet<usize>,
-) -> Vec<BasicBlock> {
+fn construct_blocks(instructions: &[(usize, Instruction)], leaders: &[usize]) -> Vec<BasicBlock> {
     let mut blocks = Vec::with_capacity(leaders.len());
     let mut current_start_pc = instructions[0].0;
     let mut current_start_idx = 0;
 
     for (i, (pc, _)) in instructions.iter().enumerate() {
-        if leaders.contains(pc) && i > current_start_idx {
+        if leaders.binary_search(pc).is_ok() && i > current_start_idx {
             blocks.push(BasicBlock {
                 start_pc: current_start_pc,
                 end_pc: *pc,

--- a/crates/duke-bytecode/src/cfg.rs
+++ b/crates/duke-bytecode/src/cfg.rs
@@ -389,11 +389,10 @@ pub fn generate_basic_block_cfg(blocks: &[crate::basic_block::BasicBlock]) -> St
         return cfg;
     }
 
-    // Map PC to Block ID (start_pc) for edge resolution
-    let mut pc_to_block = std::collections::HashMap::new();
-    for block in blocks {
-        pc_to_block.insert(block.start_pc, block.start_pc);
-    }
+    debug_assert!(
+        blocks.windows(2).all(|w| w[0].start_pc < w[1].start_pc),
+        "blocks must be strictly sorted by start_pc"
+    );
 
     for block in blocks {
         let block_id = block.start_pc;
@@ -411,7 +410,10 @@ pub fn generate_basic_block_cfg(blocks: &[crate::basic_block::BasicBlock]) -> St
         // Edge definition based on the last instruction
         if let Some((last_pc, last_instr)) = block.instructions.last() {
             let next_block_id = block.end_pc;
-            let next_pc = if pc_to_block.contains_key(&next_block_id) {
+            let next_pc = if blocks
+                .binary_search_by_key(&next_block_id, |b| b.start_pc)
+                .is_ok()
+            {
                 Some(next_block_id)
             } else {
                 None

--- a/crates/duke-bytecode/src/reachability.rs
+++ b/crates/duke-bytecode/src/reachability.rs
@@ -86,25 +86,32 @@ pub fn find_dead_blocks(blocks: &[BasicBlock], entry_pc: usize) -> Vec<usize> {
         return Vec::new();
     }
 
-    // ⚡ Bolt: Pre-allocate capacities based on known block count to eliminate heap reallocations
-    let mut block_map = HashMap::with_capacity(blocks.len());
-    for block in blocks {
-        block_map.insert(block.start_pc, block);
-    }
+    debug_assert!(
+        blocks.windows(2).all(|w| w[0].start_pc < w[1].start_pc),
+        "blocks must be strictly sorted by start_pc"
+    );
 
     let mut visited = HashSet::with_capacity(blocks.len());
     let mut queue = VecDeque::with_capacity(blocks.len());
 
-    if block_map.contains_key(&entry_pc) {
+    if blocks
+        .binary_search_by_key(&entry_pc, |b| b.start_pc)
+        .is_ok()
+    {
         queue.push_back(entry_pc);
         visited.insert(entry_pc);
     }
 
     while let Some(current_pc) = queue.pop_front() {
-        if let Some(block) = block_map.get(&current_pc) {
+        if let Ok(idx) = blocks.binary_search_by_key(&current_pc, |b| b.start_pc) {
+            let block = &blocks[idx];
             let successors = get_successors(block);
             for next_pc in successors {
-                if block_map.contains_key(&next_pc) && !visited.contains(&next_pc) {
+                if blocks
+                    .binary_search_by_key(&next_pc, |b| b.start_pc)
+                    .is_ok()
+                    && !visited.contains(&next_pc)
+                {
                     visited.insert(next_pc);
                     queue.push_back(next_pc);
                 }
@@ -167,13 +174,18 @@ pub fn find_shortest_path(
         return None;
     }
 
-    // ⚡ Bolt: Pre-allocate capacities based on known block count to eliminate heap reallocations
-    let mut block_map = HashMap::with_capacity(blocks.len());
-    for block in blocks {
-        block_map.insert(block.start_pc, block);
-    }
+    debug_assert!(
+        blocks.windows(2).all(|w| w[0].start_pc < w[1].start_pc),
+        "blocks must be strictly sorted by start_pc"
+    );
 
-    if !block_map.contains_key(&start_pc) || !block_map.contains_key(&target_pc) {
+    if blocks
+        .binary_search_by_key(&start_pc, |b| b.start_pc)
+        .is_err()
+        || blocks
+            .binary_search_by_key(&target_pc, |b| b.start_pc)
+            .is_err()
+    {
         return None;
     }
 
@@ -192,9 +204,14 @@ pub fn find_shortest_path(
             break;
         }
 
-        if let Some(block) = block_map.get(&current_pc) {
+        if let Ok(idx) = blocks.binary_search_by_key(&current_pc, |b| b.start_pc) {
+            let block = &blocks[idx];
             for next_pc in get_successors(block) {
-                if block_map.contains_key(&next_pc) && !visited.contains(&next_pc) {
+                if blocks
+                    .binary_search_by_key(&next_pc, |b| b.start_pc)
+                    .is_ok()
+                    && !visited.contains(&next_pc)
+                {
                     visited.insert(next_pc);
                     parents.insert(next_pc, current_pc);
                     queue.push_back(next_pc);


### PR DESCRIPTION
**💡 What:** 
- Replaced 3 intermediate `HashMap` constructions with zero-allocation `binary_search_by_key` lookups across CFG and reachability algorithms (`find_dead_blocks`, `find_shortest_path`, `generate_basic_block_cfg`).
- Enforced the structural requirement for the binary search with `debug_assert!(blocks.windows(2).all(|w| w[0].start_pc < w[1].start_pc))` statements.
- Replaced the node-allocating `BTreeSet` in `find_leaders` with a standard `Vec<usize>` that is populated, `sort_unstable()`'d, and `dedup()`'d. 

**🎯 Why:** 
- `HashMap::with_capacity` still requires initializing large contiguous buckets and performing expensive SipHash passes on simple integer `start_pc` keys. By relying on the invariant that `BasicBlock` slices are pre-sorted by `start_pc` from the decoder, we can perform O(log N) `binary_search` lookups without any heap allocations.
- `BTreeSet` inherently heap allocates every single node which adds unnecessary pressure when we just need to collect unique branch targets up front.

**📊 Impact:** 
- Reduces heap allocations by a minimum of 4 distinct collections (`1x BTreeSet`, `3x HashMap`) per CFG method analyzed.

**🔬 Measurement:** 
- Run `cargo test -p duke-bytecode --all-targets --all-features` to verify correctness.
- Run `cargo clippy -p duke-bytecode --all-targets --all-features -- -D warnings` to verify idiom adherence.

---
*PR created automatically by Jules for task [4969401824387757950](https://jules.google.com/task/4969401824387757950) started by @madmax983*