### PR TITLE
🌟 Nova: Add Structural Clone Detector (jar-clones)

### DIFF
--- a/duke/src/jar_clones.rs
+++ b/duke/src/jar_clones.rs
@@ -1,0 +1,135 @@
+#![allow(clippy::items_after_statements)]
+#[cfg(feature = "nova")]
+use duke_bytecode::{calculate_similarity, decode};
+#[cfg(feature = "nova")]
+use duke_classfile::{
+    parse, {AttributeData, CpEntry, CpIndex},
+};
+#[cfg(feature = "nova")]
+use duke_loader::{ClassLoader, ZipLoader};
+use std::path::Path;
+use std::process;
+
+#[cfg(feature = "nova")]
+#[cfg(not(tarpaulin_include))]
+#[allow(unexpected_cfgs)]
+fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
+    cf.constant_pool
+        .get(idx.0 as usize)
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
+        .and_then(|entry| {
+            if let CpEntry::Utf8(s) = entry {
+                Some(s.as_str())
+            } else {
+                None
+            }
+        })
+}
+
+#[cfg(feature = "nova")]
+#[cfg(not(tarpaulin_include))]
+#[allow(
+    unexpected_cfgs,
+    clippy::print_stdout,
+    clippy::use_debug,
+    clippy::collapsible_if,
+    clippy::cast_precision_loss,
+    clippy::too_many_lines
+)]
+pub fn dump_jar_clones(jar_path: &str, threshold: f64) {
+    let loader = ZipLoader::open(Path::new(jar_path)).unwrap_or_else(|e| {
+        eprintln!("duke: failed to open JAR '{jar_path}': {e}");
+        process::exit(1);
+    });
+
+    let reader = loader.reader();
+    let class_entries: Vec<String> = reader
+        .entry_names()
+        .filter(|name| {
+            std::path::Path::new(name)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("class"))
+        })
+        .map(std::string::ToString::to_string)
+        .collect();
+
+    // Collect all methods and their instructions
+    struct MethodInfo {
+        full_name: String,
+        instructions: Vec<duke_bytecode::Instruction>,
+    }
+    let mut all_methods: Vec<MethodInfo> = Vec::new();
+
+    for entry_name in class_entries {
+        let class_name_internal = &entry_name[..entry_name.len() - 6];
+        if let Ok(bytes) = loader.find_class(class_name_internal) {
+            if let Ok(cf) = parse(&bytes) {
+                for method in &cf.methods {
+                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+                    let full_name = format!("{class_name_internal}.{name_str}{desc_str}");
+
+                    for attr in &method.attributes {
+                        if let AttributeData::Code(code) = &attr.data {
+                            if let Ok(instructions) = decode(&code.code) {
+                                // Extract just the instructions without the PC
+                                let just_instrs: Vec<_> =
+                                    instructions.into_iter().map(|(_, i)| i).collect();
+                                // Ignore very small methods (e.g. getters/setters) to avoid noise
+                                if just_instrs.len() > 5 {
+                                    all_methods.push(MethodInfo {
+                                        full_name: full_name.clone(),
+                                        instructions: just_instrs,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    println!("======================================");
+    println!(" JAR Code Clone Detector");
+    println!("======================================");
+    println!("File:      {jar_path}");
+    println!("Threshold: {threshold:.2}");
+    println!("Methods:   {}", all_methods.len());
+    println!();
+
+    let mut found_clones = false;
+    // O(N^2) comparison - fine for moderately sized JARs like our test fixtures
+    for i in 0..all_methods.len() {
+        for j in (i + 1)..all_methods.len() {
+            let sim =
+                calculate_similarity(&all_methods[i].instructions, &all_methods[j].instructions);
+            if sim >= threshold {
+                found_clones = true;
+                println!("🚨 Clone Detected! (Similarity: {sim:.2})");
+                println!("  A: {}", all_methods[i].full_name);
+                println!("  B: {}", all_methods[j].full_name);
+                println!();
+            }
+        }
+    }
+
+    if !found_clones {
+        println!("✅ No clones detected above threshold.");
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "nova")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dump_jar_clones_valid() {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../tests/fixtures/hello.jar");
+        let path_str = path.to_str().unwrap();
+
+        dump_jar_clones(path_str, 0.9);
+    }
+}

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -3,8 +3,7 @@
 
 #[cfg(feature = "nova")]
 use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    parse, {AttributeData, CpEntry, CpIndex},
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +17,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +37,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -19,6 +19,8 @@ mod html;
 mod html_jar;
 mod jar_analyze;
 #[cfg(feature = "nova")]
+mod jar_clones;
+#[cfg(feature = "nova")]
 mod jar_diff;
 #[cfg(feature = "nova")]
 mod jar_search;
@@ -333,6 +335,8 @@ fn main() {
         eprintln!("       duke jar-dead-code <file.jar>");
         #[cfg(feature = "nova")]
         eprintln!("       duke jar-search <file.jar> <query>");
+        #[cfg(feature = "nova")]
+        eprintln!("       duke jar-clones <file.jar> [threshold]");
         eprintln!("       duke -jar <file.jar> [string-arg...]");
         eprintln!("Options: --telemetry[=path]  dump telemetry JSON after execution");
         eprintln!("         --telemetry-md[=p]  dump telemetry Markdown report after execution");
@@ -370,6 +374,28 @@ fn main() {
         #[cfg(not(feature = "nova"))]
         eprintln!("duke: 'jar-diff' command requires the 'nova' feature flag.");
         return;
+    }
+
+    // Dispatch `jar-clones`
+    if args.len() > 1 && args[1] == "jar-clones" {
+        if args.len() < 3 {
+            eprintln!("Usage: duke jar-clones <file.jar> [threshold]");
+            std::process::exit(1);
+        }
+        #[cfg(feature = "nova")]
+        {
+            let threshold = args
+                .get(3)
+                .and_then(|s| s.parse::<f64>().ok())
+                .unwrap_or(0.9);
+            jar_clones::dump_jar_clones(&args[2], threshold);
+            return;
+        }
+        #[cfg(not(feature = "nova"))]
+        {
+            eprintln!("duke: unknown subcommand 'jar-clones'");
+            std::process::exit(1);
+        }
     }
 
     // Dispatch `jar-search`


### PR DESCRIPTION
💡 **The Spark:** I noticed we have tools to analyze bytecode length, complexity, and basic blocks, and `duke-bytecode` has a `calculate_similarity` function for comparing two sequences of JVM instructions. I wanted to leverage this to build a powerful user-facing tool!
🚀 **The Feature:** Implemented `duke jar-clones <file.jar> [threshold]` in `duke/src/jar_clones.rs` which reads a JAR file, extracts all class methods, decodes their bytecode, and computes the Levenshtein distance between sequences of JVM instructions (using `calculate_similarity`). It prints pairs of methods that have a similarity score above the configured threshold.
🔭 **The Potential:** Can be used to build a "code clone detector" for JAR files, identifying redundant methods or copy-pasted code blocks across classes.
⚠️ **Risk:** Low. Isolated in `duke/src/jar_clones.rs` and properly feature-flagged behind `#[cfg(feature = "nova")]`. It has no impact on runtime execution. As part of this change, I also resolved some residual compilation errors from previous refactoring by explicitly annotating types and removing the no-longer-needed `types::` module prefix for classfile exports.

---
*PR created automatically by Jules for task [2674874795280776248](https://jules.google.com/task/2674874795280776248) started by @madmax983*