### PR TITLE
⚡ Bolt: Eliminate intermediate string allocations in String native methods

### DIFF
--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -16520,9 +16520,16 @@ pub(crate) fn native_string_touppercase(
     _out: &mut dyn Write,
     _control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
+    // ⚡ Bolt Optimization: Eliminated intermediate String heap allocation by using
+    // `.as_deref()` inside a scoped block. This allows us to perform the `to_uppercase`
+    // operation directly on the borrowed string slice (`&str`) without cloning the original,
+    // and correctly drops the immutable heap borrow before calling `heap.allocate_string()`.
     let this_ref = extract_ref_arg(args, 0)?;
-    let s = heap.get(this_ref)?.string_value.clone().unwrap_or_default();
-    let r = heap.allocate_string(s.to_uppercase());
+    let result = {
+        let s = heap.get(this_ref)?.string_value.as_deref().unwrap_or_default();
+        s.to_uppercase()
+    };
+    let r = heap.allocate_string(result);
     Ok(Some(Slot::Reference(Some(r))))
 }
 
@@ -16533,9 +16540,16 @@ pub(crate) fn native_string_tolowercase(
     _out: &mut dyn Write,
     _control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
+    // ⚡ Bolt Optimization: Eliminated intermediate String heap allocation by using
+    // `.as_deref()` inside a scoped block. This allows us to perform the `to_lowercase`
+    // operation directly on the borrowed string slice (`&str`) without cloning the original,
+    // and correctly drops the immutable heap borrow before calling `heap.allocate_string()`.
     let this_ref = extract_ref_arg(args, 0)?;
-    let s = heap.get(this_ref)?.string_value.clone().unwrap_or_default();
-    let r = heap.allocate_string(s.to_lowercase());
+    let result = {
+        let s = heap.get(this_ref)?.string_value.as_deref().unwrap_or_default();
+        s.to_lowercase()
+    };
+    let r = heap.allocate_string(result);
     Ok(Some(Slot::Reference(Some(r))))
 }
 
@@ -16547,11 +16561,19 @@ pub(crate) fn native_string_replace_char(
     _out: &mut dyn Write,
     _control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
+    // ⚡ Bolt Optimization: Eliminated intermediate String heap allocation for both
+    // the target string and the replacement character.
+    // 1. Used `.as_deref()` in a scoped block to borrow the original string without cloning.
+    // 2. Used `char::encode_utf8(&mut [0; 4])` with a stack-allocated buffer instead of
+    //    `new_char.to_string()` to create a zero-cost `&str` for the replacement.
     let this_ref = extract_ref_arg(args, 0)?;
-    let s = heap.get(this_ref)?.string_value.clone().unwrap_or_default();
     let old_char = char::from_u32(extract_int_arg(args, 1)?.cast_unsigned()).unwrap_or('?');
     let new_char = char::from_u32(extract_int_arg(args, 2)?.cast_unsigned()).unwrap_or('?');
-    let result = s.replace(old_char, &new_char.to_string());
+    let result = {
+        let s = heap.get(this_ref)?.string_value.as_deref().unwrap_or_default();
+        let mut b = [0; 4];
+        s.replace(old_char, new_char.encode_utf8(&mut b))
+    };
     let r = heap.allocate_string(result);
     Ok(Some(Slot::Reference(Some(r))))
 }
@@ -16563,21 +16585,22 @@ pub(crate) fn native_string_replace_charsequence(
     _out: &mut dyn Write,
     _control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
+    // ⚡ Bolt Optimization: Eliminated three intermediate String heap allocations by
+    // replacing `.clone()` with `.as_deref()` inside a scoped block. This allows
+    // `str::replace` to operate directly on the borrowed string slices (`&str`),
+    // keeping memory footprint minimal and properly managing lifetimes before the
+    // final `heap.allocate_string()` call.
     let this_ref = extract_ref_arg(args, 0)?;
-    let s = heap.get(this_ref)?.string_value.clone().unwrap_or_default();
     let target_ref = extract_ref_arg(args, 1)?;
-    let target = heap
-        .get(target_ref)?
-        .string_value
-        .clone()
-        .unwrap_or_default();
     let replacement_ref = extract_ref_arg(args, 2)?;
-    let replacement = heap
-        .get(replacement_ref)?
-        .string_value
-        .clone()
-        .unwrap_or_default();
-    let result = s.replace(&*target, &replacement);
+
+    let result = {
+        let s = heap.get(this_ref)?.string_value.as_deref().unwrap_or_default();
+        let target = heap.get(target_ref)?.string_value.as_deref().unwrap_or_default();
+        let replacement = heap.get(replacement_ref)?.string_value.as_deref().unwrap_or_default();
+        s.replace(target, replacement)
+    };
+
     let r = heap.allocate_string(result);
     Ok(Some(Slot::Reference(Some(r))))
 }

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +15,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +35,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
💡 What: Replaced `.clone()` calls on `string_value` with `.as_deref()` inside scoped blocks for `String` native methods (`toUpperCase`, `toLowerCase`, `replace`). In `replace_char`, switched `new_char.to_string()` to `new_char.encode_utf8(&mut [0; 4])`. Also included minimal fixes to `duke/src/jar_diff.rs` to fix build breaks (flattened imports, explicit closure type annotations).
🎯 Why: To eliminate expensive and unnecessary intermediate `String` heap allocations on the hot path without fighting the borrow checker.
📊 Impact: Reduces heap allocations by 1-3 allocations per `String.replace` or case conversion native call.
🔬 Measurement: Verify by running `cargo test --all-targets --all-features`.

---
*PR created automatically by Jules for task [16870183173781285591](https://jules.google.com/task/16870183173781285591) started by @madmax983*