### PR TITLE
⚒️ Forge: Refactor jar_diff to improve readability using guard clauses

### DIFF
--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{parse, AttributeData, CpEntry, CpIndex};
+use duke_classfile::{AttributeData, CpEntry, CpIndex, parse};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -28,7 +28,10 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
         return "<none>".to_string();
     }
 
-    let entry = cf.constant_pool.get(idx.0 as usize).and_then(|s| s.as_ref());
+    let entry = cf
+        .constant_pool
+        .get(idx.0 as usize)
+        .and_then(|s| s.as_ref());
     let Some(CpEntry::Class { name_index }) = entry else {
         return "<not a class ref>".to_string();
     };

--- a/duke/src/jar_diff.rs
+++ b/duke/src/jar_diff.rs
@@ -2,10 +2,7 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 #[cfg(feature = "nova")]
-use duke_classfile::{
-    parse,
-    types::{AttributeData, CpEntry, CpIndex},
-};
+use duke_classfile::{parse, AttributeData, CpEntry, CpIndex};
 #[cfg(feature = "nova")]
 use duke_loader::{ClassLoader, ZipLoader};
 use std::collections::{HashMap, HashSet};
@@ -16,16 +13,11 @@ use std::path::Path;
 #[cfg(not(tarpaulin_include))]
 #[allow(unexpected_cfgs)]
 fn cp_str(cf: &duke_classfile::ClassFile, idx: CpIndex) -> Option<&str> {
-    cf.constant_pool
-        .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
-        .and_then(|entry| {
-            if let CpEntry::Utf8(s) = entry {
-                Some(s.as_str())
-            } else {
-                None
-            }
-        })
+    let entry = cf.constant_pool.get(idx.0 as usize)?.as_ref()?;
+    let CpEntry::Utf8(s) = entry else {
+        return None;
+    };
+    Some(s.as_str())
 }
 
 #[cfg(feature = "nova")]
@@ -35,17 +27,15 @@ fn resolve_class_name(cf: &duke_classfile::ClassFile, idx: CpIndex) -> String {
     if idx.0 == 0 {
         return "<none>".to_string();
     }
-    let class_entry = cf
-        .constant_pool
-        .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
-    if let Some(CpEntry::Class { name_index }) = class_entry {
-        cp_str(cf, *name_index)
-            .unwrap_or("<invalid utf8>")
-            .to_string()
-    } else {
-        "<not a class ref>".to_string()
-    }
+
+    let entry = cf.constant_pool.get(idx.0 as usize).and_then(|s| s.as_ref());
+    let Some(CpEntry::Class { name_index }) = entry else {
+        return "<not a class ref>".to_string();
+    };
+
+    cp_str(cf, *name_index)
+        .unwrap_or("<invalid utf8>")
+        .to_string()
 }
 
 #[cfg(feature = "nova")]
@@ -151,25 +141,27 @@ fn load_jar_methods(jar_path: &str) -> HashMap<String, u64> {
 
     for entry_name in class_entries {
         let class_name_internal = entry_name.strip_suffix(".class").unwrap();
-        if let Ok(bytes) = loader.find_class(class_name_internal) {
-            #[allow(clippy::collapsible_if)]
-            if let Ok(cf) = parse(&bytes) {
-                let class_name = resolve_class_name(&cf, cf.this_class);
+        let Ok(bytes) = loader.find_class(class_name_internal) else {
+            continue;
+        };
+        let Ok(cf) = parse(&bytes) else {
+            continue;
+        };
 
-                for method in &cf.methods {
-                    let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
-                    let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
-                    let full_name = format!("{class_name}::{name_str}{desc_str}");
+        let class_name = resolve_class_name(&cf, cf.this_class);
 
-                    let mut hasher = DefaultHasher::new();
-                    for attr in &method.attributes {
-                        if let AttributeData::Code(code) = &attr.data {
-                            code.code.hash(&mut hasher);
-                        }
-                    }
-                    method_hashes.insert(full_name, hasher.finish());
+        for method in &cf.methods {
+            let name_str = cp_str(&cf, method.name_index).unwrap_or("<invalid>");
+            let desc_str = cp_str(&cf, method.descriptor_index).unwrap_or("<invalid>");
+            let full_name = format!("{class_name}::{name_str}{desc_str}");
+
+            let mut hasher = DefaultHasher::new();
+            for attr in &method.attributes {
+                if let AttributeData::Code(code) = &attr.data {
+                    code.code.hash(&mut hasher);
                 }
             }
+            method_hashes.insert(full_name, hasher.finish());
         }
     }
     method_hashes


### PR DESCRIPTION
🚮 Smell: Deeply nested `and_then` and `if let` blocks ("Pyramid of Doom") in `cp_str`, `resolve_class_name`, and `load_jar_methods` within `duke/src/jar_diff.rs`.
✨ Solution: Extracted the logic and flattened the control flow using early-return guard clauses (`let ... else`) to break out of complex nested blocks. Also, fixed the compilation issue with the types import.
🧼 Benefit: Significantly reduces cognitive load by eliminating deep nesting, improving code readability and making error paths explicitly handleable early on.
🛡️ Verification: Tests passed. No runtime logic was changed. Run `cargo fmt`, `cargo clippy`, and `cargo test`.

---
*PR created automatically by Jules for task [16341294169938091347](https://jules.google.com/task/16341294169938091347) started by @madmax983*