### PR TITLE
🗺️ Atlas: [architectural change] Fix imports and type inference in jar_diff

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -7,3 +7,6 @@
 **[Encapsulate `duke_classfile` Facade]**
 **Tangle:** The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types, and `duke-telemetry` exposed internal serialization helpers via `pub mod ser_helpers`. This creates confusing, leaky abstractions and redundant paths.
 **Blueprint:** Encapsulated both modules. In `duke_classfile`, replaced `pub mod types` with direct `pub use` statements at the crate root, eliminating the `types` namespace from the public API entirely. In `duke_telemetry`, reduced `ser_helpers` visibility to `pub(crate)`.
+**[Fix type inference failure in `duke/src/jar_diff.rs`]**
+**Tangle:** The type inference failure `E0282` in `duke/src/jar_diff.rs` was caused by chained `.and_then()` closures on nested `Option`s returned by `cf.constant_pool.get(...)`.
+**Blueprint:** Replaced the chained `.and_then()` closures with explicit `let Some(Some(...)) = ... else { ... };` guard clauses. This provides explicit type constraints and flattens control flow, resolving the `E0282` compilation error.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -16,16 +13,18 @@ use std::path::Path;
 #[cfg(not(tarpaulin_include))]
 #[allow(unexpected_cfgs)]
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
-    cf.constant_pool
+    let Some(Some(entry)) = cf
+        .constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
-        .and_then(|entry| {
-            if let CpEntry::Utf8(s) = entry {
-                Some(s.as_str())
-            } else {
-                None
-            }
-        })
+        .map(|slot| slot.as_ref())
+    else {
+        return None;
+    };
+    if let CpEntry::Utf8(s) = entry {
+        Some(s.as_str())
+    } else {
+        None
+    }
 }
 
 #[cfg(feature = "nova")]
@@ -35,10 +34,12 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     if idx.0 == 0 {
         return "<none>".to_string();
     }
-    let class_entry = cf
-        .constant_pool
-        .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+    let class_entry =
+        if let Some(Some(s)) = cf.constant_pool.get(idx.0 as usize).map(|s| s.as_ref()) {
+            Some(s)
+        } else {
+            None
+        };
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
🕸️ Tangle: The codebase had a build breakage due to unresolved imports (`types::` prefix for encapsulated `duke_classfile` types) and a type inference failure (`E0282`) caused by chained `.and_then()` closures on nested `Option`s in `duke/src/jar_diff.rs`.
📐 Blueprint: Removed the obsolete `types::` prefix from the imports, correctly utilizing the new root re-exports. Replaced the chained `.and_then()` closures with explicit `let Some(Some(...)) = ... else { ... };` guard clauses. This flattened the control flow and provided clear type constraints.
🧱 Stability: Restored successful compilation, improved code readability, and enforced proper module boundaries.
🔬 Verification: Build passes successfully (`cargo check`, `cargo test`, `cargo clippy -- -D warnings`), and the architectural fix was documented in `.jules/atlas.md`.

---
*PR created automatically by Jules for task [17318153614344723233](https://jules.google.com/task/17318153614344723233) started by @madmax983*