### PR TITLE
🛡️ Sentry: [test coverage improvement] added simulate error cases

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -47,3 +47,6 @@
 ## 2024-05-24 - Testing ReentrantReadWriteLock Native Operations
 **Learning:** Found several native functions implementing `ReentrantReadWriteLock` and `PriorityQueue` operations missing test coverage in `duke-interpreter`. Adding dummy tests correctly executes these logic branches without needing fully mocked multi-threading scenarios.
 **Action:** Add inline unit tests using a mocked heap and manually setting up the `obj_ref` payload.
+## 2024-05-24 - Testing Simulate Module Error Cases
+**Learning:** Found untested panic edges in `duke/src/simulate.rs` where the parser invokes `unwrap()` or `expect()`, which needed test coverage for situations like missing files and corrupt classfiles.
+**Action:** Wrote explicit tests wrapping executions in `std::panic::catch_unwind` and asserting `result.is_err()` to capture unhandled panics from file read or parser failures securely.

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,6 @@
+🛡️ Sentry: [test coverage improvement] added simulate error cases
+
+Targets: duke/src/simulate.rs
+Risk: Prevents unhandled parsing and IO errors from bubbling up un-tested.
+Strategy: Added invalid dummy class file to test error propagation through std::panic::catch_unwind using tempfile to avoid global state conflicts.
+Verification: cargo test --all-features

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/duke/src/simulate.rs
+++ b/duke/src/simulate.rs
@@ -8,7 +8,7 @@ use duke_classfile::{AttributeData, ClassFile, CpEntry, CpIndex};
 fn cp_str(cf: &ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -51,9 +51,67 @@ pub fn dump_simulate(path: &str, method_name: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use duke_classfile::{
-        ClassAccessFlags, {ClassFile, CpEntry, CpIndex},
-    };
+    use duke_classfile::{ClassAccessFlags, ClassFile, CpEntry, CpIndex};
+
+    #[test]
+    fn test_dump_simulate_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dummy_not_found_parse_error.class");
+        // Create a truncated dummy file to force a parse failure at `expect("Failed to parse class file")`
+        std::fs::write(&path, b"\xca\xfe\xba\xbe\x00\x00\x00\x34\x00\x00\x00").unwrap();
+
+        let path_str = path.to_str().unwrap();
+        let result = std::panic::catch_unwind(|| {
+            dump_simulate(path_str, "missing_method");
+        });
+
+        assert!(result.is_err(), "Expected parsing to fail and panic");
+    }
+
+    #[test]
+    fn test_dump_simulate_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does_not_exist_xyz123.class");
+
+        let path_str = path.to_str().unwrap();
+        let result = std::panic::catch_unwind(|| {
+            dump_simulate(path_str, "missing_method");
+        });
+        assert!(result.is_err(), "Expected file read to fail and panic");
+    }
+
+    #[test]
+    fn test_dump_simulate_method_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dummy_valid_class2.class");
+        let valid_class_bytes: [u8; 24] = [
+            0xca, 0xfe, 0xba, 0xbe, // magic
+            0x00, 0x00, // minor
+            0x00, 0x34, // major (52)
+            0x00, 0x01, // constant pool count (1, so 0 entries)
+            0x00, 0x21, // access flags (SUPER | PUBLIC)
+            0x00, 0x00, // this class (invalid index, but parser might not care)
+            0x00, 0x00, // super class
+            0x00, 0x00, // interfaces count
+            0x00, 0x00, // fields count
+            0x00, 0x00, // methods count
+            0x00, 0x00, // attributes count
+        ];
+
+        std::fs::write(&path, valid_class_bytes).unwrap();
+
+        let path_str = path.to_str().unwrap();
+        let result = std::panic::catch_unwind(|| {
+            dump_simulate(path_str, "missing_method");
+        });
+
+        // The parser correctly parses this minimal dummy file and returns Ok.
+        // It should then print `duke: method 'missing_method' not found` without panicking.
+        assert!(
+            result.is_ok(),
+            "Expected valid empty class to parse successfully and simulate to exit cleanly"
+        );
+    }
 
     #[test]
     fn test_cp_str() {


### PR DESCRIPTION
Targets: duke/src/simulate.rs
Risk: Prevents unhandled parsing and IO errors from bubbling up un-tested.
Strategy: Added invalid dummy class file to test error propagation through std::panic::catch_unwind using tempfile to avoid global state conflicts.
Verification: cargo test --all-features

---
*PR created automatically by Jules for task [8719694697984611526](https://jules.google.com/task/8719694697984611526) started by @madmax983*