### PR TITLE
🗺️ Atlas: [architectural change] Fix type inference error from earlier encapsulate change

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -7,3 +7,6 @@
 **[Encapsulate `duke_classfile` Facade]**
 **Tangle:** The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types, and `duke-telemetry` exposed internal serialization helpers via `pub mod ser_helpers`. This creates confusing, leaky abstractions and redundant paths.
 **Blueprint:** Encapsulated both modules. In `duke_classfile`, replaced `pub mod types` with direct `pub use` statements at the crate root, eliminating the `types` namespace from the public API entirely. In `duke_telemetry`, reduced `ser_helpers` visibility to `pub(crate)`.
+**[Fix type annotations in `jar_diff.rs`]**
+**Tangle:** The file `duke/src/jar_diff.rs` was broken with `E0282: type annotations needed` inside an `.and_then` call on a complex nested `Option` chain involving `CpEntry`. Also, it contained a broken `duke_classfile::types` import resulting from a previous structural change to encapsulate the `duke_classfile` API facade.
+**Blueprint:** Fixed the broken import path and explicitly annotated the closure parameter type (`|slot: &Option<CpEntry>|`) to unblock the compiler's type inference.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
🕸️ Tangle: The duke_classfile facade was previously modified to remove the leaky types module, but this broke an import in jar_diff.rs. When fixing the import, the closure parameters needed explicit typing because the inference could not deduce &Option<CpEntry>.
📐 Blueprint: Fixed the broken import path and explicitly typed the closure parameter to &Option<CpEntry> to unblock compilation.
🧱 Stability: Fixes the workspace build which was failing due to E0282.
🔬 Verification: Builds successfully and passes test/clippy.

---
*PR created automatically by Jules for task [3187819036013565414](https://jules.google.com/task/3187819036013565414) started by @madmax983*