### PR TITLE
🛡️ Sentry: Add coverage for telemetry print methods

### DIFF
--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -598,4 +598,28 @@ mod tests {
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("java/lang/Exception"));
     }
+
+    #[test]
+    fn test_print_dispatch_resolution_with_less_than_10() {
+        let mut store = crate::TelemetryStore::default();
+        store
+            .dispatch_resolution
+            .record("Foo", 42, "java/lang/String", true);
+        let mut buf = Vec::new();
+        store.print_dispatch_resolution(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("Foo[cp42] calls=1 targets=1 walks=1"));
+    }
+
+    #[test]
+    fn test_print_native_boundary_with_less_than_10() {
+        let mut store = crate::TelemetryStore::default();
+        store
+            .native_boundary
+            .record_call("java/lang/String", "intern", 100, true);
+        let mut buf = Vec::new();
+        store.print_native_boundary(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("java/lang/String.intern calls=1 errors=1"));
+    }
 }


### PR DESCRIPTION
* 🎯 **Target:** `TelemetryStore::print_dispatch_resolution` and `TelemetryStore::print_native_boundary` in `crates/duke-telemetry/src/lib.rs`.
* 💣 **Risk:** The previous lack of coverage meant that formatting changes or logic errors when iterating through less than 10 telemetry events could silently break the console reporting output without CI noticing.
* 🧪 **Strategy:** Added targeted unit tests (`test_print_dispatch_resolution_with_less_than_10` and `test_print_native_boundary_with_less_than_10`) inside the existing test module to hit the formatting logic for these edge cases and ensure string contents match expectations.
* 🔬 **Verification:** `cargo test -p duke-telemetry`

---
*PR created automatically by Jules for task [17621880695680457395](https://jules.google.com/task/17621880695680457395) started by @madmax983*