### PR TITLE
⚒️ Forge: Extract stack opcode decoding helper

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**Extract Decoder Helpers**
+**Learning:** `decode_one` in `crates/duke-bytecode/src/decoder.rs` had an inline match block for stack operations (`POP..=SWAP`), which broke the symmetry with the rest of the file that delegated to helper functions like `decode_constant_op` and `decode_load_store_op`.
+**Action:** Extract inline match blocks for specific opcode groups into dedicated helper functions (e.g., `decode_stack_op`) to maintain consistent levels of abstraction and improve readability in the main dispatch function.

--- a/crates/duke-bytecode/src/decoder.rs
+++ b/crates/duke-bytecode/src/decoder.rs
@@ -145,6 +145,20 @@ fn decode_constant_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
         _ => unreachable!(),
     })
 }
+fn decode_stack_op(opcode: u8) -> Instruction {
+    match opcode {
+        op::POP => Instruction::Pop,
+        op::POP2 => Instruction::Pop2,
+        op::DUP => Instruction::Dup,
+        op::DUP_X1 => Instruction::DupX1,
+        op::DUP_X2 => Instruction::DupX2,
+        op::DUP2 => Instruction::Dup2,
+        op::DUP2_X1 => Instruction::Dup2X1,
+        op::DUP2_X2 => Instruction::Dup2X2,
+        op::SWAP => Instruction::Swap,
+        _ => unreachable!(),
+    }
+}
 fn decode_load_store_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
     Ok(match opcode {
         // -- Loads -----------------------------------------------------------
@@ -399,18 +413,7 @@ fn decode_one(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> Result<Instruction> 
     match opcode {
         op::NOP..=op::LDC2_W => decode_constant_op(c, opcode),
         op::ILOAD..=op::SASTORE => decode_load_store_op(c, opcode),
-        op::POP..=op::SWAP => Ok(match opcode {
-            op::POP => Instruction::Pop,
-            op::POP2 => Instruction::Pop2,
-            op::DUP => Instruction::Dup,
-            op::DUP_X1 => Instruction::DupX1,
-            op::DUP_X2 => Instruction::DupX2,
-            op::DUP2 => Instruction::Dup2,
-            op::DUP2_X1 => Instruction::Dup2X1,
-            op::DUP2_X2 => Instruction::Dup2X2,
-            op::SWAP => Instruction::Swap,
-            _ => unreachable!(),
-        }),
+        op::POP..=op::SWAP => Ok(decode_stack_op(opcode)),
         op::IADD..=op::IINC => decode_math_op(c, opcode),
         op::I2L..=op::I2S => decode_conversion_op(opcode),
         op::LCMP..=op::RETURN => decode_control_flow_op(c, opcode, pc),


### PR DESCRIPTION
**🚮 Smell:** The `decode_one` function in `crates/duke-bytecode/src/decoder.rs` contained an inline match block for stack operations (`POP..=SWAP`). This created deep nesting and broke the symmetrical structure of the function, which otherwise elegantly delegates to grouped helper functions like `decode_constant_op`, `decode_math_op`, etc.

**✨ Solution:** Extracted the stack-related opcodes into a dedicated `decode_stack_op` helper function that takes an opcode and returns an `Instruction`. Updated `decode_one` to delegate to this helper and wrap the result in `Ok()`.

**🧼 Benefit:** Restores structural consistency, reduces the cognitive load of reading the main dispatch function, flattens the pyramid of doom, and strictly bounds stack opcode matching logic to one place.

**🛡️ Verification:** Ran `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test --all-targets --all-features`. Verified no runtime behavior or tests were broken. Updated Forge journal.

---
*PR created automatically by Jules for task [7224730322443348029](https://jules.google.com/task/7224730322443348029) started by @madmax983*