### PR TITLE
⚡ Bolt: Remove unnecessary heap allocation in jul_manager_find_logger_by_name

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,6 @@
 **Trust the Iterator: .collect() is Optimized**
 **Learning:** In Rust, `.collect::<Vec<_>>()` called on an `ExactSizeIterator` (which `slice.iter().map()` implements) already knows the exact number of elements. The standard library heavily optimizes this via the `TrustedLen` trait to allocate the precise capacity upfront and completely bypass bounds checks during insertion.
 **Action:** Do not manually replace `.collect::<Vec<_>>()` with `Vec::with_capacity` and a `for` loop, as it re-introduces bounds checks on every push, making the "optimization" unidiomatic and a micro-regression.
+**Avoid Unnecessary Vector Clones**
+**Learning:** Found an unneeded O(N) heap allocation `fields.clone()` in `jul_manager_find_logger_by_name`.
+**Action:** Replaced it with an immutable borrow `&heap.get(manager_ref)?.fields` to eliminate the allocation on a heavily used search path.

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -550,22 +550,28 @@ fn jul_manager_count(heap: &duke_gc::Heap, manager_ref: u64) -> usize {
     }
 }
 
+/// Replaces the cloning of the whole fields vector (O(N) allocation) with a borrowed
+/// reference to eliminate a heap allocation in a heavily used search path.
 fn jul_manager_find_logger_by_name(
     heap: &duke_gc::Heap,
     manager_ref: u64,
     name: &str,
 ) -> Result<Option<u64>> {
-    let fields = heap.get(manager_ref)?.fields.clone();
+    let fields = &heap.get(manager_ref)?.fields;
     let count = jul_manager_count(heap, manager_ref);
     for idx in 0..count {
         let name_idx = JUL_MANAGER_LOGGERS_START + idx * 2;
         let logger_idx = name_idx + 1;
+
         let Some(Slot::Reference(Some(name_ref))) = fields.get(name_idx).copied() else {
             continue;
         };
-        if string_value_from_ref(heap, name_ref)? == name
-            && let Some(Slot::Reference(Some(logger_ref))) = fields.get(logger_idx).copied()
-        {
+
+        let Some(Slot::Reference(Some(logger_ref))) = fields.get(logger_idx).copied() else {
+            continue;
+        };
+
+        if string_value_from_ref(heap, name_ref)? == name {
             return Ok(Some(logger_ref));
         }
     }


### PR DESCRIPTION
💡 What: Replaced an unnecessary `O(N)` `.clone()` on the `fields` vector with an immutable borrow `&heap.get(manager_ref)?.fields` in `jul_manager_find_logger_by_name`. Also refactored the extraction logic using `let-else` to satisfy the borrow checker and idiomatic Rust.
🎯 Why: `jul_manager_find_logger_by_name` is a heavily used search path for logging lookup. Cloning the whole `fields` vector created unnecessary heap allocations and overhead.
📊 Impact: Eliminates a major `O(N)` heap allocation per logger lookup without sacrificing safety.
🔬 Measurement: Run `cargo test --all-targets --all-features` and `cargo bench` (if available) to verify functionality and performance.

---
*PR created automatically by Jules for task [4402352757737020535](https://jules.google.com/task/4402352757737020535) started by @madmax983*