### PR TITLE
⚡ Bolt: Replace BTreeSet with Vec and binary_search for basic block leaders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,6 @@
 **Trust the Iterator: .collect() is Optimized**
 **Learning:** In Rust, `.collect::<Vec<_>>()` called on an `ExactSizeIterator` (which `slice.iter().map()` implements) already knows the exact number of elements. The standard library heavily optimizes this via the `TrustedLen` trait to allocate the precise capacity upfront and completely bypass bounds checks during insertion.
 **Action:** Do not manually replace `.collect::<Vec<_>>()` with `Vec::with_capacity` and a `for` loop, as it re-introduces bounds checks on every push, making the "optimization" unidiomatic and a micro-regression.
+**Replaced BTreeSet with Vec and binary_search for basic block leaders**
+**Learning:** Replaced the `BTreeSet<usize>` used for finding basic block leaders with a `Vec<usize>` that uses `.sort_unstable()`, `.dedup()`, and `.binary_search()`. Constructing a basic block sequence operates in a hot path when deciphering and traversing bytecode graphs. The `BTreeSet` causes many unnecessary node-based heap allocations during inserts since it's just building up the list of targets once before lookups.
+**Action:** Replaced the `BTreeSet` used for finding basic block leaders with a `Vec<usize>` that uses `.sort_unstable()`, `.dedup()`, and `.binary_search()`.

--- a/crates/duke-bytecode/src/basic_block.rs
+++ b/crates/duke-bytecode/src/basic_block.rs
@@ -5,8 +5,6 @@
 //! code sequence with no branches in except to the entry and no branches out
 //! except at the exit.
 
-use std::collections::BTreeSet;
-
 use crate::Instruction;
 
 /// A basic block of JVM bytecode.
@@ -76,9 +74,10 @@ pub fn build_basic_blocks(instructions: &[(usize, Instruction)]) -> Vec<BasicBlo
 }
 
 #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
-fn find_leaders(instructions: &[(usize, Instruction)]) -> BTreeSet<usize> {
-    let mut leaders = BTreeSet::new();
-    leaders.insert(instructions[0].0);
+/// ⚡ Bolt: Using `Vec` with `sort_unstable()` and `dedup()` avoids `BTreeSet` node-based heap allocations.
+fn find_leaders(instructions: &[(usize, Instruction)]) -> Vec<usize> {
+    let mut leaders = Vec::with_capacity(16);
+    leaders.push(instructions[0].0);
 
     for (i, (pc, instr)) in instructions.iter().enumerate() {
         let is_branch_or_return = instr.is_conditional_branch()
@@ -88,27 +87,30 @@ fn find_leaders(instructions: &[(usize, Instruction)]) -> BTreeSet<usize> {
 
         // Target of any jump or branch is a leader
         for target in instr.control_flow_targets(*pc, None) {
-            leaders.insert(target);
+            leaders.push(target);
         }
 
         // The instruction immediately following any jump, branch, or return is a leader
         if is_branch_or_return && i + 1 < instructions.len() {
-            leaders.insert(instructions[i + 1].0);
+            leaders.push(instructions[i + 1].0);
         }
     }
+    leaders.sort_unstable();
+    leaders.dedup();
     leaders
 }
 
-fn construct_blocks(
-    instructions: &[(usize, Instruction)],
-    leaders: &BTreeSet<usize>,
-) -> Vec<BasicBlock> {
+fn construct_blocks(instructions: &[(usize, Instruction)], leaders: &[usize]) -> Vec<BasicBlock> {
+    debug_assert!(
+        leaders.windows(2).all(|w| w[0] < w[1]),
+        "leaders slice must be sorted and deduplicated for binary_search"
+    );
     let mut blocks = Vec::with_capacity(leaders.len());
     let mut current_start_pc = instructions[0].0;
     let mut current_start_idx = 0;
 
     for (i, (pc, _)) in instructions.iter().enumerate() {
-        if leaders.contains(pc) && i > current_start_idx {
+        if leaders.binary_search(pc).is_ok() && i > current_start_idx {
             blocks.push(BasicBlock {
                 start_pc: current_start_pc,
                 end_pc: *pc,

--- a/pr_details.txt
+++ b/pr_details.txt
@@ -1,6 +1,7 @@
-Title: 🛡️ Sentry: [test coverage improvement]
-Body:
-🎯 Target: `duke_loader::ZipReader::read_entry_info`, `duke_loader::parse_central_directory`, and `duke_telemetry::ser_helpers`.
-💣 Risk: Edge cases where zip central directories have truncated entries or mismatched local header offsets, and missing telemetry map empty paths could panic or fail implicitly if refactored.
-🧪 Strategy: Added specific inline tests inside `crates/duke-loader/src/zip.rs` to reach missing branches of Zip Format errors (e.g. truncated `filename_len`, exceeded `uncompressed_size`). Added tests in `crates/duke-telemetry/src/helpers.rs` for empty map serialization. Added an empty check for `print_report`.
-🔭 Verification: `cargo test -p duke-loader` and `cargo test -p duke-telemetry`
+Title: ⚡ Bolt: Replace BTreeSet with Vec and binary_search for basic block leaders
+
+Description:
+💡 What: Replaced the `BTreeSet<usize>` used for finding basic block leaders with a `Vec<usize>` that uses `.sort_unstable()`, `.dedup()`, and `.binary_search()`.
+🎯 Why: Constructing a basic block sequence operates in a hot path when deciphering and traversing bytecode graphs. The `BTreeSet` causes many unnecessary node-based heap allocations during inserts since it's just building up the list of targets once before lookups.
+📊 Impact: Eliminates numerous tiny heap allocations in `find_leaders` during `build_basic_blocks` without compromising lookup performance (O(log n)).
+🔬 Measurement: Run `cargo test -p duke-bytecode` and `cargo bench -p duke-bytecode` to verify correctness and performance.


### PR DESCRIPTION
💡 What: Replaced the `BTreeSet<usize>` used for finding basic block leaders with a `Vec<usize>` that uses `.sort_unstable()`, `.dedup()`, and `.binary_search()`.
🎯 Why: Constructing a basic block sequence operates in a hot path when deciphering and traversing bytecode graphs. The `BTreeSet` causes many unnecessary node-based heap allocations during inserts since it's just building up the list of targets once before lookups.
📊 Impact: Eliminates numerous tiny heap allocations in `find_leaders` during `build_basic_blocks` without compromising lookup performance (O(log n)).
🔬 Measurement: Run `cargo test -p duke-bytecode` and `cargo bench -p duke-bytecode` to verify correctness and performance.

---
*PR created automatically by Jules for task [9795586885262640024](https://jules.google.com/task/9795586885262640024) started by @madmax983*