### PR TITLE
🛡️ Sentry: add test coverage for jimage read_str invalid utf8

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -47,3 +47,7 @@
 ## 2024-05-24 - Testing ReentrantReadWriteLock Native Operations
 **Learning:** Found several native functions implementing `ReentrantReadWriteLock` and `PriorityQueue` operations missing test coverage in `duke-interpreter`. Adding dummy tests correctly executes these logic branches without needing fully mocked multi-threading scenarios.
 **Action:** Add inline unit tests using a mocked heap and manually setting up the `obj_ref` payload.
+
+## 2024-06-18 - Missing tests for invalid UTF-8 in JImage strings
+**Learning:** `std::str::from_utf8` returns `Result::Err` when bytes are not valid UTF-8, which the `jimage::read_str` function correctly handles via `.unwrap_or("")`. This behavior lacked unit test coverage.
+**Action:** Added a unit test to verify that `read_str` gracefully returns an empty string when encountering an invalid UTF-8 byte sequence in a JImage string table.

--- a/crates/duke-loader/src/jimage.rs
+++ b/crates/duke-loader/src/jimage.rs
@@ -983,3 +983,14 @@ mod tests_oob {
         }
     }
 }
+
+#[cfg(test)]
+mod read_str_tests {
+    use super::*;
+
+    #[test]
+    fn test_read_str_invalid_utf8() {
+        let data: &[u8] = b"\xff\xff\x00";
+        assert_eq!(read_str(data, 0, 0), "");
+    }
+}

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
* 🎯 Target: `duke_loader::jimage::read_str` function.
* 💣 Risk: Prevents an untested execution path when `std::str::from_utf8` returns `Err` due to malformed or malicious JImage file strings.
* 🧪 Strategy: Added a targeted inline test `test_read_str_invalid_utf8` that invokes the private reading logic directly on invalid UTF-8 bytes (`b"\xff\xff\x00"`), verifying it securely falls back to `unwrap_or("")`.
* 🔬 Verification: Run `cargo test --manifest-path crates/duke-loader/Cargo.toml`

---
*PR created automatically by Jules for task [17292539953788035437](https://jules.google.com/task/17292539953788035437) started by @madmax983*