### PR TITLE
⚒️ Forge: Extract and flatten decoder match blocks

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,8 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+
+## 2024-06-29 - Flattening Match Blocks
+**Learning:** `decode_one` contained inline match logic (`op::POP..=op::SWAP`) and a massive ~80-line helper `decode_load_store_op` that handled both loads and stores in a single `match` statement. This makes functions harder to read and breaks homogeneity.
+**Action:** Extracted the inline stack ops into `decode_stack_op` and split the massive load/store match into `decode_load_op` and `decode_store_op` to drastically improve readability and flatten nesting.

--- a/crates/duke-bytecode/src/decoder.rs
+++ b/crates/duke-bytecode/src/decoder.rs
@@ -145,9 +145,8 @@ fn decode_constant_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
         _ => unreachable!(),
     })
 }
-fn decode_load_store_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
+fn decode_load_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
     Ok(match opcode {
-        // -- Loads -----------------------------------------------------------
         op::ILOAD => Instruction::Iload(c.read_u8()?),
         op::LLOAD => Instruction::Lload(c.read_u8()?),
         op::FLOAD => Instruction::Fload(c.read_u8()?),
@@ -181,7 +180,12 @@ fn decode_load_store_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
         op::BALOAD => Instruction::Baload,
         op::CALOAD => Instruction::Caload,
         op::SALOAD => Instruction::Saload,
-        // -- Stores ----------------------------------------------------------
+        _ => unreachable!(),
+    })
+}
+
+fn decode_store_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
+    Ok(match opcode {
         op::ISTORE => Instruction::Istore(c.read_u8()?),
         op::LSTORE => Instruction::Lstore(c.read_u8()?),
         op::FSTORE => Instruction::Fstore(c.read_u8()?),
@@ -218,6 +222,22 @@ fn decode_load_store_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
         _ => unreachable!(),
     })
 }
+#[allow(clippy::unnecessary_wraps)]
+fn decode_stack_op(opcode: u8) -> Result<Instruction> {
+    Ok(match opcode {
+        op::POP => Instruction::Pop,
+        op::POP2 => Instruction::Pop2,
+        op::DUP => Instruction::Dup,
+        op::DUP_X1 => Instruction::DupX1,
+        op::DUP_X2 => Instruction::DupX2,
+        op::DUP2 => Instruction::Dup2,
+        op::DUP2_X1 => Instruction::Dup2X1,
+        op::DUP2_X2 => Instruction::Dup2X2,
+        op::SWAP => Instruction::Swap,
+        _ => unreachable!(),
+    })
+}
+
 fn decode_math_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
     Ok(match opcode {
         op::IADD => Instruction::Iadd,
@@ -398,19 +418,9 @@ fn decode_extended_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
 fn decode_one(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> Result<Instruction> {
     match opcode {
         op::NOP..=op::LDC2_W => decode_constant_op(c, opcode),
-        op::ILOAD..=op::SASTORE => decode_load_store_op(c, opcode),
-        op::POP..=op::SWAP => Ok(match opcode {
-            op::POP => Instruction::Pop,
-            op::POP2 => Instruction::Pop2,
-            op::DUP => Instruction::Dup,
-            op::DUP_X1 => Instruction::DupX1,
-            op::DUP_X2 => Instruction::DupX2,
-            op::DUP2 => Instruction::Dup2,
-            op::DUP2_X1 => Instruction::Dup2X1,
-            op::DUP2_X2 => Instruction::Dup2X2,
-            op::SWAP => Instruction::Swap,
-            _ => unreachable!(),
-        }),
+        op::ILOAD..=op::SALOAD => decode_load_op(c, opcode),
+        op::ISTORE..=op::SASTORE => decode_store_op(c, opcode),
+        op::POP..=op::SWAP => decode_stack_op(opcode),
         op::IADD..=op::IINC => decode_math_op(c, opcode),
         op::I2L..=op::I2S => decode_conversion_op(opcode),
         op::LCMP..=op::RETURN => decode_control_flow_op(c, opcode, pc),


### PR DESCRIPTION
🚮 **Smell**: `decode_one` contained an inline match arm for stack operations (`op::POP..=op::SWAP`) that broke the homogenous helper pattern. Additionally, `decode_load_store_op` was a massive 80-line match block handling both loads and stores together.
✨ **Solution**: Extracted the stack logic into `decode_stack_op`. Split the massive load/store match block into `decode_load_op` and `decode_store_op`, updating the dispatch in `decode_one`.
🧼 **Benefit**: Flattens nested blocks, completely eliminates "God Match Blocks" from the main loop, keeps helper logic cleanly separated, and strictly adheres to Forge principles.
🛡️ **Verification**: Tests passed successfully without any changes to runtime logic. CI format and clippy checks pass.

---
*PR created automatically by Jules for task [11179932646245063152](https://jules.google.com/task/11179932646245063152) started by @madmax983*