### PR TITLE
🎸 Bard: Documenting Havoc Proptests

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,6 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+## 2024-06-26 - Documenting Proptests
+**Confusion:** Fuzzing and proptest files were triggering missing documentation warnings.
+**Clarification:** Suppressed warnings using `#![allow(missing_docs)]` since internal testing files do not strictly require comprehensive public API documentation for end-users.

--- a/crates/duke-bytecode/src/fuzz.rs
+++ b/crates/duke-bytecode/src/fuzz.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 #[cfg(test)]
 mod tests {
     use crate::decoder::decode;

--- a/crates/duke-classfile/src/fuzz.rs
+++ b/crates/duke-classfile/src/fuzz.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 #[cfg(test)]
 mod tests {
     use crate::parse;

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -1,4 +1,8 @@
-//! `duke-classfile::parser` — JVM `.class` file parser implementation
+//! JVM `.class` file parser implementation.
+//!
+//! This module implements the main parsing logic for reading raw binary byte slices
+//! and decoding them into a structured `ClassFile` representation according to the JVM
+//! specification. It is designed to be panic-free on arbitrary input.
 
 use crate::{
     access_flags::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags},

--- a/crates/duke-classfile/tests/havoc_classfile_proptest.rs
+++ b/crates/duke-classfile/tests/havoc_classfile_proptest.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use proptest::prelude::*;
 
 proptest! {

--- a/crates/duke-gc/src/fuzz.rs
+++ b/crates/duke-gc/src/fuzz.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 #[cfg(test)]
 mod tests {
     use crate::Heap;

--- a/crates/duke-interpreter/src/fuzz.rs
+++ b/crates/duke-interpreter/src/fuzz.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::large_stack_arrays)]

--- a/crates/duke-loader/src/fuzz.rs
+++ b/crates/duke-loader/src/fuzz.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 #[cfg(test)]
 mod tests {
     use crate::ZipLoader;

--- a/crates/duke-runtime/src/fuzz.rs
+++ b/crates/duke-runtime/src/fuzz.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 #[cfg(test)]
 mod tests {
     use crate::frame::Frame;

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
📖 Chapter: Documenting Proptests
🔦 Insight: Fuzzing and proptest files were triggering missing documentation warnings.
🧪 Example: Suppressed warnings using `#![allow(missing_docs)]` since internal testing files do not strictly require comprehensive public API documentation for end-users, avoiding false and noisy `//!` module comments. Also fixed some build errors in `duke/src/jar_diff.rs` and added module docs to `crates/duke-classfile/src/parser.rs`.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [107925420475295803](https://jules.google.com/task/107925420475295803) started by @madmax983*