### PR TITLE
⚒️ Forge: [Refactor load_jar_methods nesting and fix compilation]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,6 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+**Extract Hash Logic (God Block)**
+**Learning:** `load_jar_methods` in `duke/src/jar_diff.rs` contained an incredibly deep "Pyramid of Doom" block nested 4-levels deep (`for`, `if let`, `if let`, `for`), embedding raw parsing, variable resolution, and hashing directly within control flow iteration. This severely damages readability and muddles the function's core responsibility.
+**Action:** Always extract the internal logic of deeply nested iterative blocks (e.g. hashing the `cf.methods`) into strictly-typed helper functions like `hash_class_methods` to flatten the caller. Use guard clauses (`let Some(...) = ... else { continue; }`) to remove the remaining outer `if let` nesting.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -3,8 +3,7 @@
 
 #[cfg(feature = "nova")]
 use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    parse, AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +17,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +37,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")
@@ -136,6 +135,32 @@ pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
 #[cfg(feature = "nova")]
 #[cfg(not(tarpaulin_include))]
 #[allow(unexpected_cfgs)]
+fn hash_class_methods(
+    bytes: &[u8],
+    method_hashes: &mut HashMap<String, u64>,
+) -> Result<(), duke_classfile::Error> {
+    let cf = parse(bytes)?;
+    let class_name = resolve_class_name(&cf, cf.this_class);
+
+    for method in &cf.methods {
+        let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+        let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+        let full_name = format!("{class_name}::{name_str}{desc_str}");
+
+        let mut hasher = DefaultHasher::new();
+        for attr in &method.attributes {
+            if let AttributeData::Code(code) = &attr.data {
+                code.code.hash(&mut hasher);
+            }
+        }
+        method_hashes.insert(full_name, hasher.finish());
+    }
+    Ok(())
+}
+
+#[cfg(feature = "nova")]
+#[cfg(not(tarpaulin_include))]
+#[allow(unexpected_cfgs)]
 fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
     let Ok(loader) = ZipLoader::open(Path::new(jar_path)) else {
         return HashMap::new(); // If we cannot load, treat as empty
@@ -150,27 +175,15 @@ fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
         .collect();
 
     for entry_name in class_entries {
-        let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            #[allow(clippy::collapsible_if)]
-            if let Ok(cf) = parse(&bytes) {
-                let class_name = resolve_class_name(&cf, cf.this_class);
+        let Some(class_name_internal) = entry_name.strip_suffix(".class") else {
+            continue;
+        };
 
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{class_name}::{name_str}{desc_str}");
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
 
-                    let mut hasher = DefaultHasher::new();
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            code.code.hash(&mut hasher);
-                        }
-                    }
-                    method_hashes.insert(full_name, hasher.finish());
-                }
-            }
-        }
+        let _ = hash_class_methods(&bytes, &mut method_hashes);
     }
     method_hashes
 }


### PR DESCRIPTION
🚮 **Smell:** `load_jar_methods` in `duke/src/jar_diff.rs` was a deeply nested "Pyramid of Doom" (4+ levels deep) combining zip loading, classfile parsing, name resolution, and attribute hashing. This made it difficult to read and maintain. Furthermore, there were unresolved compilation errors regarding imports and closure type annotations blocking the CI.

✨ **Solution:** 
- Corrected the `use` statement for `duke_classfile` types to resolve the import error.
- Added explicit type annotations to `and_then` closures resolving `E0282`.
- Extracted the class method hashing logic into a new, strongly-typed helper function `hash_class_methods`.
- Refactored `load_jar_methods` to use early `continue` guard clauses instead of nested `if let` blocks.

🧼 **Benefit:** The refactored code has a dramatically flatter structure, improving readability and separating the concern of iterating over zip entries from the logic of hashing bytecode attributes. The compilation errors have been fully resolved.

🛡️ **Verification:** Tests passed. No logic changed. All Clippy warnings resolved. Code review passed.

---
*PR created automatically by Jules for task [3574937466529585616](https://jules.google.com/task/3574937466529585616) started by @madmax983*