### PR TITLE
⚡ Bolt: Replace BTreeSet with Vec in build_basic_blocks

### DIFF
--- a/commit.txt
+++ b/commit.txt
@@ -1,0 +1,6 @@
+⚡ Bolt: Replace BTreeSet with Vec in build_basic_blocks
+
+💡 What: Replaced the `BTreeSet` used to track leader instructions during basic block construction with a `Vec` combined with `sort_unstable` and `dedup`. Updated `construct_blocks` to use `binary_search` instead of `contains`. Also resolved pending compiler errors in `jar_diff.rs` involving missing `types::` imports and `and_then` type inference that failed due to previous optimizations.
+🎯 Why: `BTreeSet::insert` causes a node-based heap allocation for each unique insertion. During basic block parsing (a very hot path when loading classes), this leads to dozens of allocations per method.
+📊 Impact: Eliminates O(N) node allocations per method parsed, replacing them with a single contiguous buffer allocation and an O(N log N) sort.
+🔬 Measurement: Run `cargo bench` or `cargo test --all-targets --all-features`.

--- a/crates/duke-bytecode/src/basic_block.rs
+++ b/crates/duke-bytecode/src/basic_block.rs
@@ -5,8 +5,6 @@
 //! code sequence with no branches in except to the entry and no branches out
 //! except at the exit.
 
-use std::collections::BTreeSet;
-
 use crate::Instruction;
 
 /// A basic block of JVM bytecode.
@@ -76,9 +74,9 @@ pub fn build_basic_blocks(instructions: &[(usize, Instruction)]) -> Vec<BasicBlo
 }
 
 #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
-fn find_leaders(instructions: &[(usize, Instruction)]) -> BTreeSet<usize> {
-    let mut leaders = BTreeSet::new();
-    leaders.insert(instructions[0].0);
+fn find_leaders(instructions: &[(usize, Instruction)]) -> Vec<usize> {
+    let mut leaders = Vec::new();
+    leaders.push(instructions[0].0);
 
     for (i, (pc, instr)) in instructions.iter().enumerate() {
         let is_branch_or_return = instr.is_conditional_branch()
@@ -88,27 +86,30 @@ fn find_leaders(instructions: &[(usize, Instruction)]) -> BTreeSet<usize> {
 
         // Target of any jump or branch is a leader
         for target in instr.control_flow_targets(*pc, None) {
-            leaders.insert(target);
+            leaders.push(target);
         }
 
         // The instruction immediately following any jump, branch, or return is a leader
         if is_branch_or_return && i + 1 < instructions.len() {
-            leaders.insert(instructions[i + 1].0);
+            leaders.push(instructions[i + 1].0);
         }
     }
+
+    // ⚡ Bolt: Replace BTreeSet with a sorted, deduplicated Vec.
+    // This avoids costly node-based heap allocations for multiple insertions.
+    // Memory allocations are the enemy.
+    leaders.sort_unstable();
+    leaders.dedup();
     leaders
 }
 
-fn construct_blocks(
-    instructions: &[(usize, Instruction)],
-    leaders: &BTreeSet<usize>,
-) -> Vec<BasicBlock> {
+fn construct_blocks(instructions: &[(usize, Instruction)], leaders: &[usize]) -> Vec<BasicBlock> {
     let mut blocks = Vec::with_capacity(leaders.len());
     let mut current_start_pc = instructions[0].0;
     let mut current_start_idx = 0;
 
     for (i, (pc, _)) in instructions.iter().enumerate() {
-        if leaders.contains(pc) && i > current_start_idx {
+        if leaders.binary_search(pc).is_ok() && i > current_start_idx {
             blocks.push(BasicBlock {
                 start_pc: current_start_pc,
                 end_pc: *pc,

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/plan.md
+++ b/plan.md
@@ -1,20 +1,16 @@
-1. **Optimize String concatenation in `native_string_concat`**
-   - The function currently uses `format!("{s1}{s2}")` to concatenate two strings, which allocates a new string buffer inside `format!`, formats the arguments, and returns it.
-   - We can optimize this by pre-allocating a `String` with the exact required capacity and appending the strings:
-     ```rust
-     let mut combined = String::with_capacity(s1.len() + s2.len());
-     combined.push_str(&s1);
-     combined.push_str(&s2);
-     let r = heap.allocate_string(combined);
-     ```
-   - This eliminates the intermediate allocation and parsing overhead of `format!`, which is a common hotspot in interpreters.
-   - Add `// ⚡ Bolt: Eliminate intermediate format! allocation` comment.
-   - Ensure the tests pass.
-1. Refactor `print_report` methods in `duke-telemetry/src/lib.rs` to handle empty states gracefully (Reduces noise from empty reports).
-   - Before: Outputs headers and empty tables for empty components.
-   - After: Outputs a concise message stating no events were recorded.
-2. Complete pre commit steps to make sure proper testing, verifications, reviews and reflections are done.
-3. Submit the change using a descriptive title.
-1. **Optimize Vector Allocations in Execution (Vec::with_capacity)**: Pre-allocate vectors in `crates/duke-interpreter/src/execution.rs` for `Multianewarray` `dims` array and lambda args `impl_args` to avoid unnecessary dynamic heap reallocations.
-2. Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.
-3. **Submit the PR**: Present PR titled '⚡ Bolt: Optimize Vector Allocations in Execution & Native' detailing 💡 What, 🎯 Why, 📊 Impact, and 🔭 Measurement. I will use `run_in_bash_session` to execute `git commit` with the requested PR details.
+1.  **Refactor `find_leaders` in `crates/duke-bytecode/src/basic_block.rs` to avoid `BTreeSet`**:
+    - Change the return type of `find_leaders` from `BTreeSet<usize>` to `Vec<usize>`.
+    - Change `leaders.insert(x)` to `leaders.push(x)`.
+    - At the end of `find_leaders`, sort and deduplicate the vector: `leaders.sort_unstable(); leaders.dedup();`.
+    - Update `construct_blocks` to accept `&[usize]` instead of `&BTreeSet<usize>`.
+    - Replace `leaders.contains(pc)` with `leaders.binary_search(pc).is_ok()` in `construct_blocks`.
+    - Add a doc comment explaining the optimization.
+
+2.  **Fix unresolved import error**:
+    - `jar_diff.rs` was breaking compilation due to an issue with `duke_classfile::types` missing. Refactor the `jar_diff.rs` imports and `and_then` closure type annotations to resolve compilation errors resulting from changes made during previous optimizations.
+
+3.  **Complete pre-commit steps**:
+    - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+
+4.  **Submit the change**:
+    - Submit the PR with the title '⚡ Bolt: Replace BTreeSet with Vec in build_basic_blocks'.


### PR DESCRIPTION
💡 What: Replaced the `BTreeSet` used to track leader instructions during basic block construction with a `Vec` combined with `sort_unstable` and `dedup`. Updated `construct_blocks` to use `binary_search` instead of `contains`. Also resolved pending compiler errors in `jar_diff.rs` involving missing `types::` imports and `and_then` type inference that failed due to previous optimizations.
🎯 Why: `BTreeSet::insert` causes a node-based heap allocation for each unique insertion. During basic block parsing (a very hot path when loading classes), this leads to dozens of allocations per method. 
📊 Impact: Eliminates O(N) node allocations per method parsed, replacing them with a single contiguous buffer allocation and an O(N log N) sort.
🔬 Measurement: Run `cargo bench` or `cargo test --all-targets --all-features`.

---
*PR created automatically by Jules for task [12152265523613860643](https://jules.google.com/task/12152265523613860643) started by @madmax983*