### PR TITLE
⚡ Bolt: Optimize String Constants Allocation in Execution

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,7 @@
 **Trust the Iterator: .collect() is Optimized**
 **Learning:** In Rust, `.collect::<Vec<_>>()` called on an `ExactSizeIterator` (which `slice.iter().map()` implements) already knows the exact number of elements. The standard library heavily optimizes this via the `TrustedLen` trait to allocate the precise capacity upfront and completely bypass bounds checks during insertion.
 **Action:** Do not manually replace `.collect::<Vec<_>>()` with `Vec::with_capacity` and a `for` loop, as it re-introduces bounds checks on every push, making the "optimization" unidiomatic and a micro-regression.
+
+**Pre-allocate String Constants Vector in Execution**
+**Learning:** In the bytecode interpreter's execution loop, `Vec::new()` was used to allocate an array for `bsm_args` constants, causing unnecessary dynamic heap reallocations. The number of constants is known upfront since it skips the first argument (`bsm_args.len() - 1`).
+**Action:** When mapping or extracting elements from an array or slice into a new `Vec`, always use `Vec::with_capacity()` based on the source collection's length (using `.saturating_sub(1)` if elements are skipped) to eliminate dynamic allocations in hot loops.

--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -2510,7 +2510,8 @@ pub fn run_execution(
                         } else {
                             resolve_cp_string(cp, bsm_args[0].0 as usize)?
                         };
-                        let mut consts = Vec::new();
+                        // ⚡ Bolt: Eliminate dynamic vector reallocations by pre-sizing for constants
+                        let mut consts = Vec::with_capacity(bsm_args.len().saturating_sub(1));
                         for arg_idx in bsm_args.iter().skip(1) {
                             if let Ok(s) = resolve_cp_string(cp, arg_idx.0 as usize) {
                                 consts.push(s);

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
💡 **What:** Replaced `let mut consts = Vec::new();` with `let mut consts = Vec::with_capacity(bsm_args.len().saturating_sub(1));` in the interpreter execution loop. Also fixed unrelated pre-existing import and type inference compilation errors in `duke/src/jar_diff.rs`.
🎯 **Why:** The interpreter hot-path was doing unnecessary dynamic heap reallocations to build the constant arguments vector for `Multianewarray` / `InvokeDynamic` recipes. We already knew the target capacity upfront (`bsm_args.len() - 1`).
📊 **Impact:** Reduces heap reallocations on `StringConcatFactory.makeConcatWithConstants` boots.
🔬 **Measurement:** Run `cargo test` and verify tests pass. No regressions in CI or functionality.

---
*PR created automatically by Jules for task [7911505989828726745](https://jules.google.com/task/7911505989828726745) started by @madmax983*