### PR TITLE
⚒️ Forge: [Refactor verifier.rs to use Instruction method]

### DIFF
--- a/crates/duke-bytecode/src/instruction.rs
+++ b/crates/duke-bytecode/src/instruction.rs
@@ -782,6 +782,19 @@ impl Instruction {
 
     /// Returns `true` if the instruction halts execution in the current frame.
     #[must_use]
+    pub const fn is_method_return(&self) -> bool {
+        matches!(
+            self,
+            Self::Return
+                | Self::Ireturn
+                | Self::Lreturn
+                | Self::Freturn
+                | Self::Dreturn
+                | Self::Areturn
+        )
+    }
+
+    #[must_use]
     pub const fn is_return(&self) -> bool {
         matches!(
             self,

--- a/crates/duke-bytecode/src/verifier.rs
+++ b/crates/duke-bytecode/src/verifier.rs
@@ -82,7 +82,7 @@ pub fn verify(
         }
 
         // Empty-stack-on-return check
-        if is_return(instr) && depth != 0 {
+        if instr.is_method_return() && depth != 0 {
             return Err(crate::Error::Verify(VerifyError::NonEmptyStackOnReturn {
                 pc,
                 depth,
@@ -357,18 +357,6 @@ const fn stack_effect(instr: &Instruction) -> (usize, usize) {
 
         Instruction::Monitorenter | Instruction::Monitorexit => (1, 0),
     }
-}
-
-const fn is_return(instr: &Instruction) -> bool {
-    matches!(
-        instr,
-        Instruction::Return
-            | Instruction::Ireturn
-            | Instruction::Lreturn
-            | Instruction::Freturn
-            | Instruction::Dreturn
-            | Instruction::Areturn
-    )
 }
 
 /// Check that any local variable accesses are within `max_locals`.

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
🚮 Smell: Local `is_return` helper function in `verifier.rs` duplicates logic that should logically belong to the `Instruction` enum itself.
✨ Solution: Added `Instruction::is_method_return()` to specifically check for actual method returns (matching the behavior of the original local `is_return` helper, without matching `Athrow` or `Ret`) and used it in `verifier.rs`. Removed the redundant local function.
🧼 Benefit: Improves encapsulation and readability by putting the behavior on the enum itself, reducing noise in the verifier.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [3774821324952468556](https://jules.google.com/task/3774821324952468556) started by @madmax983*