### PR TITLE
🎻 Bard: [documentation update] JAR Utility tools missing module documentation

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,7 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+
+## 2024-06-14 - [JAR Utility Modules Documentation]
+**Confusion:** The massive addition of new JAR utility tools (`jar_diff`, `jar_analyze`, `jar_search`, `histogram`, etc.) lacked module-level (`//!`) documentation, leaving developers without a clear entry point explaining the high-level concept of these modules and their distinct purposes.
+**Clarification:** Added concise module-level documentation to all 11 new JAR utility files in `duke/src/` (e.g., `jar_diff.rs`, `jar_analyze.rs`), clarifying what each module does and how it aids in bytecode analysis and security auditing.

--- a/duke/src/audit.rs
+++ b/duke/src/audit.rs
@@ -1,3 +1,5 @@
+//! Performs a security audit on a JAR file.
+
 #![allow(clippy::items_after_statements)]
 #[cfg(feature = "nova")]
 use duke_bytecode::Instruction;

--- a/duke/src/cycle_detect.rs
+++ b/duke/src/cycle_detect.rs
@@ -1,3 +1,5 @@
+//! Detects cyclic dependencies between classes inside a JAR.
+
 use duke_classfile::{
     parse, {CpEntry, CpIndex},
 };

--- a/duke/src/dead_code.rs
+++ b/duke/src/dead_code.rs
@@ -1,3 +1,5 @@
+//! Performs reachability analysis to identify potentially unused methods.
+
 use duke_bytecode::{Instruction, decode};
 use duke_classfile::{
     ClassFile, {AttributeData, CpEntry, CpIndex},

--- a/duke/src/deps_graph.rs
+++ b/duke/src/deps_graph.rs
@@ -1,3 +1,5 @@
+//! Generates a dependency graph in Graphviz DOT format.
+
 use duke_classfile::{
     ClassFile, {CpEntry, CpIndex},
 };

--- a/duke/src/histogram.rs
+++ b/duke/src/histogram.rs
@@ -1,3 +1,5 @@
+//! Generates an opcode histogram from all class files in a JAR.
+
 use duke_bytecode::decode;
 use duke_classfile::{AttributeData, parse};
 use duke_loader::{ClassLoader, ZipLoader};

--- a/duke/src/html_jar.rs
+++ b/duke/src/html_jar.rs
@@ -1,3 +1,5 @@
+//! Generates HTML documentation from class files inside a JAR.
+
 use duke_classfile::parse;
 use duke_loader::{ClassLoader, ZipLoader};
 use std::fmt::Write;

--- a/duke/src/jar_analyze.rs
+++ b/duke/src/jar_analyze.rs
@@ -1,3 +1,5 @@
+//! Analyzes the methods of a JAR file and computes cyclomatic complexity.
+
 #![allow(clippy::items_after_statements)]
 #![allow(
     clippy::case_sensitive_file_extension_comparisons,

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -1,11 +1,10 @@
+//! Compares two JAR files and reports added, removed, and modified methods.
+
 #![allow(clippy::items_after_statements)]
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +17,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +37,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/duke/src/jar_search.rs
+++ b/duke/src/jar_search.rs
@@ -1,3 +1,5 @@
+//! Searches a JAR file for string constants or references matching a query.
+
 #![allow(clippy::items_after_statements)]
 #[cfg(feature = "nova")]
 use duke_bytecode::decode;

--- a/duke/src/pathfinding.rs
+++ b/duke/src/pathfinding.rs
@@ -1,3 +1,5 @@
+//! Finds the shortest path between two points in the control flow graph.
+
 #![allow(clippy::items_after_statements)]
 #[cfg(feature = "nova")]
 use duke_bytecode::{build_basic_blocks, decode, find_shortest_path};

--- a/duke/src/scan.rs
+++ b/duke/src/scan.rs
@@ -1,3 +1,5 @@
+//! Scans class files for potentially dangerous method calls (e.g., Runtime.exec).
+
 use duke_classfile::{
     ClassFile, {CpEntry, CpIndex},
 };

--- a/tests/test_jar_analyze_scan.rs
+++ b/tests/test_jar_analyze_scan.rs
@@ -1,3 +1,5 @@
+//! Integration tests for the JAR analyze and scan commands.
+
 #![allow(missing_docs)]
 use std::process::Command;
 use std::path::PathBuf;


### PR DESCRIPTION
📖 Chapter: JAR Utility Modules (`duke/src/*`)
🔦 Insight: A large chunk of JAR analysis tools (like `jar_diff.rs`, `jar_analyze.rs`, and `histogram.rs`) were added recently but lacked high-level module documentation, causing warnings and confusion for incoming developers regarding their responsibilities. Additionally, a type inference compilation issue prevented `duke` from compiling fully. Both have been addressed by supplying specific module documentation to 11 separate JAR tools and explicitly typing closure arguments.
🧪 Example: Clean `cargo doc` execution and `cargo check`.
🖼️ Preview: (Clean HTML doc representation for the `duke` utility binaries).

---
*PR created automatically by Jules for task [2147881735723063575](https://jules.google.com/task/2147881735723063575) started by @madmax983*