### PR TITLE
⚡ Bolt: String replacement optimizations

### DIFF
--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -16548,10 +16548,22 @@ pub(crate) fn native_string_replace_char(
     _control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let s = heap.get(this_ref)?.string_value.clone().unwrap_or_default();
     let old_char = char::from_u32(extract_int_arg(args, 1)?.cast_unsigned()).unwrap_or('?');
     let new_char = char::from_u32(extract_int_arg(args, 2)?.cast_unsigned()).unwrap_or('?');
-    let result = s.replace(old_char, &new_char.to_string());
+
+    let s = heap.get(this_ref)?.string_value.as_deref().unwrap_or_default();
+
+    // ⚡ Bolt: Use a single pass over string chars, appending conditionally.
+    // This avoids the intermediate String allocation from s.replace(), and new_char.to_string()
+    let mut result = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c == old_char {
+            result.push(new_char);
+        } else {
+            result.push(c);
+        }
+    }
+
     let r = heap.allocate_string(result);
     Ok(Some(Slot::Reference(Some(r))))
 }
@@ -16564,20 +16576,17 @@ pub(crate) fn native_string_replace_charsequence(
     _control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let s = heap.get(this_ref)?.string_value.clone().unwrap_or_default();
     let target_ref = extract_ref_arg(args, 1)?;
-    let target = heap
-        .get(target_ref)?
-        .string_value
-        .clone()
-        .unwrap_or_default();
     let replacement_ref = extract_ref_arg(args, 2)?;
-    let replacement = heap
-        .get(replacement_ref)?
-        .string_value
-        .clone()
-        .unwrap_or_default();
-    let result = s.replace(&*target, &replacement);
+
+    // ⚡ Bolt: Eliminate multiple `String` heap allocations by avoiding `.clone()` and retrieving string slices
+    let result = {
+        let s = heap.get(this_ref)?.string_value.as_deref().unwrap_or_default();
+        let target = heap.get(target_ref)?.string_value.as_deref().unwrap_or_default();
+        let replacement = heap.get(replacement_ref)?.string_value.as_deref().unwrap_or_default();
+        s.replace(target, replacement)
+    };
+
     let r = heap.allocate_string(result);
     Ok(Some(Slot::Reference(Some(r))))
 }

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
💡 What: Converted two `java/lang/String` replacement native functions (`native_string_replace_char` and `native_string_replace_charsequence`) to directly operate on string slices rather than using `.clone().unwrap_or_default()`. In `native_string_replace_char`, swapped out the `.replace()` call for a fast single-pass string scan using `String::with_capacity`.
🎯 Why: Heap allocations block the hot path of basic primitive string replacement operations within the JVM logic.
📊 Impact: Eliminates multiple heap allocations per call for String replacement methods, which are frequent operations in string-heavy Java applications.
🔬 Measurement: Verified there were zero regressions in correctness via existing `cargo test` suite, while checking execution metrics and allocations.

---
*PR created automatically by Jules for task [17246911812300250949](https://jules.google.com/task/17246911812300250949) started by @madmax983*