### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/crates/duke-loader/src/lib.rs
+++ b/crates/duke-loader/src/lib.rs
@@ -62,6 +62,17 @@ pub(crate) fn path_to_file_url(path: &Path) -> String {
 /// Abstraction over class file loading sources.
 ///
 /// `name` is internal form: `"java/lang/Object"` (no `.class` suffix).
+///
+/// # Examples
+///
+/// ```
+/// use std::path::PathBuf;
+/// use duke_loader::{ClassLoader, DirectoryLoader};
+///
+/// let loader = DirectoryLoader::new(PathBuf::from("my_classes"));
+/// // Load the raw `.class` bytes for `com/example/Main.class`
+/// let _result = loader.find_class("com/example/Main");
+/// ```
 pub trait ClassLoader {
     /// Load the raw `.class` bytes for a class.
     ///


### PR DESCRIPTION
📖 Chapter: The `ClassLoader` trait in `duke-loader` module.
🔦 Insight: Explained and demonstrated how to initialize a loader and resolve a class using `DirectoryLoader` as an example to fulfill the "Hero's Journey" usage requirement.
🧪 Example: Added 1 executable doctest showing `DirectoryLoader::new()` and `.find_class()`.
🖼️ Preview: (Ran `cargo doc --open` to verify layout visually, shows `# Examples` clearly below trait docs).

---
*PR created automatically by Jules for task [8059632418407735377](https://jules.google.com/task/8059632418407735377) started by @madmax983*