### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -598,4 +598,128 @@ mod tests {
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("java/lang/Exception"));
     }
+
+    #[test]
+    #[cfg(feature = "telemetry")]
+    fn test_print_bytecode_cost_io_error() {
+        struct FailingWriter;
+        impl std::io::Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("disk full"))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut store = crate::TelemetryStore::default();
+        store.bytecode_cost.record("iadd", "Foo", "bar", 10, 100);
+        let mut w = FailingWriter;
+        assert!(store.print_bytecode_cost(&mut w).is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "telemetry")]
+    fn test_print_object_lineage_io_error() {
+        struct FailingWriter;
+        impl std::io::Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("disk full"))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut store = crate::TelemetryStore::default();
+        store
+            .object_lineage
+            .record("java/lang/String", "Foo", 10, "bar");
+        let mut w = FailingWriter;
+        assert!(store.print_object_lineage(&mut w).is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "telemetry")]
+    fn test_print_class_init_dag_io_error() {
+        struct FailingWriter;
+        impl std::io::Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("disk full"))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut store = crate::TelemetryStore::default();
+        store
+            .class_init_dag
+            .record("java/lang/String", "java/lang/System", 500);
+        let mut w = FailingWriter;
+        assert!(store.print_class_init_dag(&mut w).is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "telemetry")]
+    fn test_print_exception_flow_io_error() {
+        struct FailingWriter;
+        impl std::io::Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("disk full"))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut store = crate::TelemetryStore::default();
+        store
+            .exception_flow
+            .record_throw("java/lang/Exception", "Foo", "bar", 10);
+        let mut w = FailingWriter;
+        assert!(store.print_exception_flow(&mut w).is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "telemetry")]
+    fn test_print_dispatch_resolution_io_error() {
+        struct FailingWriter;
+        impl std::io::Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("disk full"))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut store = crate::TelemetryStore::default();
+        store
+            .dispatch_resolution
+            .record("Foo", 42, "java/lang/String", true);
+        let mut w = FailingWriter;
+        assert!(store.print_dispatch_resolution(&mut w).is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "telemetry")]
+    fn test_print_native_boundary_io_error() {
+        struct FailingWriter;
+        impl std::io::Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("disk full"))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut store = crate::TelemetryStore::default();
+        store
+            .native_boundary
+            .record_call("java/lang/String", "intern", 100, true);
+        let mut w = FailingWriter;
+        assert!(store.print_native_boundary(&mut w).is_err());
+    }
 }

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};


### PR DESCRIPTION
🎯 **Target:** `TelemetryStore::print_*` functions in `crates/duke-telemetry/src/lib.rs` (e.g., `print_bytecode_cost`, `print_object_lineage`, `print_class_init_dag`, `print_exception_flow`, `print_dispatch_resolution`, `print_native_boundary`).

💣 **Risk:** The `print_*` functions use `writeln!` which can fail (e.g., if a buffer is full, network stream closes, or standard out is broken). If these underlying IO errors propagate up unchecked, they might cause unexpected panics or unhandled errors later in the VM telemetry shutdown sequence. The `Result::Err` path must be validated to ensure they correctly return the error to the caller rather than panicking internally.

🧪 **Strategy:** Added targeted unit tests at the bottom of the module in the `#[cfg(test)] mod tests` block. I created a mock `FailingWriter` struct that unconditionally returns an `std::io::Error::other("disk full")`. We instantiate a `TelemetryStore`, record a synthetic event, and verify that passing the `FailingWriter` correctly results in `Err` being returned from each specific `print_*` function using `assert!(...is_err())`.

🔬 **Verification:** 
```bash
cargo test -p duke-telemetry
```

---
*PR created automatically by Jules for task [6443785636570813536](https://jules.google.com/task/6443785636570813536) started by @madmax983*