### PR TITLE
⚒️ Forge: Extract Control Flow category and ZipLoader duplicate logic

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,11 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**Extract duplicate `ZipLoader` resource lookup logic**
+**Learning:** `crates/duke-loader/src/zip.rs` contained four extremely repetitive methods (`find_resource`, `find_resources`, `find_resource_entry`, `find_resource_entries`). Each sequentially probed the current Zip for a specific path, then the BOOT-INF path, and finally iterated over all `nested_libs`. This boilerplate violated DRY and bloated the struct implementation.
+**Action:** Extract repetitive sequential path probing and nested fallbacks into private, highly generic helper functions (`find_first_entry` and `find_all_entries`) using inline closures, dramatically collapsing the API surface into single-statement method calls.
+
+**Extract control flow check logic**
+**Learning:** Checking whether an `Instruction` was a branch, jump, switch, or return required inline chaining (`instr.is_conditional_branch() || instr.is_unconditional_jump() || instr.is_switch() || instr.is_return()`) duplicated across multiple sites (e.g., `basic_block.rs` and `cfg.rs`).
+**Action:** Centralize compound capability checks into single predicate methods on the enum itself (`pub const fn is_control_flow(&self) -> bool`) to compress calling logic and clearly state the semantic intent.

--- a/crates/duke-bytecode/src/basic_block.rs
+++ b/crates/duke-bytecode/src/basic_block.rs
@@ -81,10 +81,7 @@ fn find_leaders(instructions: &[(usize, Instruction)]) -> BTreeSet<usize> {
     leaders.insert(instructions[0].0);
 
     for (i, (pc, instr)) in instructions.iter().enumerate() {
-        let is_branch_or_return = instr.is_conditional_branch()
-            || instr.is_unconditional_jump()
-            || instr.is_switch()
-            || instr.is_return();
+        let is_branch_or_return = instr.is_control_flow();
 
         // Target of any jump or branch is a leader
         for target in instr.control_flow_targets(*pc, None) {

--- a/crates/duke-bytecode/src/instruction.rs
+++ b/crates/duke-bytecode/src/instruction.rs
@@ -780,6 +780,15 @@ impl Instruction {
         matches!(self, Self::Tableswitch { .. } | Self::Lookupswitch { .. })
     }
 
+    /// Returns `true` if the instruction alters control flow (branch, jump, switch, or return).
+    #[must_use]
+    pub const fn is_control_flow(&self) -> bool {
+        self.is_conditional_branch()
+            || self.is_unconditional_jump()
+            || self.is_switch()
+            || self.is_return()
+    }
+
     /// Returns `true` if the instruction halts execution in the current frame.
     #[must_use]
     pub const fn is_return(&self) -> bool {
@@ -1452,6 +1461,23 @@ mod tests {
         assert_eq!(iter.collect::<Vec<_>>(), vec![(10, 100), (20, 200)]);
 
         assert!(Instruction::Iconst0.switch_targets().is_none());
+    }
+
+    #[test]
+    fn test_is_control_flow() {
+        assert!(Instruction::Ifeq(0).is_control_flow());
+        assert!(Instruction::Goto(0).is_control_flow());
+        assert!(Instruction::Return.is_control_flow());
+        assert!(
+            Instruction::Tableswitch {
+                default: 0,
+                low: 0,
+                high: 0,
+                offsets: vec![]
+            }
+            .is_control_flow()
+        );
+        assert!(!Instruction::Iconst0.is_control_flow());
     }
 
     #[test]

--- a/crates/duke-loader/src/zip.rs
+++ b/crates/duke-loader/src/zip.rs
@@ -482,114 +482,111 @@ impl ClassLoader for ZipLoader {
     }
 
     fn find_resource(&self, name: &str) -> Result<Vec<u8>> {
-        match self.reader.read_entry(name) {
-            Err(Error::NotFound { .. }) => {}
-            result => return result,
-        }
-
-        // ⚡ Bolt: Eliminate intermediate String allocation and format! macro overhead
-        let mut boot_inf_name = String::with_capacity(name.len() + 17);
-        Self::append_boot_inf_classes_path(&mut boot_inf_name, name);
-        match self.reader.read_entry(&boot_inf_name) {
-            Err(Error::NotFound { .. }) => {}
-            result => return result,
-        }
-
-        for nested_lib in &self.nested_libs {
-            match nested_lib.find_resource(name) {
-                Err(Error::NotFound { .. }) => {}
-                result => return result,
-            }
-        }
-        Err(Error::NotFound {
-            name: name.to_string(),
-        })
+        self.find_first_entry(
+            name,
+            |s, p| s.reader.read_entry(p),
+            |n: &Self, p| n.find_resource(p),
+        )
     }
 
     fn find_resources(&self, name: &str) -> Result<Vec<Vec<u8>>> {
-        let mut resources = Vec::new();
-        match self.reader.read_entry(name) {
-            Ok(bytes) => resources.push(bytes),
-            Err(Error::NotFound { .. }) => {}
-            Err(err) => return Err(err),
-        }
-
-        // ⚡ Bolt: Eliminate intermediate String allocation and format! macro overhead
-        let mut boot_inf_name = String::with_capacity(name.len() + 17);
-        Self::append_boot_inf_classes_path(&mut boot_inf_name, name);
-        match self.reader.read_entry(&boot_inf_name) {
-            Ok(bytes) => resources.push(bytes),
-            Err(Error::NotFound { .. }) => {}
-            Err(err) => return Err(err),
-        }
-
-        for nested_lib in &self.nested_libs {
-            resources.extend(nested_lib.find_resources(name)?);
-        }
-        Ok(resources)
+        self.find_all_entries(
+            name,
+            |s, p| s.reader.read_entry(p),
+            |n: &Self, p| n.find_resources(p),
+        )
     }
 
     fn find_resource_entry(&self, name: &str) -> Result<LocatedResource> {
-        match self.reader.read_entry(name) {
-            Ok(bytes) => {
-                return Ok(LocatedResource {
+        self.find_first_entry(
+            name,
+            |s, p| {
+                s.reader.read_entry(p).map(|bytes| LocatedResource {
                     bytes,
-                    url: self.resource_url(name),
-                });
-            }
+                    url: s.resource_url(p),
+                })
+            },
+            |n: &Self, p| n.find_resource_entry(p),
+        )
+    }
+
+    fn find_resource_entries(&self, name: &str) -> Result<Vec<LocatedResource>> {
+        self.find_all_entries(
+            name,
+            |s, p| {
+                s.reader.read_entry(p).map(|bytes| LocatedResource {
+                    bytes,
+                    url: s.resource_url(p),
+                })
+            },
+            |n: &Self, p| n.find_resource_entries(p),
+        )
+    }
+}
+
+impl ZipLoader {
+    #[inline]
+    fn find_first_entry<T, F, G>(
+        &self,
+        name: &str,
+        mut check_self: F,
+        mut check_nested: G,
+    ) -> Result<T>
+    where
+        F: FnMut(&Self, &str) -> Result<T>,
+        G: FnMut(&Self, &str) -> Result<T>,
+    {
+        match check_self(self, name) {
             Err(Error::NotFound { .. }) => {}
-            Err(err) => return Err(err),
+            result => return result,
         }
 
         let mut boot_inf_name = String::with_capacity(name.len() + 17);
         Self::append_boot_inf_classes_path(&mut boot_inf_name, name);
-        match self.reader.read_entry(&boot_inf_name) {
-            Ok(bytes) => {
-                return Ok(LocatedResource {
-                    bytes,
-                    url: self.resource_url(&boot_inf_name),
-                });
-            }
+        match check_self(self, &boot_inf_name) {
             Err(Error::NotFound { .. }) => {}
-            Err(err) => return Err(err),
+            result => return result,
         }
 
         for nested_lib in &self.nested_libs {
-            match nested_lib.find_resource_entry(name) {
+            match check_nested(nested_lib, name) {
                 Err(Error::NotFound { .. }) => {}
                 result => return result,
             }
         }
-
         Err(Error::NotFound {
             name: name.to_string(),
         })
     }
 
-    fn find_resource_entries(&self, name: &str) -> Result<Vec<LocatedResource>> {
+    #[inline]
+    fn find_all_entries<T, F, G>(
+        &self,
+        name: &str,
+        mut check_self: F,
+        mut check_nested: G,
+    ) -> Result<Vec<T>>
+    where
+        F: FnMut(&Self, &str) -> Result<T>,
+        G: FnMut(&Self, &str) -> Result<Vec<T>>,
+    {
         let mut resources = Vec::new();
-        match self.reader.read_entry(name) {
-            Ok(bytes) => resources.push(LocatedResource {
-                bytes,
-                url: self.resource_url(name),
-            }),
+        match check_self(self, name) {
+            Ok(res) => resources.push(res),
             Err(Error::NotFound { .. }) => {}
             Err(err) => return Err(err),
         }
 
         let mut boot_inf_name = String::with_capacity(name.len() + 17);
         Self::append_boot_inf_classes_path(&mut boot_inf_name, name);
-        match self.reader.read_entry(&boot_inf_name) {
-            Ok(bytes) => resources.push(LocatedResource {
-                bytes,
-                url: self.resource_url(&boot_inf_name),
-            }),
+        match check_self(self, &boot_inf_name) {
+            Ok(res) => resources.push(res),
             Err(Error::NotFound { .. }) => {}
             Err(err) => return Err(err),
         }
 
         for nested_lib in &self.nested_libs {
-            resources.extend(nested_lib.find_resource_entries(name)?);
+            resources.extend(check_nested(nested_lib, name)?);
         }
 
         Ok(resources)

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
🚮 **Smell**: 
1. Repeated boolean checking logic like `instr.is_conditional_branch() || instr.is_unconditional_jump() || instr.is_switch() || instr.is_return()` in `crates/duke-bytecode/src/basic_block.rs` to determine if an instruction alters control flow.
2. Extensive boilerplate duplication in `crates/duke-loader/src/zip.rs` across `find_resource`, `find_resources`, `find_resource_entry`, and `find_resource_entries` where the exact same fallback order (base -> BOOT-INF -> nested libs) was repeated line-for-line.

✨ **Solution**: 
1. Added `Instruction::is_control_flow(&self) -> bool` to encapsulate this logic directly on the enum. Replaced the inline usage in `build_basic_blocks`.
2. Created highly generic inline helper functions `find_first_entry` and `find_all_entries` inside `ZipLoader` taking closures to execute the fallback sequence, collapsing the 4 public methods into simple, single-statement invocations.

🧼 **Benefit**: 
Dramatically reduces technical debt and cognitive load by removing duplicated logic and nested Pyramids of Doom. Uses zero-cost abstractions (`#[inline]` closures) ensuring performance is completely preserved.

🛡️ **Verification**: 
Ran `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-targets --all-features`, and `cargo fmt --all`. All tests pass, no logic changed.

---
*PR created automatically by Jules for task [15935405639425441348](https://jules.google.com/task/15935405639425441348) started by @madmax983*