### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -47,3 +47,6 @@
 ## 2024-05-24 - Testing ReentrantReadWriteLock Native Operations
 **Learning:** Found several native functions implementing `ReentrantReadWriteLock` and `PriorityQueue` operations missing test coverage in `duke-interpreter`. Adding dummy tests correctly executes these logic branches without needing fully mocked multi-threading scenarios.
 **Action:** Add inline unit tests using a mocked heap and manually setting up the `obj_ref` payload.
+## 2024-05-24 - Testing Annotation Recursion Limits
+**Learning:** Certain `Error` variants like `RecursionLimitExceeded` inside recursive annotation element decoding were previously untested. By constructing malicious byte streams in `duke-classfile/src/parser.rs` with heavily nested annotation arrays, we can trigger the maximum recursion bounds directly.
+**Action:** When evaluating heavily recursive parser loops, intentionally craft binary sequences that exceed depth limits and assert correct `RecursionLimitExceeded` error propagation to ensure safe failure.

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -773,4 +773,40 @@ mod tests {
         };
         assert_eq!(values.len(), 2);
     }
+
+    #[test]
+    fn should_return_error_when_decoding_element_value_exceeds_recursion_limit() {
+        let mut raw = Vec::new();
+        // We construct a nested array: '[' ...
+        for _ in 0..17 {
+            raw.push(b'[');
+            raw.extend_from_slice(&[0x00, 0x01]); // 1 element
+        }
+        raw.push(b'I');
+        raw.extend_from_slice(&[0x00, 0x01]); // leaf integer
+
+        let mut cursor = Cursor::new(&raw);
+        let result = decode_element_value(&mut cursor, 17);
+        assert!(
+            matches!(result, Err(Error::RecursionLimitExceeded { .. })),
+            "Expected RecursionLimitExceeded, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn should_return_error_when_decoding_annotation_exceeds_recursion_limit() {
+        let mut raw = Vec::new();
+        for _ in 0..17 {
+            // annotation: type_index, num_pairs=1, name_index, value=@...
+            raw.extend_from_slice(&[0x00, 0x01, 0x00, 0x01, 0x00, 0x02, b'@']);
+        }
+        raw.extend_from_slice(&[0x00, 0x01, 0x00, 0x00]); // base case: empty annotation
+
+        let mut cursor = Cursor::new(&raw);
+        let result = decode_annotation(&mut cursor, 17);
+        assert!(
+            matches!(result, Err(Error::RecursionLimitExceeded { .. })),
+            "Expected RecursionLimitExceeded, got {result:?}"
+        );
+    }
 }

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -16,16 +13,10 @@ use std::path::Path;
 #[cfg(not(tarpaulin_include))]
 #[allow(unexpected_cfgs)]
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
-    cf.constant_pool
-        .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
-        .and_then(|entry| {
-            if let CpEntry::Utf8(s) = entry {
-                Some(s.as_str())
-            } else {
-                None
-            }
-        })
+    let Some(Some(CpEntry::Utf8(s))) = cf.constant_pool.get(idx.0 as usize) else {
+        return None;
+    };
+    Some(s.as_str())
 }
 
 #[cfg(feature = "nova")]
@@ -35,17 +26,12 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     if idx.0 == 0 {
         return "<none>".to_string();
     }
-    let class_entry = cf
-        .constant_pool
-        .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
-    if let Some(CpEntry::Class { name_index }) = class_entry {
-        cp_str(cf, *name_index)
-            .unwrap_or("<invalid utf8>")
-            .to_string()
-    } else {
-        "<not a class ref>".to_string()
-    }
+    let Some(Some(CpEntry::Class { name_index })) = cf.constant_pool.get(idx.0 as usize) else {
+        return "<not a class ref>".to_string();
+    };
+    cp_str(cf, *name_index)
+        .unwrap_or("<invalid utf8>")
+        .to_string()
 }
 
 #[cfg(feature = "nova")]


### PR DESCRIPTION
Added unit tests to cover the `RecursionLimitExceeded` error variant in the `duke-classfile` parser. This ensures that deeply nested annotations or arrays gracefully fail instead of causing stack overflows. Also refactored `jar_diff.rs` to fix `clippy::manual_let_else` and compilation errors related to unresolved imports and type inference.

---
*PR created automatically by Jules for task [2536361193239370278](https://jules.google.com/task/2536361193239370278) started by @madmax983*