### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,6 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+## 2024-05-25 - [Test Files Missing Docs - Proptest]
+**Confusion:** The `havoc_classfile_proptest.rs` test generated missing documentation warnings.
+**Clarification:** Added `#![allow(missing_docs)]` to `havoc_classfile_proptest.rs` to suppress the warning, as test files don't require full crate documentation blocks.

--- a/crates/duke-classfile/src/attributes.rs
+++ b/crates/duke-classfile/src/attributes.rs
@@ -98,36 +98,54 @@ pub enum ElementValue {
 }
 
 /// Typed attribute payload.
+///
+/// The `AttributeData` enum represents the specific data associated with an attribute in a `.class` file.
+/// Each variant corresponds to a known attribute type defined in the JVM specification. If an attribute
+/// is not explicitly supported or parsed, it is represented as a `Raw` byte array.
+///
+/// # Examples
+///
+/// ```
+/// use duke_classfile::{AttributeData, CpIndex};
+///
+/// let const_val = AttributeData::ConstantValue {
+///     constant_value_index: CpIndex(10),
+/// };
+///
+/// if let AttributeData::ConstantValue { constant_value_index } = const_val {
+///     assert_eq!(constant_value_index.0, 10);
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub enum AttributeData {
-    /// Code attribute (§4.7.3) — method bytecode.
+    /// Code attribute (§4.7.3) — method bytecode. Contains instructions, local variables, and exceptions.
     Code(CodeAttribute),
     /// `ConstantValue` attribute (§4.7.2) — compile-time constant for static fields.
     ConstantValue {
         /// Index into the constant pool.
         constant_value_index: CpIndex,
     },
-    /// `SourceFile` attribute (§4.7.10).
+    /// `SourceFile` attribute (§4.7.10) - Optional debugging information associating a class file with a source file.
     SourceFile {
         /// Index into the constant pool representing the name of the source file.
         sourcefile_index: CpIndex,
     },
-    /// `LineNumberTable` (§4.7.12).
+    /// `LineNumberTable` (§4.7.12) - Optional debugging information to map bytecode offsets to line numbers.
     LineNumberTable(Vec<LineNumberEntry>),
-    /// `LocalVariableTable` (§4.7.13).
+    /// `LocalVariableTable` (§4.7.13) - Optional debugging information about local variables in a method.
     LocalVariableTable(Vec<LocalVariableEntry>),
-    /// Exceptions attribute (§4.7.5).
+    /// Exceptions attribute (§4.7.5) - Checked exceptions a method is declared to throw.
     Exceptions {
         /// Table of exception indices.
         exception_index_table: Vec<CpIndex>,
     },
-    /// `BootstrapMethods` attribute (§4.7.23) — required for invokedynamic.
+    /// `BootstrapMethods` attribute (§4.7.23) — required for `invokedynamic` instructions.
     BootstrapMethods(Vec<BootstrapMethodEntry>),
-    /// `RuntimeVisibleAnnotations` (§4.7.16).
+    /// `RuntimeVisibleAnnotations` (§4.7.16) - Annotations on classes, methods, or fields that are available at runtime.
     RuntimeVisibleAnnotations(Vec<Annotation>),
-    /// `AnnotationDefault` (§4.7.22) default value for an annotation element.
+    /// `AnnotationDefault` (§4.7.22) - Default value for an annotation element.
     AnnotationDefault(ElementValue),
-    /// Any attribute we don't parse in detail yet.
+    /// Any attribute we don't parse in detail yet, stored safely as a raw byte array.
     Raw(Vec<u8>),
 }
 

--- a/crates/duke-classfile/tests/havoc_classfile_proptest.rs
+++ b/crates/duke-classfile/tests/havoc_classfile_proptest.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use proptest::prelude::*;
 
 proptest! {

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
📖 **Chapter:** The `AttributeData` module

🔦 **Insight:** Added comprehensive module-level and variant-level documentation to the `AttributeData` enum, explaining what each attribute does and linking to the relevant JVM specification sections. This fixes the confusion around how attributes are represented internally.

🧪 **Example:** Added an executable doctest for the `AttributeData` enum demonstrating pattern matching on the `ConstantValue` variant.

🖼️ **Preview:**
(Available via `cargo doc --open`)

Other Fixes:
- Fixed the `missing_docs` lint warning in `havoc_classfile_proptest.rs`.
- Corrected imports and type inference issues in `duke/src/jar_diff.rs` where the `types` module prefix was incorrectly used, causing compilation failures.

---
*PR created automatically by Jules for task [12889767329200744053](https://jules.google.com/task/12889767329200744053) started by @madmax983*