### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -47,3 +47,7 @@
 ## 2024-05-24 - Testing ReentrantReadWriteLock Native Operations
 **Learning:** Found several native functions implementing `ReentrantReadWriteLock` and `PriorityQueue` operations missing test coverage in `duke-interpreter`. Adding dummy tests correctly executes these logic branches without needing fully mocked multi-threading scenarios.
 **Action:** Add inline unit tests using a mocked heap and manually setting up the `obj_ref` payload.
+
+## 2024-06-15 - Unsafe Path Reconstruction in BFS
+**Learning:** In graph algorithms like BFS, assuming a target node's parent is present in the visited/parents map during path reconstruction via `.unwrap()` is risky. While mathematically sound if the target was found, it creates a potential panic point if the graph or map invariants are ever corrupted.
+**Action:** Replace `unwrap()` with a safe fallback (e.g. `let else` guard) returning `None` or an explicit error, removing the "fuse" from the time bomb. Also, always add a test for the base case (e.g. `start_pc == target_pc`).

--- a/crates/duke-bytecode/src/reachability.rs
+++ b/crates/duke-bytecode/src/reachability.rs
@@ -152,7 +152,7 @@ pub fn find_dead_blocks(blocks: &[BasicBlock], entry_pc: usize) -> Vec<usize> {
 /// let blocks = build_basic_blocks(&instructions);
 ///
 /// // Path to PC 10 goes through PC 0, then falls through/jumps to PC 3, which jumps to PC 10.
-/// let path = find_shortest_path(&blocks, 0, 10).unwrap();
+/// let path = find_shortest_path(&blocks, 0, 10).expect("should find path");
 /// assert_eq!(path, vec![0, 3, 10]);
 /// # }
 /// ```
@@ -208,7 +208,8 @@ pub fn find_shortest_path(
         let mut curr = target_pc;
         while curr != start_pc {
             path.push(curr);
-            curr = *parents.get(&curr).unwrap();
+            let &prev = parents.get(&curr)?;
+            curr = prev;
         }
         path.push(start_pc);
         path.reverse();
@@ -271,14 +272,29 @@ mod tests {
         let blocks = build_basic_blocks(&instructions);
 
         // Path to 10: 0 -> 3 -> 10
-        let path = find_shortest_path(&blocks, 0, 10).unwrap();
+        let path = find_shortest_path(&blocks, 0, 10).expect("should find path");
         assert_eq!(path, vec![0, 3, 10]);
 
         // Path to 8: 0 -> 8
-        let path2 = find_shortest_path(&blocks, 0, 8).unwrap();
+        let path2 = find_shortest_path(&blocks, 0, 8).expect("should find path");
         assert_eq!(path2, vec![0, 8]);
 
         // Unreachable
         assert!(find_shortest_path(&blocks, 0, 6).is_none());
+    }
+
+    #[test]
+    fn test_find_shortest_path_start_eq_target() {
+        let instructions = vec![
+            (0, Instruction::Goto(6)),
+            (3, Instruction::Ireturn),
+            (6, Instruction::Ireturn),
+        ];
+        let blocks = build_basic_blocks(&instructions);
+
+        // Path where start_pc == target_pc
+        let path =
+            find_shortest_path(&blocks, 0, 0).expect("should find path when start == target");
+        assert_eq!(path, vec![0]);
     }
 }


### PR DESCRIPTION
🎯 Target: `find_shortest_path` in `crates/duke-bytecode/src/reachability.rs`
💣 Risk: Prevents potential panic during path reconstruction when parent mappings are broken or incomplete.
🧪 Strategy: Replaced the timebomb `.unwrap()` with `?` to return `None` safely. Removed `.unwrap()` instances in tests/doc-tests by changing them to `.expect()`. Added an explicit test case to ensure paths are properly constructed when `start == target`.
🔬 Verification: Run `cargo test -p duke-bytecode` and `cargo clippy -p duke-bytecode --all-features`.

---
*PR created automatically by Jules for task [17066894795330378091](https://jules.google.com/task/17066894795330378091) started by @madmax983*