### PR TITLE
⚡ Bolt: Remove String allocations in call graph generation

### DIFF
--- a/crates/duke-bytecode/src/call_graph.rs
+++ b/crates/duke-bytecode/src/call_graph.rs
@@ -40,7 +40,10 @@ fn resolve_class_name(cf: &ClassFile, idx: CpIndex) -> &str {
     }
 }
 
-fn extract_method_ref(cf: &ClassFile, idx: CpIndex) -> Option<(String, String, String)> {
+/// **Bolt Optimization:**
+/// Eliminates intermediate `String` allocations by returning string slices (`&str`)
+/// directly from the constant pool instead of allocating owned `String` instances.
+fn extract_method_ref(cf: &ClassFile, idx: CpIndex) -> Option<(&str, &str, &str)> {
     let entry = cf.constant_pool.get(idx.0 as usize)?.as_ref()?;
 
     let (CpEntry::Methodref {
@@ -55,7 +58,7 @@ fn extract_method_ref(cf: &ClassFile, idx: CpIndex) -> Option<(String, String, S
         return None;
     };
 
-    let class_name = resolve_class_name(cf, *class_idx).to_string();
+    let class_name = resolve_class_name(cf, *class_idx);
 
     let nat_entry = cf.constant_pool.get(nat_idx.0 as usize)?.as_ref()?;
     if let CpEntry::NameAndType {
@@ -63,8 +66,8 @@ fn extract_method_ref(cf: &ClassFile, idx: CpIndex) -> Option<(String, String, S
         descriptor_index,
     } = nat_entry
     {
-        let method_name = cp_str(cf, *name_index)?.to_string();
-        let method_desc = cp_str(cf, *descriptor_index)?.to_string();
+        let method_name = cp_str(cf, *name_index)?;
+        let method_desc = cp_str(cf, *descriptor_index)?;
         Some((class_name, method_name, method_desc))
     } else {
         None


### PR DESCRIPTION
## 💡 What

Modified `extract_method_ref` in `call_graph.rs` to return `Option<(&str, &str, &str)>` instead of `Option<(String, String, String)>`.

## 🎯 Why

During Mermaid CFG generation, extracting method references triggers unnecessary heap allocations for the class name, method name, and descriptor. By utilizing Rust's lifetime elision and string slices directly pointing to the constant pool entries, we can avoid these allocations entirely. 

## 📊 Impact

Reduces string allocations in a hot loop (graph traversal/generation). Instead of creating three owned `String` instances per method call reference, we pass lightweight `&str` references directly to the final `format!` macro or `println!`.

## 🔬 Measurement

Run `cargo check` and `cargo test --package duke-bytecode` to verify everything continues functioning as normal with reduced memory overhead.

---
*PR created automatically by Jules for task [14440406645269594035](https://jules.google.com/task/14440406645269594035) started by @madmax983*