### PR TITLE
⚒️ Forge: Fix broken imports and type inference in jar_diff.rs

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**Refactoring nested Options in closure chains**
+**Learning:** `jar_diff.rs` contained `and_then(|slot| slot.as_ref())` on a dynamically fetched `Option`, which caused type inference failures (`E0282`) and poor readability.
+**Action:** Replace nested Option chained extractions with explicit `let Some(Some(...)) = ... else { ... };` guard clauses. This resolves type inference issues organically and flattens the control flow logic.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -3,8 +3,7 @@
 
 #[cfg(feature = "nova")]
 use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    parse, AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -16,16 +15,10 @@ use std::path::Path;
 #[cfg(not(tarpaulin_include))]
 #[allow(unexpected_cfgs)]
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
-    cf.constant_pool
-        .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
-        .and_then(|entry| {
-            if let CpEntry::Utf8(s) = entry {
-                Some(s.as_str())
-            } else {
-                None
-            }
-        })
+    let Some(Some(CpEntry::Utf8(s))) = cf.constant_pool.get(idx.0 as usize) else {
+        return None;
+    };
+    Some(s.as_str())
 }
 
 #[cfg(feature = "nova")]
@@ -35,11 +28,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     if idx.0 == 0 {
         return "<none>".to_string();
     }
-    let class_entry = cf
-        .constant_pool
-        .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
-    if let Some(CpEntry::Class { name_index }) = class_entry {
+    if let Some(Some(CpEntry::Class { name_index })) = cf.constant_pool.get(idx.0 as usize) {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")
             .to_string()


### PR DESCRIPTION
🚮 Smell: `duke/src/jar_diff.rs` had a broken import referencing a non-existent `types` module in `duke_classfile`, breaking the build. It also used nested `.and_then()` chains with `Option`s that caused type inference errors (`E0282`).
✨ Solution: Fixed the import statement to pull `AttributeData`, `CpEntry`, and `CpIndex` directly from the crate root. Replaced the confusing `.and_then()` chains with idiomatic guard clauses using `let Some(Some(...)) = ... else { ... }`.
🧼 Benefit: Fixes the compilation error and dramatically flattens the logic in `cp_str` and `resolve_class_name`, organically fixing the `E0282` error while improving readability.
🛡️ Verification: `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt` passed. No logic was altered.

---
*PR created automatically by Jules for task [6328987898483414323](https://jules.google.com/task/6328987898483414323) started by @madmax983*