### PR TITLE
⚡ Bolt: Remove string allocations from formatting stack trace messages

### DIFF
--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -3664,13 +3664,23 @@ fn stack_trace_element_text(heap: &duke_gc::Heap, element_ref: u64) -> Result<St
         Some(Slot::Int(line)) => *line,
         _ => -1,
     };
-    let location = match (file_name, line_number) {
-        (_, -2) => "Native Method".to_string(),
-        (Some(file), line) if line >= 0 => format!("{file}:{line}"),
-        (Some(file), _) => file,
-        (None, _) => "Unknown Source".to_string(),
-    };
-    Ok(format!("{class_name}.{method_name}({location})"))
+    let mut result = String::with_capacity(class_name.len() + method_name.len() + 32);
+    result.push_str(&class_name);
+    result.push('.');
+    result.push_str(&method_name);
+    result.push('(');
+    match (file_name, line_number) {
+        (_, -2) => result.push_str("Native Method"),
+        (Some(file), line) if line >= 0 => {
+            result.push_str(&file);
+            result.push(':');
+            let _ = std::fmt::Write::write_fmt(&mut result, format_args!("{line}"));
+        }
+        (Some(file), _) => result.push_str(&file),
+        (None, _) => result.push_str("Unknown Source"),
+    }
+    result.push(')');
+    Ok(result)
 }
 
 fn append_throwable_trace(

--- a/pr_details.txt
+++ b/pr_details.txt
@@ -1,6 +1,7 @@
-Title: 🛡️ Sentry: [test coverage improvement]
+Title: ⚡ Bolt: Remove string allocations from formatting stack trace messages
+
 Body:
-🎯 Target: `duke_loader::ZipReader::read_entry_info`, `duke_loader::parse_central_directory`, and `duke_telemetry::ser_helpers`.
-💣 Risk: Edge cases where zip central directories have truncated entries or mismatched local header offsets, and missing telemetry map empty paths could panic or fail implicitly if refactored.
-🧪 Strategy: Added specific inline tests inside `crates/duke-loader/src/zip.rs` to reach missing branches of Zip Format errors (e.g. truncated `filename_len`, exceeded `uncompressed_size`). Added tests in `crates/duke-telemetry/src/helpers.rs` for empty map serialization. Added an empty check for `print_report`.
-🔭 Verification: `cargo test -p duke-loader` and `cargo test -p duke-telemetry`
+💡 What: Replaced a `format!` allocation in `stack_trace_element_text` with an efficient sequence of `String::with_capacity` and `push_str()` / `std::fmt::Write` logic.
+🎯 Why: Exception formatting can allocate numerous strings when creating the final stack trace representation. By manually calculating string capacities upfront and avoiding the heavy `format!` macro and intermediate copies, the generation process has fewer heap allocations.
+📊 Impact: Reduces memory allocations during throwable exception printing and logging, avoiding intermediate buffer resizes and format parsing overhead.
+🔬 Measurement: Run bench tests on stack traces / overall interpreter execution.


### PR DESCRIPTION
💡 What: Replaced a `format!` allocation in `stack_trace_element_text` with an efficient sequence of `String::with_capacity` and `push_str()` / `std::fmt::Write` logic.
🎯 Why: Exception formatting can allocate numerous strings when creating the final stack trace representation. By manually calculating string capacities upfront and avoiding the heavy `format!` macro and intermediate copies, the generation process has fewer heap allocations.
📊 Impact: Reduces memory allocations during throwable exception printing and logging, avoiding intermediate buffer resizes and format parsing overhead.
🔬 Measurement: Run bench tests on stack traces / overall interpreter execution.

---
*PR created automatically by Jules for task [13112151799006302759](https://jules.google.com/task/13112151799006302759) started by @madmax983*