### PR TITLE
👺 Havoc: Thread Registry State Leak

### DIFF
--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -11597,71 +11597,84 @@ fn next_thread_host_key() -> i32 {
     NEXT_THREAD_HOST_KEY.fetch_add(1, Ordering::Relaxed)
 }
 
-fn java_thread_hosts() -> &'static RwLock<HashMap<i32, std::thread::ThreadId>> {
-    static HOSTS: OnceLock<RwLock<HashMap<i32, std::thread::ThreadId>>> = OnceLock::new();
-    HOSTS.get_or_init(|| RwLock::new(HashMap::new()))
+#[derive(Default)]
+struct ThreadRegistry {
+    hosts: HashMap<i32, std::thread::ThreadId>,
+    interrupted: HashSet<std::thread::ThreadId>,
 }
 
-fn interrupted_host_threads() -> &'static RwLock<HashSet<std::thread::ThreadId>> {
-    static INTERRUPTED: OnceLock<RwLock<HashSet<std::thread::ThreadId>>> = OnceLock::new();
-    INTERRUPTED.get_or_init(|| RwLock::new(HashSet::new()))
+fn thread_registry() -> &'static RwLock<ThreadRegistry> {
+    static REGISTRY: OnceLock<RwLock<ThreadRegistry>> = OnceLock::new();
+    REGISTRY.get_or_init(|| RwLock::new(ThreadRegistry::default()))
 }
 
 fn register_java_host_thread(host_key: i32, host_thread_id: std::thread::ThreadId) {
-    java_thread_hosts()
+    thread_registry()
         .write()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .hosts
         .insert(host_key, host_thread_id);
 }
 
 fn unregister_java_host_thread(host_key: i32) {
-    let removed_host_thread = java_thread_hosts()
+    let mut registry = thread_registry()
         .write()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .remove(&host_key);
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let removed_host_thread = registry.hosts.remove(&host_key);
     if let Some(host_thread_id) = removed_host_thread {
-        interrupted_host_threads()
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .remove(&host_thread_id);
+        registry.interrupted.remove(&host_thread_id);
     }
 }
 
 fn host_thread_for_java_thread(host_key: i32) -> Option<std::thread::ThreadId> {
-    java_thread_hosts()
+    thread_registry()
         .read()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .hosts
         .get(&host_key)
         .copied()
 }
 
 fn java_host_key_for_current_host() -> Option<i32> {
     let host_thread_id = current_host_thread_id();
-    java_thread_hosts()
+    thread_registry()
         .read()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .hosts
         .iter()
         .find_map(|(host_key, mapped_host)| (*mapped_host == host_thread_id).then_some(*host_key))
 }
 
 fn interrupt_host_thread(host_thread_id: std::thread::ThreadId) {
-    interrupted_host_threads()
+    thread_registry()
         .write()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .interrupted
         .insert(host_thread_id);
 }
 
+fn interrupt_java_thread_by_key(host_key: i32) {
+    let mut registry = thread_registry()
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(&host_thread_id) = registry.hosts.get(&host_key) {
+        registry.interrupted.insert(host_thread_id);
+    }
+}
+
 fn current_host_thread_is_interrupted() -> bool {
-    interrupted_host_threads()
+    thread_registry()
         .read()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .interrupted
         .contains(&current_host_thread_id())
 }
 
 fn take_current_host_thread_interrupted() -> bool {
-    interrupted_host_threads()
+    thread_registry()
         .write()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .interrupted
         .remove(&current_host_thread_id())
 }
 
@@ -13366,9 +13379,7 @@ pub(crate) fn native_thread_interrupt(
         _ => -1,
     };
     heap.write_field(thread_ref, THREAD_INTERRUPTED_SLOT, Slot::Int(1))?;
-    if let Some(host_thread_id) = host_thread_for_java_thread(host_key) {
-        interrupt_host_thread(host_thread_id);
-    }
+    interrupt_java_thread_by_key(host_key);
     Ok(None)
 }
 
@@ -13389,9 +13400,10 @@ pub(crate) fn native_thread_is_interrupted(
     };
     let host_interrupted = host_thread_for_java_thread(host_key)
         .is_some_and(|host_thread_id| {
-            interrupted_host_threads()
+            thread_registry()
                 .read()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .interrupted
                 .contains(&host_thread_id)
         });
     Ok(Some(Slot::Int(i32::from(


### PR DESCRIPTION
🧨 **The Trigger:**
Calling `host_thread_for_java_thread` drops its read lock, returning a native thread ID. Before the caller can execute `interrupt_host_thread(id)`, the background native thread might exit and call `unregister_java_host_thread`. The unregister call removes the mapping but finds no matching interrupted state. Then, the original caller resumes, blindly adding the thread ID to the `interrupted` set. Since the thread is already unregistered, this ID stays in the `HashSet` forever, causing a memory and state leak.

📉 **The Stack Trace:**
```
thread 'test_thread_registry_state_leak' panicked at crates/duke-interpreter/tests/havoc_thread_registry_loom.rs:66:9:
State leak detected: Unregistered thread is still marked as interrupted!
```

🧪 **Reproduction:**
A dedicated `loom` harness demonstrating the race condition is included in the PR commit history (but intentionally left out of final workspace to keep it clean, or retained if desired as `test_thread_registry_state_leak_fixed`).

😈 **Comment:**
"You assumed `RwLock` operations were atomic across multiple collections. You were wrong."

---
*PR created automatically by Jules for task [1049918713161245755](https://jules.google.com/task/1049918713161245755) started by @madmax983*