### PR TITLE
⚡ Bolt: [Zero-cost abstraction for String.replace(char, char)]

### DIFF
--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -16540,6 +16540,7 @@ pub(crate) fn native_string_tolowercase(
 }
 
 /// Native: `String.replace(char, char)` — replaces all occurrences of old char with new char.
+/// ⚡ Bolt: Avoids allocating a String by encoding the char directly into a stack buffer.
 #[allow(clippy::cast_sign_loss)]
 pub(crate) fn native_string_replace_char(
     args: &[Slot],
@@ -16551,7 +16552,9 @@ pub(crate) fn native_string_replace_char(
     let s = heap.get(this_ref)?.string_value.clone().unwrap_or_default();
     let old_char = char::from_u32(extract_int_arg(args, 1)?.cast_unsigned()).unwrap_or('?');
     let new_char = char::from_u32(extract_int_arg(args, 2)?.cast_unsigned()).unwrap_or('?');
-    let result = s.replace(old_char, &new_char.to_string());
+    // ⚡ Bolt: Avoid allocating a String by encoding the char directly into a stack buffer
+    let mut buf = [0; 4];
+    let result = s.replace(old_char, new_char.encode_utf8(&mut buf));
     let r = heap.allocate_string(result);
     Ok(Some(Slot::Reference(Some(r))))
 }


### PR DESCRIPTION
💡 What: Replaced `new_char.to_string()` with `new_char.encode_utf8(&mut buf)` in `native_string_replace_char`.
🎯 Why: `char::to_string()` allocates a new `String` on the heap just to pass a string slice to `s.replace()`. This creates unnecessary memory allocations on a potentially hot path when processing strings character by character.
📊 Impact: Eliminates one intermediate `String` heap allocation per call to `String.replace(char, char)`.
🔬 Measurement: Run `cargo test` and verify memory profiles using `cargo bench` or equivalent tools to observe the reduced allocation pressure.

---
*PR created automatically by Jules for task [86850251801441837](https://jules.google.com/task/86850251801441837) started by @madmax983*