### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,6 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+## 2024-05-25 - [Ghost Parameters in Documentation]
+**Confusion:** Many public functions have undocumented parameters (Ghost Params) that are not mentioned in their docstrings, violating the 'Ghost Param' rule.
+**Clarification:** Updated docstrings to explicitly mention and explain the purpose of all parameters, especially for core utility functions like `cp_utf8` and `resolve_attributes`.

--- a/crates/duke-bytecode/src/call_graph.rs
+++ b/crates/duke-bytecode/src/call_graph.rs
@@ -75,7 +75,7 @@ fn extract_method_ref(cf: &ClassFile, idx: CpIndex) -> Option<(String, String, S
 ///
 /// **Why it exists:** Navigating method invocations across a codebase manually is
 /// error-prone. This function automates the creation of a visual Call Graph by tracing
-/// all `invoke*` instructions, making it easier to see dependencies and side effects.
+/// all `invoke*` instructions in the given `cf` (`ClassFile`), making it easier to see dependencies and side effects.
 ///
 /// Generates a Mermaid call graph (CFG) from a given Java class file.
 ///

--- a/crates/duke-bytecode/src/reachability.rs
+++ b/crates/duke-bytecode/src/reachability.rs
@@ -122,7 +122,10 @@ pub fn find_dead_blocks(blocks: &[BasicBlock], entry_pc: usize) -> Vec<usize> {
 /// Finds the shortest execution path (in terms of basic block transitions)
 /// from the entry block to a target block.
 ///
-/// This uses Breadth-First Search (BFS) to traverse the control flow graph.
+/// This uses Breadth-First Search (BFS) to traverse the control flow graph constructed from
+/// the given `blocks`. It finds the shortest sequence of block transitions starting from the
+/// block with `start_pc` to the block with `target_pc`.
+///
 /// It is useful for test generation, coverage analysis, and finding the
 /// quickest way to reach a specific block of bytecode.
 ///

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -408,6 +408,9 @@ fn parse_attribute(c: &mut Cursor<'_>, _cp_len: usize) -> Result<AttributeInfo> 
 
 /// Resolve raw attributes into typed forms using the constant pool.
 ///
+/// Modifies the `attrs` slice in place, decoding `Raw` bytes into structured attributes like `Code`
+/// or `LineNumberTable` using the entries from the `pool`.
+///
 /// Called after the whole class file is parsed, when we have the full CP.
 /// ⚡ Bolt: Pre-allocates vectors for known attribute table sizes to eliminate intermediate heap allocations.
 pub fn resolve_attributes(attrs: &mut [AttributeInfo], pool: &[Option<CpEntry>]) -> Result<()> {
@@ -615,6 +618,9 @@ fn parse_code_attribute(c: &mut Cursor<'_>) -> Result<CodeAttribute> {
 // ---------------------------------------------------------------------------
 
 /// Look up a UTF-8 string in the constant pool.
+///
+/// Retrieves the `Utf8` entry at the specified `idx` from the `pool`. Returns an error
+/// if the index is invalid or points to a different entry type.
 pub fn cp_utf8(pool: &[Option<CpEntry>], idx: CpIndex) -> Result<&str> {
     let i = idx.0 as usize;
     if i == 0 {

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "nova")]
 use duke_classfile::{
     parse,
-    types::{AttributeData, CpEntry, CpIndex},
+    AttributeData, CpEntry, CpIndex,
 };
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
@@ -18,7 +18,7 @@ use std::path::Path;
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
     cf.constant_pool
         .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
+        .and_then(|slot: &Option<CpEntry>| slot.as_ref())
         .and_then(|entry| {
             if let CpEntry::Utf8(s) = entry {
                 Some(s.as_str())
@@ -38,7 +38,7 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     let class_entry = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
+        .and_then(|s: &Option<CpEntry>| s.as_ref());
     if let Some(CpEntry::Class { name_index }) = class_entry {
         cp_str(cf, *name_index)
             .unwrap_or("<invalid utf8>")

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,16 +1,4 @@
-🧨 **The Trigger:**
-Concurrent threads throwing Java exceptions with the same class name (e.g. `java/lang/IllegalArgumentException`) clobbered each other's pending state.
-
-📉 **The Stack Trace:**
-```
-thread 'test_pending_exception_state_leak' panicked at crates/duke-interpreter/tests/havoc_pending_exceptions_loom.rs:33:9:
-assertion `left == right` failed: Thread 1 received wrong exception message!
-  left: "thread2_error"
- right: "thread1_error"
-```
-
-🧪 **Reproduction:**
-Run `cargo test --test havoc_pending_exceptions_loom` (added in this PR).
-
-😈 **Comment:**
-You assumed exceptions in a multi-threaded VM wouldn't race. You put them in a global `HashMap` keyed only by the `class_name`. You were wrong. They are now scoped by `(std::thread::ThreadId, class_name)`.
+📖 Chapter: Fleshing Out Ghost Parameters
+💡 Insight: Multiple functions throughout the workspace (like `cp_utf8`, `resolve_attributes`, `find_shortest_path`, and `generate_mermaid_call_graph`) had parameters that were not explicitly mentioned or explained in their corresponding doc comments. This violates the "Ghost Param" rule where developers are left wondering what role a specific parameter plays.
+🧪 Example: For instance, `find_shortest_path` now clearly articulates how `blocks`, `start_pc`, and `target_pc` are utilized in the BFS algorithm.
+🖼️ Preview: (Viewable via `cargo doc --open`)


### PR DESCRIPTION
📖 Chapter: Fleshing Out Ghost Parameters
💡 Insight: Multiple functions throughout the workspace (like `cp_utf8`, `resolve_attributes`, `find_shortest_path`, and `generate_mermaid_call_graph`) had parameters that were not explicitly mentioned or explained in their corresponding doc comments. This violates the "Ghost Param" rule where developers are left wondering what role a specific parameter plays.
🧪 Example: For instance, `find_shortest_path` now clearly articulates how `blocks`, `start_pc`, and `target_pc` are utilized in the BFS algorithm.
🖼️ Preview: (Viewable via `cargo doc --open`)

---
*PR created automatically by Jules for task [11964921652848787583](https://jules.google.com/task/11964921652848787583) started by @madmax983*