### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,7 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+
+## 2024-05-25 - [Jar Diff Compilation Fix]
+**Confusion:** The `duke` binary crate failed to compile because `AttributeData` was moved directly to the crate root of `duke-classfile` instead of being nested under `types`, and type inference failed for `slot` and `s` in `and_then` closures.
+**Clarification:** Updated `jar_diff.rs` imports to correctly reference `duke_classfile::{AttributeData, CpEntry, CpIndex}` directly, and explicitly typed the closure arguments `|slot: &Option<CpEntry>|` and `|s: &Option<CpEntry>|` to resolve the type inference errors.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
📖 Chapter: Jar Diff Fixes
🔦 Insight: The `AttributeData` enum was moved to the crate root instead of `types::AttributeData`, breaking compilation. Also, closures required explicit type inferences for `&Option<CpEntry>`.
🧪 Example: Resolved compilation error and added learnings to `.jules/bard.md`.
🖼️ Preview: Compilation passes.

---
*PR created automatically by Jules for task [10269737072941088060](https://jules.google.com/task/10269737072941088060) started by @madmax983*