### PR TITLE
⚒️ Forge: [Extract Stack Opcodes]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,11 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**[Extract God Function (decode_one stack ops)]
+**Learning:** `decode_one` had a deeply nested match block specifically for stack manipulation opcodes (`POP`, `DUP`, `SWAP`, etc.). This caused visual noise and broke the pattern established by other categorized helper functions (like `decode_constant_op`).
+**Action:** Extract nested variant-specific match blocks into well-named helper functions (`decode_stack_op`) to maintain a flat, predictable structure across large instruction decoding loops.
+
+**[Clippy Unnecessary Wraps]
+**Learning:** Extracting an inline `Ok(match ...)` into a helper function that returns `Result<T>` when all match arms are infallible triggers the `clippy::unnecessary_wraps` lint.
+**Action:** Always verify if a newly extracted helper function actually *needs* to return a `Result`. If the logic never fails, return the raw type directly and wrap the helper function call site in `Ok(...)` instead.

--- a/crates/duke-bytecode/src/decoder.rs
+++ b/crates/duke-bytecode/src/decoder.rs
@@ -393,24 +393,28 @@ fn decode_extended_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
     })
 }
 
+fn decode_stack_op(opcode: u8) -> Instruction {
+    match opcode {
+        op::POP => Instruction::Pop,
+        op::POP2 => Instruction::Pop2,
+        op::DUP => Instruction::Dup,
+        op::DUP_X1 => Instruction::DupX1,
+        op::DUP_X2 => Instruction::DupX2,
+        op::DUP2 => Instruction::Dup2,
+        op::DUP2_X1 => Instruction::Dup2X1,
+        op::DUP2_X2 => Instruction::Dup2X2,
+        op::SWAP => Instruction::Swap,
+        _ => unreachable!(),
+    }
+}
+
 #[allow(clippy::unnecessary_wraps)]
 #[allow(clippy::too_many_lines)]
 fn decode_one(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> Result<Instruction> {
     match opcode {
         op::NOP..=op::LDC2_W => decode_constant_op(c, opcode),
         op::ILOAD..=op::SASTORE => decode_load_store_op(c, opcode),
-        op::POP..=op::SWAP => Ok(match opcode {
-            op::POP => Instruction::Pop,
-            op::POP2 => Instruction::Pop2,
-            op::DUP => Instruction::Dup,
-            op::DUP_X1 => Instruction::DupX1,
-            op::DUP_X2 => Instruction::DupX2,
-            op::DUP2 => Instruction::Dup2,
-            op::DUP2_X1 => Instruction::Dup2X1,
-            op::DUP2_X2 => Instruction::Dup2X2,
-            op::SWAP => Instruction::Swap,
-            _ => unreachable!(),
-        }),
+        op::POP..=op::SWAP => Ok(decode_stack_op(opcode)),
         op::IADD..=op::IINC => decode_math_op(c, opcode),
         op::I2L..=op::I2S => decode_conversion_op(opcode),
         op::LCMP..=op::RETURN => decode_control_flow_op(c, opcode, pc),

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -3,8 +3,7 @@
 
 #[cfg(feature = "nova")]
 use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    parse, AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};


### PR DESCRIPTION
🚮 Smell: The `decode_one` function had an inline nested `match` block for stack operations (`POP`, `DUP`, etc.), breaking the pattern of using typed helpers for instruction groups.
✨ Solution: Extracted the logic into a new `decode_stack_op` function. Flattened `duke_classfile` type imports in `jar_diff.rs` to fix build warnings/errors.
🧼 Benefit: Reduces cognitive load by flattening the massive opcode matching function, maintaining consistent abstraction layers.
🛡️ Verification: `cargo test` passed. No logic changed.

---
*PR created automatically by Jules for task [5362456435502106711](https://jules.google.com/task/5362456435502106711) started by @madmax983*