### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")
@@ -56,7 +56,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     clippy::use_debug,
     clippy::collapsible_if
 )]
-pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
+pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
     let map1 = load_jar_methods(jar1_path);
     let map2 = load_jar_methods(jar2_path);
 
@@ -88,55 +88,56 @@ pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
     removed.sort();
     modified.sort();
 
-    println!("======================================");
-    println!(" JAR Bytecode Diff Analysis");
-    println!("======================================");
-    println!("File 1:               {jar1_path}");
-    println!("File 2:               {jar2_path}");
-    println!("Methods Added:        {}", added.len());
-    println!("Methods Removed:      {}", removed.len());
-    println!("Methods Modified:     {}", modified.len());
-    println!("Methods Unchanged:    {unchanged}");
-    println!();
+    writeln!(writer, "======================================")?;
+    writeln!(writer, " JAR Bytecode Diff Analysis")?;
+    writeln!(writer, "======================================")?;
+    writeln!(writer, "File 1:               {jar1_path}")?;
+    writeln!(writer, "File 2:               {jar2_path}")?;
+    writeln!(writer, "Methods Added:        {}", added.len())?;
+    writeln!(writer, "Methods Removed:      {}", removed.len())?;
+    writeln!(writer, "Methods Modified:     {}", modified.len())?;
+    writeln!(writer, "Methods Unchanged:    {unchanged}")?;
+    writeln!(writer)?;
 
     if !added.is_empty() {
-        println!("--- Top 10 Added Methods ---");
+        writeln!(writer, "--- Top 10 Added Methods ---")?;
         for m in added.iter().take(10) {
-            println!("  + {m}");
+            writeln!(writer, "  + {m}")?;
         }
         if added.len() > 10 {
-            println!("  ... and {} more", added.len() - 10);
+            writeln!(writer, "  ... and {} more", added.len() - 10)?;
         }
-        println!();
+        writeln!(writer)?;
     }
 
     if !removed.is_empty() {
-        println!("--- Top 10 Removed Methods ---");
+        writeln!(writer, "--- Top 10 Removed Methods ---")?;
         for m in removed.iter().take(10) {
-            println!("  - {m}");
+            writeln!(writer, "  - {m}")?;
         }
         if removed.len() > 10 {
-            println!("  ... and {} more", removed.len() - 10);
+            writeln!(writer, "  ... and {} more", removed.len() - 10)?;
         }
-        println!();
+        writeln!(writer)?;
     }
 
     if !modified.is_empty() {
-        println!("--- Top 10 Modified Methods ---");
+        writeln!(writer, "--- Top 10 Modified Methods ---")?;
         for m in modified.iter().take(10) {
-            println!("  ~ {m}");
+            writeln!(writer, "  ~ {m}")?;
         }
         if modified.len() > 10 {
-            println!("  ... and {} more", modified.len() - 10);
+            writeln!(writer, "  ... and {} more", modified.len() - 10)?;
         }
-        println!();
+        writeln!(writer)?;
     }
+    Ok(())
 }
 
 #[cfg(feature = "nova")]
 #[cfg(not(tarpaulin_include))]
 #[allow(unexpected_cfgs)]
-fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
+pub fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
     let Ok(loader) = ZipLoader::open(Path::new(jar_path)) else {
         return HashMap::new(); // If we cannot load, treat as empty
     };
@@ -182,12 +183,69 @@ mod tests {
 
     #[test]
     fn test_dump_jar_diff_dummy() {
-        // Since we don't have the zip crate in dependencies, we'll test the difference logic
-        // with two non-existent paths, which should gracefully return empty HashMaps and diff them.
-
         let path1 = "dummy1.jar";
         let path2 = "dummy2.jar";
 
-        dump_jar_diff(path1, path2);
+        let mut buf = Vec::new();
+        dump_jar_diff(path1, path2, &mut buf).unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("File 1:               dummy1.jar"));
+        assert!(output.contains("Methods Added:        0"));
+    }
+
+    #[test]
+    fn test_load_jar_methods_invalid_path() {
+        let result = load_jar_methods("invalid_path_does_not_exist.jar");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_cp_str_invalid() {
+        // Provide enough context to reach branch statements on resolving class name and invalid cp elements
+        use duke_classfile::{ClassFile, CpIndex, CpEntry};
+        let cf = ClassFile {
+            minor_version: 0,
+            major_version: 0,
+            constant_pool: vec![
+                None, // 0
+                Some(CpEntry::Utf8("test".to_string())), // 1
+                Some(CpEntry::Integer(42)), // 2
+                Some(CpEntry::Class { name_index: CpIndex(1) }), // 3
+                Some(CpEntry::Class { name_index: CpIndex(2) }), // 4
+            ],
+            access_flags: duke_classfile::ClassAccessFlags::empty(),
+            this_class: CpIndex(0),
+            super_class: CpIndex(0),
+            interfaces: vec![],
+            fields: vec![],
+            methods: vec![],
+            attributes: vec![],
+        };
+        assert_eq!(cp_str(&cf, CpIndex(1)), Some("test"));
+        assert_eq!(cp_str(&cf, CpIndex(2)), None);
+        assert_eq!(cp_str(&cf, CpIndex(99)), None);
+
+        assert_eq!(resolve_class_name(&cf, CpIndex(0)), "<none>");
+        assert_eq!(resolve_class_name(&cf, CpIndex(2)), "<not a class ref>");
+        assert_eq!(resolve_class_name(&cf, CpIndex(3)), "test");
+        assert_eq!(resolve_class_name(&cf, CpIndex(4)), "<invalid utf8>");
+    }
+
+    struct FailingWriter;
+    impl std::io::Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("mock error"))
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_dump_jar_diff_io_error() {
+        let mut writer = FailingWriter;
+        let res = dump_jar_diff("a", "b", &mut writer);
+        assert!(res.is_err());
     }
 }

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -366,7 +366,7 @@ fn main() {
             std::process::exit(1);
         }
         #[cfg(feature = "nova")]
-        jar_diff::dump_jar_diff(&args[2], &args[3]);
+        { let mut stdout = std::io::stdout(); jar_diff::dump_jar_diff(&args[2], &args[3], &mut stdout).unwrap(); }
         #[cfg(not(feature = "nova"))]
         eprintln!("duke: 'jar-diff' command requires the 'nova' feature flag.");
         return;


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]

🎯 Target: duke::jar_diff
💣 Risk: Formatting logic in dump_jar_diff was untested and tightly coupled to stdout, preventing coverage checks for its output logic bounds. Unresolved imports and closure type inference in jar_diff.rs were breaking bin compilation entirely.
🧪 Strategy: Fixed type annotations, corrected module visibility imports, and refactored dump_jar_diff to accept a Write trait object so it can be targeted by string snapshot bounds checks. Added unit tests for empty maps, I/O errors and resolved CpEntry bounds parsing logic.
🔬 Verification: cargo test --all-targets --all-features

---
*PR created automatically by Jules for task [6828503475760660708](https://jules.google.com/task/6828503475760660708) started by @madmax983*