### PR TITLE
⚒️ Forge: Fix closure parameter type inference in Option combinators

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,6 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+**[Closure Parameter Type Inference]
+**Learning:** Chaining `.and_then()` closures on nested `Option`s containing enums (like `Option<Option<CpEntry>>`) caused type inference failures (`E0282`) across multiple files because the compiler couldn't infer the type of the closure parameter.
+**Action:** Always provide explicit type annotations for closure parameters (e.g., `|slot: &Option<CpEntry>|`) when chaining methods that return references to deeply nested or complex types.

--- a/duke/src/analyze.rs
+++ b/duke/src/analyze.rs
@@ -7,7 +7,7 @@ use std::fmt::Write;
 fn cp_str(cf: &ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -24,7 +24,7 @@ fn resolve_class_name(cf: &ClassFile, idx: CpIndex) -> &str {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index).unwrap_or("<invalid utf8>")
     } else {

--- a/duke/src/audit.rs
+++ b/duke/src/audit.rs
@@ -18,7 +18,7 @@ use std::process;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/duke/src/cycle_detect.rs
+++ b/duke/src/cycle_detect.rs
@@ -11,7 +11,7 @@ use std::process;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -30,7 +30,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/duke/src/dead_code.rs
+++ b/duke/src/dead_code.rs
@@ -12,7 +12,7 @@ use std::process;
 fn cp_str(cf: &ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -31,7 +31,7 @@ fn resolve_class_name(cf: &ClassFile, idx: CpIndex) -> &str {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index).unwrap_or("<invalid utf8>")
     } else {

--- a/duke/src/deps_graph.rs
+++ b/duke/src/deps_graph.rs
@@ -5,7 +5,7 @@ use duke_classfile::{
 fn cp_str(cf: &ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -22,7 +22,7 @@ fn resolve_class_name(cf: &ClassFile, idx: CpIndex) -> &str {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index).unwrap_or("<invalid utf8>")
     } else {

--- a/duke/src/html.rs
+++ b/duke/src/html.rs
@@ -13,7 +13,7 @@ fn escape_html(s: &str) -> String {
 fn cp_str(cf: &ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -30,7 +30,7 @@ fn resolve_class_name(cf: &ClassFile, idx: CpIndex) -> &str {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index).unwrap_or("<invalid utf8>")
     } else {

--- a/duke/src/inspect.rs
+++ b/duke/src/inspect.rs
@@ -51,7 +51,7 @@ pub fn inspect_jar(path: &str) {
                         let method_name = cf
                             .constant_pool
                             .get(method.name_index.0 as usize)
-                            .and_then(|e| e.as_ref())
+                            .and_then(|e: &Option<CpEntry>| e.as_ref())
                             .and_then(|e| {
                                 if let duke_classfile::CpEntry::Utf8(s) = e {
                                     Some(s)

--- a/duke/src/jar_analyze.rs
+++ b/duke/src/jar_analyze.rs
@@ -18,7 +18,7 @@ use std::process;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -37,7 +37,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/duke/src/jar_search.rs
+++ b/duke/src/jar_search.rs
@@ -16,7 +16,7 @@ use std::process;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -1359,7 +1359,7 @@ fn dump_class_file(cf: &ClassFile) {
 fn cp_str(cf: &ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -1376,7 +1376,7 @@ fn resolve_class_name(cf: &ClassFile, idx: CpIndex) -> &str {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index).unwrap_or("<invalid utf8>")
     } else {

--- a/duke/src/purity.rs
+++ b/duke/src/purity.rs
@@ -13,7 +13,7 @@ use std::process;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())

--- a/duke/src/scan.rs
+++ b/duke/src/scan.rs
@@ -7,7 +7,7 @@ use duke_classfile::{
 fn cp_str(cf: &ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -26,7 +26,7 @@ fn resolve_class_name(cf: &ClassFile, idx: CpIndex) -> &str {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index).unwrap_or("<invalid utf8>")
     } else {
@@ -107,7 +107,7 @@ pub fn scan_classfile(cf: &ClassFile) -> Vec<RiskMatch> {
             let name_str = cf
                 .constant_pool
                 .get(name_and_type_index.0 as usize)
-                .and_then(|s| s.as_ref())
+                .and_then(|s: &Option<CpEntry>| s.as_ref())
                 .and_then(|nat| {
                     if let CpEntry::NameAndType { name_index, .. } = nat {
                         cp_str(cf, *name_index)

--- a/duke/src/search.rs
+++ b/duke/src/search.rs
@@ -7,7 +7,7 @@ use std::process;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())

--- a/duke/src/simulate.rs
+++ b/duke/src/simulate.rs
@@ -8,7 +8,7 @@ use duke_classfile::{AttributeData, ClassFile, CpEntry, CpIndex};
 fn cp_str(cf: &ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())

--- a/duke/src/uml.rs
+++ b/duke/src/uml.rs
@@ -11,7 +11,7 @@ use std::fmt::Write;
 fn cp_str(cf: &ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -28,7 +28,7 @@ fn resolve_class_name(cf: &ClassFile, idx: CpIndex) -> &str {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index).unwrap_or("<invalid utf8>")
     } else {


### PR DESCRIPTION
🚮 Smell: Type inference failures (`E0282: type annotations needed`) across 16 files in the `duke` crate due to chaining `.and_then()` closures over nested `Option`s containing `CpEntry` enums (e.g., `Option<Option<CpEntry>>`). The compiler couldn't correctly infer the type of the closure parameter `|slot|` when `slot.as_ref()` was called. This issue was likely introduced when refactoring or updating `duke_classfile` exports. Another smell was the unresolved import of `duke_classfile::types`, which should have been just `duke_classfile`.
✨ Solution: Extracted explicit type annotations for the closure parameters (e.g., `.and_then(|slot: &Option<CpEntry>| slot.as_ref())`) across all affected modules (`jar_diff.rs`, `jar_search.rs`, `analyze.rs`, etc.). Also fixed the imports to correctly point directly to `duke_classfile::{...}` instead of `duke_classfile::types::{...}`.
🧼 Benefit: Restores compilation of the `duke` workspace and guarantees correct type propagation through deeply nested `Option` chains, making the code more explicit and robust against future inference regressions.
🛡️ Verification: `cargo check`, `cargo test`, and `cargo clippy --all-targets --all-features -- -D warnings` all pass cleanly without logic changes.

---
*PR created automatically by Jules for task [6284817743647767830](https://jules.google.com/task/6284817743647767830) started by @madmax983*