### PR TITLE
👺 Havoc: Poisoned Mutex Cascading Panic

### DIFF
--- a/.jules/havoc.md
+++ b/.jules/havoc.md
@@ -3,3 +3,9 @@
 **The Stack Trace:** The process panics with `stack overflow` or crashes due to OOM when allocating vectors at each recursion level, or exceeds system limits.
 **Reproduction:** Run `cargo test --test havoc_classfile_annotation_oom` (which we added and fixed).
 **Comment:** "You assumed the JVM specification limit of annotation depth was naturally bounded by the class file size, but deep nesting of `[` arrays with 1 element allows exponential stack growth compared to byte size. You were wrong."
+
+## 2025-06-15 - [Poisoned Mutex Cascading Panic]
+**The Trigger:** A background thread panicking while holding the `runtime` lock during execution of a Java method in `duke-interpreter`'s `spawn_java_thread`.
+**The Stack Trace:** Panics with `called `Result::unwrap()` on an `Err` value: PoisonError` on worker thread completion.
+**Reproduction:** Create a `CompletionRuntime`, poison its mutex, and pass it to `spawn_java_thread`.
+**Comment:** "You assumed `Mutex::unwrap()` was safe because you didn't expect threads to panic while holding it. You were wrong."

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -21237,7 +21237,7 @@ fn spawn_java_thread(
         }
         let _ = runtime_clone
             .lock()
-            .unwrap()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .threads
             .mark_finished_by_java_ref(thread_ref);
         unregister_java_host_thread(host_key);
@@ -38212,4 +38212,50 @@ mod tests_sentry {
         assert!(matches!(err_bool, crate::Error::InvalidRef { address: _ }));
     }
 
+}
+
+
+#[cfg(test)]
+mod havoc_tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use duke_loader::DirectoryLoader;
+    use std::path::PathBuf;
+
+    #[test]
+    fn havoc_test_runtime_lock_poison_unwrap() {
+        let registry = ClassRegistry::new();
+        let heap = duke_gc::Heap::new();
+        let loader = DirectoryLoader::new(PathBuf::from("."));
+
+        let shared = Arc::new(Mutex::new(CompletionVm {
+            registry,
+            heap,
+            output: Vec::new(),
+            live_workers: 1,
+        }));
+
+        let runtime = Arc::new(Mutex::new(CompletionRuntime::default()));
+
+        let _ = std::thread::spawn({
+            let runtime = Arc::clone(&runtime);
+            move || {
+                let _guard = runtime.lock().unwrap();
+                panic!("Havoc: Poisoning the runtime lock!");
+            }
+        }).join();
+
+        assert!(runtime.is_poisoned());
+
+        let loader_arc: Arc<dyn ClassLoader + Send + Sync> = Arc::new(loader);
+        // spawn_java_thread starts a thread. We wait for it to crash on `.unwrap()`.
+        let _ = spawn_java_thread(&shared, &runtime, &loader_arc, 0);
+
+        // Wait for the spawned thread to finish its work without sleep
+        let handles = runtime.lock().unwrap_or_else(std::sync::PoisonError::into_inner).handles.drain().collect::<Vec<_>>();
+        for (_, handle) in handles {
+            let res = handle.join();
+            assert!(res.is_ok(), "Worker thread should NOT have panicked, but it did");
+        }
+    }
 }


### PR DESCRIPTION
🧨 **The Trigger:** A background thread panicking while holding the `runtime` lock during execution of a Java method in `duke-interpreter`'s `spawn_java_thread`.
📉 **The Stack Trace:** Panics with `called Result::unwrap() on an Err value: PoisonError` on worker thread completion.
🧪 **Reproduction:** Create a `CompletionRuntime`, poison its mutex, and pass it to `spawn_java_thread`. Run `cargo test -p duke-interpreter havoc_test_runtime_lock_poison_unwrap`.
😈 **Comment:** "You assumed `Mutex::unwrap()` was safe because you didn't expect threads to panic while holding it. You were wrong."

---
*PR created automatically by Jules for task [6833722089106445930](https://jules.google.com/task/6833722089106445930) started by @madmax983*