### PR TITLE
🗺️ Atlas: [Encapsulate `duke_classfile` Facade]

### DIFF
--- a/crates/duke-telemetry/src/helpers_serialize_fail_test.rs
+++ b/crates/duke-telemetry/src/helpers_serialize_fail_test.rs
@@ -1,4 +1,4 @@
-use duke_telemetry::helpers::ser_helpers::*;
+use crate::helpers::ser_helpers::*;
 
 fn test() {
     // missing lines: 16, 17, 25, 33, 41, 49, 50, 51

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
🕸️ Tangle: The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types, and `duke-telemetry` exposed internal serialization helpers via `pub mod ser_helpers`. This creates confusing, leaky abstractions and redundant paths.
📐 Blueprint: Encapsulated both modules. In `duke_classfile`, replaced `pub mod types` with direct `pub use` statements at the crate root, eliminating the `types` namespace from the public API entirely. In `duke_telemetry`, reduced `ser_helpers` visibility to `pub(crate)`.
🧱 Stability: Reduced coupling, prevented leaky abstractions, and fixed compiler type inference failures in `jar_diff.rs`.
🔬 Verification: Builds successfully, all tests pass, and strict separation is enforced.

---
*PR created automatically by Jules for task [16893156702018027276](https://jules.google.com/task/16893156702018027276) started by @madmax983*