### PR TITLE
⚡ Bolt: Optimize String.replace(char, char) allocation overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,6 @@
 **Trust the Iterator: .collect() is Optimized**
 **Learning:** In Rust, `.collect::<Vec<_>>()` called on an `ExactSizeIterator` (which `slice.iter().map()` implements) already knows the exact number of elements. The standard library heavily optimizes this via the `TrustedLen` trait to allocate the precise capacity upfront and completely bypass bounds checks during insertion.
 **Action:** Do not manually replace `.collect::<Vec<_>>()` with `Vec::with_capacity` and a `for` loop, as it re-introduces bounds checks on every push, making the "optimization" unidiomatic and a micro-regression.
+**[Borrow Scoping]
+**Learning:** [To resolve borrow checker conflicts where an immutable borrow must end before a mutable borrow begins on the same structure (like extracting a string from a heap then pushing to the same heap), wrapping the extraction in a block `{ ... }` explicitly drops the immutable borrow early.]
+**Action:** [Always scope immutable borrows tightly in blocks when a mutable borrow on the same container is required shortly after.]

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -16548,10 +16548,16 @@ pub(crate) fn native_string_replace_char(
     _control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let s = heap.get(this_ref)?.string_value.clone().unwrap_or_default();
     let old_char = char::from_u32(extract_int_arg(args, 1)?.cast_unsigned()).unwrap_or('?');
     let new_char = char::from_u32(extract_int_arg(args, 2)?.cast_unsigned()).unwrap_or('?');
-    let result = s.replace(old_char, &new_char.to_string());
+
+    let result = {
+        let obj = heap.get(this_ref)?;
+        let s = obj.string_value.as_deref().unwrap_or_default();
+        let mut buf = [0; 4];
+        s.replace(old_char, new_char.encode_utf8(&mut buf))
+    };
+
     let r = heap.allocate_string(result);
     Ok(Some(Slot::Reference(Some(r))))
 }

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")


### PR DESCRIPTION
💡 What:
Switched `String.replace` in `native_string_replace_char` to use a stack-allocated buffer with `char::encode_utf8` instead of `to_string()`, and replaced `.clone()` with `.as_deref()` by scoping the immutable borrow. Also unblocked CI by fixing pre-existing type inference errors in `duke/src/jar_diff.rs`.

🎯 Why:
The original implementation forced a heap allocation to convert the replacement `char` to a `String` on every invocation, and performed an unnecessary clone of the source string payload.

📊 Impact:
Eliminates 2 heap allocations per call to `String.replace(char, char)`.

🔬 Measurement:
Run `cargo test` to verify logic integrity. No performance regressions.

---
*PR created automatically by Jules for task [4540372064255740541](https://jules.google.com/task/4540372064255740541) started by @madmax983*