### PR TITLE
⚒️ Forge: Extract class parsing phases and terminal instruction matcher

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,11 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**Extract File Headers**
+**Learning:** `parse_class_file` contained an inline extraction and validation of the Java class file header (magic, minor version, major version) before moving on to load constant pool and class members. This grouped low-level binary validation with higher-level semantic structures and led to a bloated function.
+**Action:** Extract binary header validation into a small `parse_class_header` helper function that returns the extracted basic values to keep parsing concerns cleanly separated.
+
+**Extract Control Flow Graph Terminals**
+**Learning:** The control flow logic in `crates/duke-bytecode/src/basic_block.rs` contained an inline, 4-clause boolean chain (`instr.is_conditional_branch() || instr.is_unconditional_jump() || instr.is_switch() || instr.is_return()`) to determine if an instruction terminates a basic block. This duplicated logic and hurt readability.
+**Action:** Consolidate multiple related boolean properties of an `enum` into a single semantic helper method (like `is_terminal()`) directly on the type to DRY up calling sites and improve code clarity.

--- a/crates/duke-bytecode/src/basic_block.rs
+++ b/crates/duke-bytecode/src/basic_block.rs
@@ -81,10 +81,7 @@ fn find_leaders(instructions: &[(usize, Instruction)]) -> BTreeSet<usize> {
     leaders.insert(instructions[0].0);
 
     for (i, (pc, instr)) in instructions.iter().enumerate() {
-        let is_branch_or_return = instr.is_conditional_branch()
-            || instr.is_unconditional_jump()
-            || instr.is_switch()
-            || instr.is_return();
+        let is_branch_or_return = instr.is_terminal();
 
         // Target of any jump or branch is a leader
         for target in instr.control_flow_targets(*pc, None) {

--- a/crates/duke-bytecode/src/instruction.rs
+++ b/crates/duke-bytecode/src/instruction.rs
@@ -780,6 +780,15 @@ impl Instruction {
         matches!(self, Self::Tableswitch { .. } | Self::Lookupswitch { .. })
     }
 
+    /// Returns `true` if this instruction terminates a basic block (e.g. branch, jump, switch, or return).
+    #[must_use]
+    pub const fn is_terminal(&self) -> bool {
+        self.is_conditional_branch()
+            || self.is_unconditional_jump()
+            || self.is_switch()
+            || self.is_return()
+    }
+
     /// Returns `true` if the instruction halts execution in the current frame.
     #[must_use]
     pub const fn is_return(&self) -> bool {

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -220,7 +220,7 @@ fn parse_class_members(
     })
 }
 
-fn parse_class_file(c: &mut Cursor<'_>) -> Result<ClassFile> {
+fn parse_class_header(c: &mut Cursor<'_>) -> Result<(u16, u16)> {
     // §4.1 — magic
     let magic = c.read_u32()?;
     if magic != MAGIC {
@@ -236,6 +236,11 @@ fn parse_class_file(c: &mut Cursor<'_>) -> Result<ClassFile> {
         });
     }
 
+    Ok((minor_version, major_version))
+}
+
+fn parse_class_file(c: &mut Cursor<'_>) -> Result<ClassFile> {
+    let (minor_version, major_version) = parse_class_header(c)?;
     let constant_pool = parse_constant_pool(c)?;
     parse_class_members(c, minor_version, major_version, constant_pool)
 }

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    AttributeData, CpEntry, CpIndex,
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/plan.md
+++ b/plan.md
@@ -1,20 +1,6 @@
-1. **Optimize String concatenation in `native_string_concat`**
-   - The function currently uses `format!("{s1}{s2}")` to concatenate two strings, which allocates a new string buffer inside `format!`, formats the arguments, and returns it.
-   - We can optimize this by pre-allocating a `String` with the exact required capacity and appending the strings:
-     ```rust
-     let mut combined = String::with_capacity(s1.len() + s2.len());
-     combined.push_str(&s1);
-     combined.push_str(&s2);
-     let r = heap.allocate_string(combined);
-     ```
-   - This eliminates the intermediate allocation and parsing overhead of `format!`, which is a common hotspot in interpreters.
-   - Add `// ⚡ Bolt: Eliminate intermediate format! allocation` comment.
-   - Ensure the tests pass.
-1. Refactor `print_report` methods in `duke-telemetry/src/lib.rs` to handle empty states gracefully (Reduces noise from empty reports).
-   - Before: Outputs headers and empty tables for empty components.
-   - After: Outputs a concise message stating no events were recorded.
-2. Complete pre commit steps to make sure proper testing, verifications, reviews and reflections are done.
-3. Submit the change using a descriptive title.
-1. **Optimize Vector Allocations in Execution (Vec::with_capacity)**: Pre-allocate vectors in `crates/duke-interpreter/src/execution.rs` for `Multianewarray` `dims` array and lambda args `impl_args` to avoid unnecessary dynamic heap reallocations.
-2. Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.
-3. **Submit the PR**: Present PR titled '⚡ Bolt: Optimize Vector Allocations in Execution & Native' detailing 💡 What, 🎯 Why, 📊 Impact, and 🔭 Measurement. I will use `run_in_bash_session` to execute `git commit` with the requested PR details.
+1.  **Fix compilation issue**: The PR contains some fixes for `duke/src/jar_diff.rs` where type inference wasn't working and an unused attribute was imported.
+2.  **Refactoring - Extract Helper Function**: The `parse_class_file` function in `crates/duke-classfile/src/parser.rs` violates the single responsibility principle and contains too many distinct parsing operations inside the same function scope. I will extract the file header parsing into a separate `parse_class_header` helper function. This directly aligns with Forge's philosophy of avoiding "God Functions" and flattening code.
+3.  **Refactoring - Consolidate Instruction matching**: The `is_terminal` method does not exist on `Instruction`, and basic block discovery relies on an inline chain of `instr.is_conditional_branch() || instr.is_unconditional_jump() || instr.is_switch() || instr.is_return()`. I'll introduce `is_terminal` to `Instruction` and replace the inline code in `basic_block.rs`. This will improve readability without changing behavior.
+4.  **Verification**: After implementing the refactoring, I will use `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-features` to ensure zero behavior changes and to polish the structure.
+5.  **Pre-commit steps**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+6.  **Submit**: Call the submit tool to create a PR titled '⚒️ Forge: Extract class parsing phases and terminal instruction matcher' detailing 🚮 Smell, ✨ Solution, 🧼 Benefit, and 🛡️ Verification.


### PR DESCRIPTION
🚮 **Smell**: `parse_class_file` in `duke-classfile` violated the Single Responsibility Principle by inline parsing the class file header alongside the constant pool and class members. Additionally, `basic_block.rs` contained an unwieldy inline boolean chain `instr.is_conditional_branch() || instr.is_unconditional_jump() || instr.is_switch() || instr.is_return()` to determine block boundaries.

✨ **Solution**: Extracted the class file header validation into a new `parse_class_header` helper function. Created a new `is_terminal()` method on the `Instruction` enum to encapsulate the basic block termination logic. Fixed type inference compilation errors in `jar_diff.rs`.

🧼 **Benefit**: Flattens nested logic, improves separation of concerns during binary parsing, and dramatically cleans up control flow graph code by providing a semantic `is_terminal()` method instead of manual inline property checking.

🛡️ **Verification**: Validated zero behavior change and correct syntax. All `cargo test` tests passed, and `cargo clippy --all-targets --all-features -- -D warnings` ran without issues. No logic was altered, only structure improved.

---
*PR created automatically by Jules for task [6480331129318159669](https://jules.google.com/task/6480331129318159669) started by @madmax983*