### PR TITLE
⚒️ Forge: Extract dump_jar_diff print statements

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,6 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+**[Extracted Print Logic in jar_diff.rs]
+**Learning:** The `dump_jar_diff` function contained a massive 30+ line pyramid of print statements repeated for added, removed, and modified methods. This violates DRY and creates a God Function.
+**Action:** Extract repetitive looping logic into helper functions (like `print_method_list`) to flatten nesting and separate formatting concerns from business logic.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")
@@ -88,49 +85,57 @@ pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
     removed.sort();
     modified.sort();
 
+    print_diff_summary(
+        jar1_path,
+        jar2_path,
+        added.len(),
+        removed.len(),
+        modified.len(),
+        unchanged,
+    );
+    print_method_list("Added", "+", &added);
+    print_method_list("Removed", "-", &removed);
+    print_method_list("Modified", "~", &modified);
+}
+
+#[cfg(feature = "nova")]
+#[cfg(not(tarpaulin_include))]
+#[allow(unexpected_cfgs, clippy::print_stdout)]
+fn print_diff_summary(
+    jar1_path: &str,
+    jar2_path: &str,
+    added_len: usize,
+    removed_len: usize,
+    modified_len: usize,
+    unchanged: usize,
+) {
     println!("======================================");
     println!(" JAR Bytecode Diff Analysis");
     println!("======================================");
     println!("File 1:               {jar1_path}");
     println!("File 2:               {jar2_path}");
-    println!("Methods Added:        {}", added.len());
-    println!("Methods Removed:      {}", removed.len());
-    println!("Methods Modified:     {}", modified.len());
+    println!("Methods Added:        {added_len}");
+    println!("Methods Removed:      {removed_len}");
+    println!("Methods Modified:     {modified_len}");
     println!("Methods Unchanged:    {unchanged}");
     println!();
+}
 
-    if !added.is_empty() {
-        println!("--- Top 10 Added Methods ---");
-        for m in added.iter().take(10) {
-            println!("  + {m}");
-        }
-        if added.len() > 10 {
-            println!("  ... and {} more", added.len() - 10);
-        }
-        println!();
+#[cfg(feature = "nova")]
+#[cfg(not(tarpaulin_include))]
+#[allow(unexpected_cfgs, clippy::print_stdout)]
+fn print_method_list(title: &str, prefix: &str, methods: &[String]) {
+    if methods.is_empty() {
+        return;
     }
-
-    if !removed.is_empty() {
-        println!("--- Top 10 Removed Methods ---");
-        for m in removed.iter().take(10) {
-            println!("  - {m}");
-        }
-        if removed.len() > 10 {
-            println!("  ... and {} more", removed.len() - 10);
-        }
-        println!();
+    println!("--- Top 10 {title} Methods ---");
+    for m in methods.iter().take(10) {
+        println!("  {prefix} {m}");
     }
-
-    if !modified.is_empty() {
-        println!("--- Top 10 Modified Methods ---");
-        for m in modified.iter().take(10) {
-            println!("  ~ {m}");
-        }
-        if modified.len() > 10 {
-            println!("  ... and {} more", modified.len() - 10);
-        }
-        println!();
+    if methods.len() > 10 {
+        println!("  ... and {} more", methods.len() - 10);
     }
+    println!();
 }
 
 #[cfg(feature = "nova")]


### PR DESCRIPTION
🚮 **Smell:** The `dump_jar_diff` function in `duke/src/jar_diff.rs` contained over 30 lines of deeply duplicated `println!` and `.iter().take(10)` formatting blocks for added, removed, and modified methods, constituting a bloated "God Function".

✨ **Solution:** Extracted the summary header into `print_diff_summary` and the repetitive top-10 method formatting logic into a robust `print_method_list` helper function.

🧼 **Benefit:** Reduces the function body length dramatically, eliminates copy-pasted layout logic, flattens the execution flow, and significantly improves readability while remaining strictly typed.

🛡️ **Verification:** Tests passed. `cargo clippy` and `cargo test` confirm zero logic changes or regressions. Diff verified via bash.

---
*PR created automatically by Jules for task [14981217978434451018](https://jules.google.com/task/14981217978434451018) started by @madmax983*