### PR TITLE
⚒️ Forge: [Refactor jar_diff printing and fix build]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,6 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+**[Extract Repeated Printing Logic]**
+**Learning:** `dump_jar_diff` in `duke/src/jar_diff.rs` had duplicated 10-line loops to print added, removed, and modified methods lists. This repeated logic cluttered the diff summary function.
+**Action:** Extracted the printing loop into a generic `print_method_list` helper function to DRY up the method display and flatten the control flow.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")
@@ -99,38 +96,34 @@ pub fn dump_jar_diff(jar1_path: &str, jar2_path: &str) {
     println!("Methods Unchanged:    {unchanged}");
     println!();
 
-    if !added.is_empty() {
-        println!("--- Top 10 Added Methods ---");
-        for m in added.iter().take(10) {
-            println!("  + {m}");
-        }
-        if added.len() > 10 {
-            println!("  ... and {} more", added.len() - 10);
-        }
-        println!();
+    print_method_list("Added", &added);
+    print_method_list("Removed", &removed);
+    print_method_list("Modified", &modified);
+}
+
+#[cfg(feature = "nova")]
+#[cfg(not(tarpaulin_include))]
+#[allow(clippy::print_stdout)]
+fn print_method_list(label: &str, methods: &[String]) {
+    if methods.is_empty() {
+        return;
     }
 
-    if !removed.is_empty() {
-        println!("--- Top 10 Removed Methods ---");
-        for m in removed.iter().take(10) {
-            println!("  - {m}");
-        }
-        if removed.len() > 10 {
-            println!("  ... and {} more", removed.len() - 10);
-        }
-        println!();
-    }
+    let sign = match label {
+        "Added" => "+",
+        "Removed" => "-",
+        "Modified" => "~",
+        _ => " ",
+    };
 
-    if !modified.is_empty() {
-        println!("--- Top 10 Modified Methods ---");
-        for m in modified.iter().take(10) {
-            println!("  ~ {m}");
-        }
-        if modified.len() > 10 {
-            println!("  ... and {} more", modified.len() - 10);
-        }
-        println!();
+    println!("--- Top 10 {label} Methods ---");
+    for m in methods.iter().take(10) {
+        println!("  {sign} {m}");
     }
+    if methods.len() > 10 {
+        println!("  ... and {} more", methods.len() - 10);
+    }
+    println!();
 }
 
 #[cfg(feature = "nova")]


### PR DESCRIPTION
**Smell:** The `dump_jar_diff` function contained three nearly identical blocks of 10+ lines each responsible for printing the top 10 items in the `added`, `removed`, and `modified` method collections.
**Solution:** Extracted this repeated logic into a standalone, generic `print_method_list` helper function that accepts a label and a slice of strings. Also fixed a pre-existing compilation error regarding unused imports and implicit closure typing for `.and_then()` over complex `Option` types.
**Benefit:** Reduces cognitive load and DRYs up the `jar_diff.rs` logic, flattening the `dump_jar_diff` function structure and keeping it concise.
**Verification:** Tests passed. No logic changed.

---
*PR created automatically by Jules for task [2887891606244589412](https://jules.google.com/task/2887891606244589412) started by @madmax983*