### PR TITLE
🛡️ Sentry: [test coverage improvement] Fix panic point in reachability pathfinding

### DIFF
--- a/crates/duke-bytecode/src/reachability.rs
+++ b/crates/duke-bytecode/src/reachability.rs
@@ -208,7 +208,7 @@ pub fn find_shortest_path(
         let mut curr = target_pc;
         while curr != start_pc {
             path.push(curr);
-            curr = *parents.get(&curr).unwrap();
+            curr = *parents.get(&curr)?;
         }
         path.push(start_pc);
         path.reverse();
@@ -280,5 +280,14 @@ mod tests {
 
         // Unreachable
         assert!(find_shortest_path(&blocks, 0, 6).is_none());
+    }
+
+    #[test]
+    fn test_find_shortest_path_base_case() {
+        let instructions = vec![(0, Instruction::Ireturn)];
+        let blocks = build_basic_blocks(&instructions);
+
+        let path = find_shortest_path(&blocks, 0, 0).unwrap();
+        assert_eq!(path, vec![0]);
     }
 }

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
🎯 **Target:** `find_shortest_path` function in `crates/duke-bytecode/src/reachability.rs`
💣 **Risk:** The function contained a naked `unwrap()` during BFS path reconstruction (`curr = *parents.get(&curr).unwrap();`). If the BFS invariant is somehow corrupted (e.g. by external modification or logic bug), this would trigger a panic and crash the VM or analyzer.
🧪 **Strategy:** Replaced `unwrap()` with the `?` operator to safely return `None` (unreachable) if the parent node isn't found. Additionally, added a unit test (`test_find_shortest_path_base_case`) to ensure `start_pc == target_pc` is handled correctly without returning an empty array or panicking.
🔬 **Verification:** `cargo test -p duke-bytecode` and `cargo clippy --all-targets --all-features -- -D warnings`

---
*PR created automatically by Jules for task [5460384112488218010](https://jules.google.com/task/5460384112488218010) started by @madmax983*