### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,7 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+
+## 2024-05-24 - [Reachability Documentation]
+**Confusion:** The `get_successors` function in `reachability.rs` had documentation that simply repeated the function name ('Gets the successor...'), violating the rule against repeating the function name.
+**Clarification:** Replaced the documentation with a narrative explanation of *why* resolving successor PCs is critical (CFG construction, dead-code elimination, cyclomatic complexity).

--- a/crates/duke-bytecode/src/reachability.rs
+++ b/crates/duke-bytecode/src/reachability.rs
@@ -10,11 +10,15 @@ use crate::basic_block::BasicBlock;
 #[cfg(feature = "nova")]
 use std::collections::{HashMap, HashSet, VecDeque};
 
-/// Gets the successor program counters (PCs) for a given [`BasicBlock`] based on its last instruction.
+/// Resolves the valid execution pathways exiting a [`BasicBlock`].
 ///
-/// This function examines the final instruction of the block (e.g., a branch, a return, or a regular instruction)
-/// to determine which instructions could potentially be executed next. This is fundamental for constructing
-/// a complete control flow graph.
+/// By examining the final bytecode instruction of a block (such as an `ifeq` branch, an unconditional `goto`,
+/// or a standard operation that simply falls through to the next sequential instruction), this analysis
+/// uncovers all program counters (PCs) that control flow could legitimately transition to next.
+///
+/// This resolution is the critical edge-discovery phase required for constructing an accurate
+/// Control Flow Graph (CFG) of a method, enabling advanced analysis like dead-code elimination
+/// and cyclomatic complexity measurement.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
📖 Chapter: The `BasicBlock` Reachability module.
🔦 Insight: Explained *why* `get_successors` is necessary (CFG construction, dead-code elimination) rather than just repeating its name.
🧪 Example: No code examples were changed; the documentation text was fundamentally rewritten for narrative flow.
🖼️ Preview: (Ran `cargo doc --open` locally to verify).

---
*PR created automatically by Jules for task [8725704271801057259](https://jules.google.com/task/8725704271801057259) started by @madmax983*