### PR TITLE
👺 Havoc: [CpTypeMismatch Error Hiding]

### DIFF
--- a/.jules/havoc.md
+++ b/.jules/havoc.md
@@ -3,3 +3,7 @@
 **The Stack Trace:** The process panics with `stack overflow` or crashes due to OOM when allocating vectors at each recursion level, or exceeds system limits.
 **Reproduction:** Run `cargo test --test havoc_classfile_annotation_oom` (which we added and fixed).
 **Comment:** "You assumed the JVM specification limit of annotation depth was naturally bounded by the class file size, but deep nesting of `[` arrays with 1 element allows exponential stack growth compared to byte size. You were wrong."
+
+**[CpTypeMismatch Error Hiding]**
+**Learning:** `cp_utf8` was hiding constant pool type mismatch errors by returning `CpIndexOutOfBounds`, making debugging impossible.
+**Action:** Introduced a distinct `CpTypeMismatch` error variant.

--- a/crates/duke-classfile/src/error.rs
+++ b/crates/duke-classfile/src/error.rs
@@ -79,6 +79,13 @@ pub enum Error {
     #[error("constant pool index 0 is reserved and must not be used")]
     CpIndexZero,
 
+    /// A constant pool entry had an unexpected type.
+    #[error("constant pool entry type mismatch at index {index}")]
+    CpTypeMismatch {
+        /// The index of the mismatched entry.
+        index: u16,
+    },
+
     /// A reference attempted to read the second (phantom) slot of a `Long` or `Double` entry.
     #[error("constant pool slot {index} is a phantom slot (occupied by preceding Long/Double)")]
     CpPhantomSlot {

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -623,10 +623,11 @@ pub fn cp_utf8(pool: &[Option<CpEntry>], idx: CpIndex) -> Result<&str> {
     match pool.get(i) {
         Some(None) => Err(Error::CpPhantomSlot { index: idx.0 }),
         Some(Some(CpEntry::Utf8(s))) => Ok(s.as_str()),
-        None | Some(Some(_)) => Err(Error::CpIndexOutOfBounds {
+        None => Err(Error::CpIndexOutOfBounds {
             index: idx.0,
             pool_size: pool.len(),
         }),
+        Some(Some(_)) => Err(Error::CpTypeMismatch { index: idx.0 }),
     }
 }
 
@@ -708,8 +709,8 @@ mod tests {
         let pool = vec![None, Some(CpEntry::Integer(42))];
         let result = cp_utf8(&pool, CpIndex(1));
         assert!(
-            matches!(result, Err(Error::CpIndexOutOfBounds { index: 1, .. })),
-            "Expected Error::CpIndexOutOfBounds for wrong type, got {result:?}"
+            matches!(result, Err(Error::CpTypeMismatch { index: 1 })),
+            "Expected Error::CpTypeMismatch for wrong type, got {result:?}"
         );
 
         let result = cp_utf8(&pool, CpIndex(99));

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
👺 **Havoc: [CpTypeMismatch Error Hiding]**

🧨 **The Trigger:** `cp_utf8` hides constant pool type mismatch errors.
📉 **The Stack Trace:** It returns `CpIndexOutOfBounds` making debugging impossible.
🧪 **Reproduction:** Call `cp_utf8` on an index that points to an Integer.
😈 **Comment:** You assumed constant pool bounds checking was enough. You forgot that types matter.

---
*PR created automatically by Jules for task [11783624597994634210](https://jules.google.com/task/11783624597994634210) started by @madmax983*