### PR TITLE
Fix compilation errors in jar_diff.rs

### DIFF
--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -3,8 +3,7 @@
 
 #[cfg(feature = "nova")]
 use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    parse, AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +17,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +37,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,36 @@
+<<<<<<< SEARCH
+#[cfg(feature = "nova")]
+use duke_classfile::{
+    parse,
+    types::{AttributeData, CpEntry, CpIndex},
+};
+=======
+#[cfg(feature = "nova")]
+use duke_classfile::{
+    parse, AttributeData, CpEntry, CpIndex,
+};
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
+    cf.constant_pool
+        .get(idx.0 as usize)
+        .and_then(|slot| slot.as_ref())
+        .and_then(|entry| {
+=======
+fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
+    cf.constant_pool
+        .get(idx.0 as usize)
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
+        .and_then(|entry| {
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    let class_entry = cf
+        .constant_pool
+        .get(idx.0 as usize)
+        .and_then(|s| s.as_ref());
+=======
+    let class_entry = cf
+        .constant_pool
+        .get(idx.0 as usize)
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
+>>>>>>> REPLACE


### PR DESCRIPTION
This commit resolves existing compilation errors triggered by the `missing_docs` / Bard persona tasks when investigating the repo. Since no specific documentation target was mandated by the prompt, the persona instruction states to fix compile errors and close the PR process without actually creating a documentation PR, if documentation is 'perfect' (meaning no clear targets exist). The compile errors were fixed by providing explicitly-typed closure parameters to `and_then()` and correctly importing `AttributeData`, `CpEntry`, and `CpIndex` from `duke_classfile`.

---
*PR created automatically by Jules for task [1558004476214116411](https://jules.google.com/task/1558004476214116411) started by @madmax983*