### PR TITLE
⚒️ Forge: Flatten Decoder Cursor

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**Flatten Decoder Cursor**
+**Learning:** The `Cursor::read_*` methods in `parser.rs` used chained sequential `read_u8()` and recursive calls. This created unnecessary nesting, multiple bound checks, and was generally less idiomatic.
+**Action:** Replaced chained `read_u8()` and bit shifts with slice-based bound checks `self.pos + n > self.data.len()` and `from_be_bytes(bytes)` to improve clarity and reduce sequential call overhead.

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -63,9 +63,12 @@ impl<'a> Cursor<'a> {
     }
 
     fn read_u16(&mut self) -> Result<u16> {
-        let hi = u16::from(self.read_u8()?);
-        let lo = u16::from(self.read_u8()?);
-        Ok((hi << 8) | lo)
+        if self.pos + 2 > self.data.len() {
+            return Err(Error::UnexpectedEof { offset: self.pos });
+        }
+        let bytes: [u8; 2] = self.data[self.pos..self.pos + 2].try_into().unwrap();
+        self.pos += 2;
+        Ok(u16::from_be_bytes(bytes))
     }
 
     #[allow(dead_code)]
@@ -74,9 +77,12 @@ impl<'a> Cursor<'a> {
     }
 
     fn read_u32(&mut self) -> Result<u32> {
-        let hi = u32::from(self.read_u16()?);
-        let lo = u32::from(self.read_u16()?);
-        Ok((hi << 16) | lo)
+        if self.pos + 4 > self.data.len() {
+            return Err(Error::UnexpectedEof { offset: self.pos });
+        }
+        let bytes: [u8; 4] = self.data[self.pos..self.pos + 4].try_into().unwrap();
+        self.pos += 4;
+        Ok(u32::from_be_bytes(bytes))
     }
 
     fn read_i32(&mut self) -> Result<i32> {
@@ -84,9 +90,12 @@ impl<'a> Cursor<'a> {
     }
 
     fn read_u64(&mut self) -> Result<u64> {
-        let hi = u64::from(self.read_u32()?);
-        let lo = u64::from(self.read_u32()?);
-        Ok((hi << 32) | lo)
+        if self.pos + 8 > self.data.len() {
+            return Err(Error::UnexpectedEof { offset: self.pos });
+        }
+        let bytes: [u8; 8] = self.data[self.pos..self.pos + 8].try_into().unwrap();
+        self.pos += 8;
+        Ok(u64::from_be_bytes(bytes))
     }
 
     fn read_i64(&mut self) -> Result<i64> {


### PR DESCRIPTION
**🚮 Smell:** The `Cursor::read_*` methods in `parser.rs` used chained sequential `read_u8()` calls and recursive bit-shifting. This created unnecessary nesting, multiple redundant bound checks, and was less idiomatic.

**✨ Solution:** Replaced chained `read_u8()` calls and manual bit shifts with slice-based bound checks (`self.pos + n > self.data.len()`) and standard `from_be_bytes(bytes)` array conversion for integer parsing.

**🧼 Benefit:** Improves clarity, simplifies the code, and reduces sequential call overhead by consolidating multiple bounds checks into one per multi-byte read.

**🛡️ Verification:** `cargo test --all-targets --all-features` and `cargo clippy` passed cleanly. No logic or runtime behavior was changed.

---
*PR created automatically by Jules for task [5298135820036677988](https://jules.google.com/task/5298135820036677988) started by @madmax983*