### PR TITLE
🎸 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,6 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+## 2024-06-21 - [cp_utf8 Documentation]
+**Confusion:** The `cp_utf8` helper function was entirely undocumented, lacking an explanation of its purpose, error conditions, and an executable example, triggering documentation gaps.
+**Clarification:** Added complete module-level documentation and an executable doctest for `cp_utf8`, explaining how it resolves `CpIndex` to UTF-8 strings.

--- a/crates/duke-classfile/src/lib.rs
+++ b/crates/duke-classfile/src/lib.rs
@@ -27,7 +27,7 @@ pub use crate::class::*;
 pub use crate::constant_pool::*;
 pub use access_flags::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 pub use error::{Error, Result};
-pub use parser::parse;
+pub use parser::{cp_utf8, parse};
 
 #[cfg(test)]
 mod tests {

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -615,6 +615,29 @@ fn parse_code_attribute(c: &mut Cursor<'_>) -> Result<CodeAttribute> {
 // ---------------------------------------------------------------------------
 
 /// Look up a UTF-8 string in the constant pool.
+///
+/// Many class file structures refer to names and descriptors via an index into the
+/// constant pool. This helper function dereferences a `CpIndex`, verifies it points
+/// to a valid `CONSTANT_Utf8_info` entry, and returns the underlying string slice.
+///
+/// # Errors
+///
+/// Returns an error if the index is out of bounds, points to a phantom slot, or
+/// points to a constant pool entry that is not a UTF-8 string.
+///
+/// # Examples
+///
+/// ```
+/// use duke_classfile::{CpIndex, CpEntry};
+/// use duke_classfile::cp_utf8;
+///
+/// let pool = vec![
+///     None, // index 0 is reserved
+///     Some(CpEntry::Utf8("Hello, World!".to_string())),
+/// ];
+/// let result = cp_utf8(&pool, CpIndex(1));
+/// assert_eq!(result.unwrap(), "Hello, World!");
+/// ```
 pub fn cp_utf8(pool: &[Option<CpEntry>], idx: CpIndex) -> Result<&str> {
     let i = idx.0 as usize;
     if i == 0 {

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
📖 Chapter: The `cp_utf8` helper function in the `duke-classfile` module.
🔦 Insight: Explained its purpose, error conditions, and how it resolves a `CpIndex` to a UTF-8 string safely.
🧪 Example: Added an executable doctest to `cp_utf8`.
🖼️ Preview: Documentation is now visible and tests pass flawlessly.

---
*PR created automatically by Jules for task [11129044346603794933](https://jules.google.com/task/11129044346603794933) started by @madmax983*