### PR TITLE
🛡️ Sentry: [test coverage improvement] Type Inference & Missing File Tests

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -47,3 +47,12 @@
 ## 2024-05-24 - Testing ReentrantReadWriteLock Native Operations
 **Learning:** Found several native functions implementing `ReentrantReadWriteLock` and `PriorityQueue` operations missing test coverage in `duke-interpreter`. Adding dummy tests correctly executes these logic branches without needing fully mocked multi-threading scenarios.
 **Action:** Add inline unit tests using a mocked heap and manually setting up the `obj_ref` payload.
+## 2025-02-05 - Missing type annotations in options inside of closures
+
+**Learning:** `and_then` closures on nested options/result types can lead to inference failures requiring type annotations in generic boundaries.
+**Action:** When adding or modifying options and combinations via `.and_then()` explicitly annotate types like `|slot: &Option<CpEntry>|` to ensure reliable build boundaries.
+
+## 2025-02-05 - Mock testing `dump_simulate`
+
+**Learning:** Testing logic dependent on disk and reading raw parsing byte structures can be challenging. Simulating behavior with valid known structure artifacts is best approach.
+**Action:** Used `catch_unwind` alongside an expected `assert!(result.is_err())` for missing files and a valid execution for the valid paths to test `panic` states.

--- a/duke/src/dead_code.rs
+++ b/duke/src/dead_code.rs
@@ -12,7 +12,7 @@ use std::process;
 fn cp_str(cf: &ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -31,7 +31,7 @@ fn resolve_class_name(cf: &ClassFile, idx: CpIndex) -> &str {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index).unwrap_or("<invalid utf8>")
     } else {

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")
@@ -179,6 +176,21 @@ fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
 #[cfg(feature = "nova")]
 mod tests {
     use super::*;
+
+    #[test]
+    #[cfg(feature = "nova")]
+    fn test_load_jar_methods_valid() {
+        // Just verify it works without panicking on a real jar
+        let methods = load_jar_methods("../tests/fixtures/multi.jar");
+        assert!(!methods.is_empty());
+    }
+
+    #[test]
+    #[cfg(feature = "nova")]
+    fn test_dump_jar_diff_valid() {
+        // Just verify it works without panicking
+        dump_jar_diff("../tests/fixtures/hello.jar", "../tests/fixtures/multi.jar");
+    }
 
     #[test]
     fn test_dump_jar_diff_dummy() {

--- a/duke/src/simulate.rs
+++ b/duke/src/simulate.rs
@@ -8,7 +8,7 @@ use duke_classfile::{AttributeData, ClassFile, CpEntry, CpIndex};
 fn cp_str(cf: &ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -54,6 +54,23 @@ mod tests {
     use duke_classfile::{
         ClassAccessFlags, {ClassFile, CpEntry, CpIndex},
     };
+
+    #[test]
+    #[cfg(feature = "nova")]
+    fn test_dump_simulate_not_found() {
+        use std::panic;
+        let result = panic::catch_unwind(|| {
+            dump_simulate("non_existent_file.class", "main");
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "nova")]
+    fn test_dump_simulate_valid() {
+        dump_simulate("../tests/fixtures/Hello.class", "main");
+        dump_simulate("../tests/fixtures/Hello.class", "missingMethod");
+    }
 
     #[test]
     fn test_cp_str() {


### PR DESCRIPTION
🎯 Target: `duke/src/jar_diff.rs`, `duke/src/dead_code.rs`, and `duke/src/simulate.rs`
💣 Risk: Type inference errors when compiling with `--all-features` and missing test coverage for file execution/panic handling logic.
🧪 Strategy: 
- Explicitly annotate `.and_then(|slot: &Option<CpEntry>| ...)` closures.
- Fixed root crate re-export path errors for `CpEntry` and `CpIndex`.
- Use `catch_unwind` to mock the behavior of `dump_simulate` when attempting to load missing files and verifying the explicit expectations/panic.
🔬 Verification: `cargo test --all-targets --all-features` and `cargo llvm-cov`.

---
*PR created automatically by Jules for task [3584984405159965805](https://jules.google.com/task/3584984405159965805) started by @madmax983*