### PR TITLE
⚒️ Forge: Fix Type Inference in jar_diff.rs

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**Flatten Nested Option Combinators**
+**Learning:** `cp_str` and `resolve_class_name` in `duke/src/jar_diff.rs` used chained `.and_then()` closures to dig into `Option<Option<CpEntry>>`. This created a "Pyramid of Doom" disguised as combinators and resulted in `E0282: type annotations needed` compiler errors when the compiler could not infer the closure argument types.
+**Action:** Replace deeply nested or ambiguous `.and_then()` chains with explicit `let Some(Some(...)) = ... else { return ... };` guard clauses. This flattens control flow, removes the need for explicit closure type annotations, and clearly documents the expected shape of the data.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -16,16 +13,10 @@ use std::path::Path;
 #[cfg(not(tarpaulin_include))]
 #[allow(unexpected_cfgs)]
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
-    cf.constant_pool
-        .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
-        .and_then(|entry| {
-            if let CpEntry::Utf8(s) = entry {
-                Some(s.as_str())
-            } else {
-                None
-            }
-        })
+    let Some(Some(CpEntry::Utf8(s))) = cf.constant_pool.get(idx.0 as usize) else {
+        return None;
+    };
+    Some(s.as_str())
 }
 
 #[cfg(feature = "nova")]
@@ -35,17 +26,12 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     if idx.0 == 0 {
         return "<none>".to_string();
     }
-    let class_entry = cf
-        .constant_pool
-        .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
-    if let Some(CpEntry::Class { name_index }) = class_entry {
-        cp_str(cf, *name_index)
-            .unwrap_or("<invalid utf8>")
-            .to_string()
-    } else {
-        "<not a class ref>".to_string()
-    }
+    let Some(Some(CpEntry::Class { name_index })) = cf.constant_pool.get(idx.0 as usize) else {
+        return "<not a class ref>".to_string();
+    };
+    cp_str(cf, *name_index)
+        .unwrap_or("<invalid utf8>")
+        .to_string()
 }
 
 #[cfg(feature = "nova")]


### PR DESCRIPTION
🚮 **Smell**: `cp_str` and `resolve_class_name` in `duke/src/jar_diff.rs` used chained `.and_then()` closures to dig into `Option<Option<CpEntry>>`. This created a "Pyramid of Doom" disguised as combinators and resulted in `E0282: type annotations needed` compiler errors when the compiler could not infer the closure argument types.

✨ **Solution**: Replaced deeply nested or ambiguous `.and_then()` chains with explicit `let Some(Some(...)) = ... else { return ... };` guard clauses.

🧼 **Benefit**: Flattens control flow, removes the need for explicit closure type annotations, fixes compiler errors, and clearly documents the expected shape of the data.

🛡️ **Verification**: `cargo check`, `cargo clippy`, and `cargo test` pass successfully.

---
*PR created automatically by Jules for task [12183706525236219347](https://jules.google.com/task/12183706525236219347) started by @madmax983*