### PR TITLE
👺 Havoc: Regex Unchecked Unwraps

### DIFF
--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -16603,16 +16603,16 @@ pub(crate) fn native_string_split(
     let parts: Vec<String> = if delim.is_empty() {
         s.chars().map(|c| c.to_string()).collect()
     } else {
-        regex::Regex::new(&delim).map_or_else(
-            |_| s.split(delim.as_str()).map(str::to_string).collect(),
-            |re| {
+        match regex::Regex::new(&delim).or_else(|_| regex::Regex::new(&regex::escape(&delim))) {
+            Ok(re) => {
                 let mut v: Vec<String> = re.split(&s).map(str::to_string).collect();
                 while v.last().is_some_and(String::is_empty) {
                     v.pop();
                 }
                 v
-            },
-        )
+            }
+            Err(e) => return Err(regex_pattern_syntax_error(e.to_string())),
+        }
     };
     let arr_ref = heap.allocate("[Ljava/lang/String;".to_string(), parts.len());
     for (i, part) in parts.iter().enumerate() {
@@ -16653,7 +16653,8 @@ pub(crate) fn native_string_split_limit(
         }
     } else {
         let re = regex::Regex::new(&delim)
-            .unwrap_or_else(|_| regex::Regex::new(&regex::escape(&delim)).unwrap());
+            .or_else(|_| regex::Regex::new(&regex::escape(&delim)))
+            .map_err(|e| regex_pattern_syntax_error(e.to_string()))?;
         if limit > 0 {
             re.splitn(&s, limit as usize).map(str::to_string).collect()
         } else {

--- a/crates/duke-interpreter/tests/havoc_regex_oom.rs
+++ b/crates/duke-interpreter/tests/havoc_regex_oom.rs
@@ -1,0 +1,80 @@
+use duke_interpreter::ClassRegistry;
+
+#[test]
+fn test_havoc_regex_split_oom() {
+    let mut registry = ClassRegistry::new();
+    let mut heap = duke_gc::Heap::new();
+    duke_interpreter::bootstrap_stdlib(&mut registry, &mut heap);
+
+    let handler = registry.natives().get(
+        "java/lang/String",
+        "split",
+        "(Ljava/lang/String;)[Ljava/lang/String;",
+    );
+    if let Some(h) = handler {
+        let this_str = heap.allocate_string("hello".to_string());
+
+        let delim = "(".repeat(10_000_000);
+        let delim_str = heap.allocate_string(delim);
+
+        let args = vec![
+            duke_runtime::Slot::Reference(Some(this_str)),
+            duke_runtime::Slot::Reference(Some(delim_str)),
+        ];
+        let mut out = Vec::new();
+        let mut control = duke_interpreter::NativeControl::default();
+
+        let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            h(&args, &mut heap, &mut out, &mut control)
+        }));
+
+        let handler_result =
+            res.expect("Handler panicked! `native_string_split` unwrap must be fixed.");
+        assert!(
+            handler_result.is_err(),
+            "Expected PatternSyntaxException but got {handler_result:?}"
+        );
+    } else {
+        panic!("Missing handler");
+    }
+}
+
+#[test]
+fn test_havoc_regex_split_limit_oom() {
+    let mut registry = ClassRegistry::new();
+    let mut heap = duke_gc::Heap::new();
+    duke_interpreter::bootstrap_stdlib(&mut registry, &mut heap);
+
+    let handler = registry.natives().get(
+        "java/lang/String",
+        "split",
+        "(Ljava/lang/String;I)[Ljava/lang/String;",
+    );
+    if let Some(h) = handler {
+        let this_str = heap.allocate_string("hello".to_string());
+
+        let delim = "a".repeat(10_000_000);
+        let delim_str = heap.allocate_string(delim);
+
+        let args = vec![
+            duke_runtime::Slot::Reference(Some(this_str)),
+            duke_runtime::Slot::Reference(Some(delim_str)),
+            duke_runtime::Slot::Int(10),
+        ];
+        let mut out = Vec::new();
+        let mut control = duke_interpreter::NativeControl::default();
+
+        let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            h(&args, &mut heap, &mut out, &mut control)
+        }));
+
+        let handler_result =
+            res.expect("Handler panicked! `native_string_split_limit` unwrap must be fixed.");
+        assert!(
+            handler_result.is_err(),
+            "Expected PatternSyntaxException but got {handler_result:?}"
+        );
+    } else {
+        panic!("Missing handler");
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** Java's `String.split()` calls into the native Rust interpreter `native_string_split` and `native_string_split_limit`. When users pass an enormous delimiter (e.g., 10 million characters), the `regex` crate compilation size limit triggers an error.
📉 **The Stack Trace:**
```
thread 'test_havoc_regex_split_limit_oom' panicked at crates/duke-interpreter/src/native.rs:16656:75:
called `Result::unwrap()` on an `Err` value: CompiledTooBig(10485760)
```
🧪 **Reproduction:** Run `cargo test --test havoc_regex_oom`
😈 **Comment:** "You assumed your regex compilation would never hit a size limit. You were wrong."

---
*PR created automatically by Jules for task [14768674378722083705](https://jules.google.com/task/14768674378722083705) started by @madmax983*