### PR TITLE
⚒️ Forge: Flatten call graph generation with guard clauses

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**Extract method matchers and use let-else**
+**Learning:** `call_graph.rs` and other bytecode manipulation files contained large nested `if let ... && let ...` blocks for pattern matching and resolving constants. This created "Pyramids of Doom" and obfuscated business logic within the boilerplate.
+**Action:** Extract deep match logic directly into reusable helpers on the enum (like `method_invocation_target()` on `Instruction`) and replace deeply nested `if let ...` blocks with flat early-return guard clauses (`let ... else { continue; }`) to maintain low cyclomatic complexity.

--- a/crates/duke-bytecode/src/call_graph.rs
+++ b/crates/duke-bytecode/src/call_graph.rs
@@ -10,34 +10,31 @@ use duke_classfile::{
     ClassFile, {AttributeData, CpEntry, CpIndex},
 };
 
-use crate::{Instruction, decode};
+use crate::decode;
 
 fn cp_str(cf: &ClassFile, idx: CpIndex) -> Option<&str> {
-    cf.constant_pool
-        .get(idx.0 as usize)
-        .and_then(|slot| slot.as_ref())
-        .and_then(|entry| {
-            if let CpEntry::Utf8(s) = entry {
-                Some(s.as_str())
-            } else {
-                None
-            }
-        })
+    let entry = cf.constant_pool.get(idx.0 as usize)?.as_ref()?;
+    let CpEntry::Utf8(s) = entry else {
+        return None;
+    };
+    Some(s.as_str())
 }
 
 fn resolve_class_name(cf: &ClassFile, idx: CpIndex) -> &str {
     if idx.0 == 0 {
         return "<none>";
     }
-    let class_entry = cf
+    let Some(class_entry) = cf
         .constant_pool
         .get(idx.0 as usize)
-        .and_then(|s| s.as_ref());
-    if let Some(CpEntry::Class { name_index }) = class_entry {
-        cp_str(cf, *name_index).unwrap_or("<invalid utf8>")
-    } else {
-        "<not a class ref>"
-    }
+        .and_then(|s| s.as_ref())
+    else {
+        return "<not a class ref>";
+    };
+    let CpEntry::Class { name_index } = class_entry else {
+        return "<not a class ref>";
+    };
+    cp_str(cf, *name_index).unwrap_or("<invalid utf8>")
 }
 
 fn extract_method_ref(cf: &ClassFile, idx: CpIndex) -> Option<(String, String, String)> {
@@ -58,17 +55,17 @@ fn extract_method_ref(cf: &ClassFile, idx: CpIndex) -> Option<(String, String, S
     let class_name = resolve_class_name(cf, *class_idx).to_string();
 
     let nat_entry = cf.constant_pool.get(nat_idx.0 as usize)?.as_ref()?;
-    if let CpEntry::NameAndType {
+    let CpEntry::NameAndType {
         name_index,
         descriptor_index,
     } = nat_entry
-    {
-        let method_name = cp_str(cf, *name_index)?.to_string();
-        let method_desc = cp_str(cf, *descriptor_index)?.to_string();
-        Some((class_name, method_name, method_desc))
-    } else {
-        None
-    }
+    else {
+        return None;
+    };
+
+    let method_name = cp_str(cf, *name_index)?.to_string();
+    let method_desc = cp_str(cf, *descriptor_index)?.to_string();
+    Some((class_name, method_name, method_desc))
 }
 
 /// Generates a Mermaid call graph (CFG) from a class file.
@@ -122,26 +119,27 @@ pub fn generate_mermaid_call_graph(cf: &ClassFile) -> String {
         let source_id = format!("{this_class_name}::{name_str}{desc_str}");
 
         for attr in &method.attributes {
-            if let AttributeData::Code(code) = &attr.data
-                && let Ok(instructions) = decode(&code.code)
-            {
-                for (_, instr) in instructions {
-                    let target_idx = match instr {
-                        Instruction::Invokevirtual(idx)
-                        | Instruction::Invokespecial(idx)
-                        | Instruction::Invokestatic(idx)
-                        | Instruction::Invokeinterface { index: idx, .. } => Some(idx),
-                        // Invokedynamic is more complex, skip for basic call graph
-                        _ => None,
-                    };
+            let AttributeData::Code(code) = &attr.data else {
+                continue;
+            };
+            let Ok(instructions) = decode(&code.code) else {
+                continue;
+            };
 
-                    if let Some(idx) = target_idx
-                        && let Some((target_class, target_method, target_descriptor)) =
-                            extract_method_ref(cf, idx)
-                    {
-                        edges.insert(format!("    \"{source_id}\" --> \"{target_class}::{target_method}{target_descriptor}\""));
-                    }
-                }
+            for (_, instr) in instructions {
+                let Some(idx) = instr.method_invocation_target() else {
+                    continue;
+                };
+
+                let Some((target_class, target_method, target_descriptor)) =
+                    extract_method_ref(cf, idx)
+                else {
+                    continue;
+                };
+
+                edges.insert(format!(
+                    "    \"{source_id}\" --> \"{target_class}::{target_method}{target_descriptor}\""
+                ));
             }
         }
     }

--- a/crates/duke-bytecode/src/instruction.rs
+++ b/crates/duke-bytecode/src/instruction.rs
@@ -745,6 +745,20 @@ impl Instruction {
         }
     }
 
+    /// Returns the constant pool index if the instruction is a method invocation.
+    /// Excludes `invokedynamic` because its index points to a dynamically-computed call site,
+    /// not a standard method reference.
+    #[must_use]
+    pub const fn method_invocation_target(&self) -> Option<CpIndex> {
+        match self {
+            Self::Invokevirtual(idx)
+            | Self::Invokespecial(idx)
+            | Self::Invokestatic(idx)
+            | Self::Invokeinterface { index: idx, .. } => Some(*idx),
+            _ => None,
+        }
+    }
+
     /// Returns the switch targets if the instruction is a switch statement.
     /// It returns `Some((default_offset, targets_iterator))`.
     ///
@@ -1422,6 +1436,35 @@ mod tests {
         assert!(Instruction::JsrW(5).is_subroutine_call());
         assert!(!Instruction::Goto(5).is_subroutine_call());
         assert!(!Instruction::Iconst0.is_subroutine_call());
+    }
+
+    #[test]
+    fn test_method_invocation_target() {
+        assert_eq!(
+            Instruction::Invokevirtual(CpIndex(5)).method_invocation_target(),
+            Some(CpIndex(5))
+        );
+        assert_eq!(
+            Instruction::Invokespecial(CpIndex(10)).method_invocation_target(),
+            Some(CpIndex(10))
+        );
+        assert_eq!(
+            Instruction::Invokestatic(CpIndex(15)).method_invocation_target(),
+            Some(CpIndex(15))
+        );
+        assert_eq!(
+            Instruction::Invokeinterface {
+                index: CpIndex(20),
+                count: 1
+            }
+            .method_invocation_target(),
+            Some(CpIndex(20))
+        );
+        assert_eq!(
+            Instruction::Invokedynamic(CpIndex(25)).method_invocation_target(),
+            None
+        );
+        assert_eq!(Instruction::Iconst0.method_invocation_target(), None);
     }
 
     #[test]


### PR DESCRIPTION
🚬 Smell: `generate_mermaid_call_graph` in `call_graph.rs` and its helper functions (`extract_method_ref`, `resolve_class_name`, `cp_str`) were heavily nested with `if let ... && let ...` blocks ("Pyramid of Doom"). The logic for determining if an instruction was a method invocation was also manually written inline, mixing bytecode analysis logic into graph generation.

✨ Solution: 
- Extracted a `method_invocation_target()` method directly onto the `Instruction` enum to encapsulate the matching logic for method invocation opcodes.
- Refactored the `call_graph.rs` functions to use idiomatic Rust `let ... else` early-return guard clauses, significantly flattening the structure.

🧼 Benefit: Dramatically reduces cognitive load by eliminating deep nesting. Separates concerns by moving bytecode interpretation logic out of the graph generation layer and into the bytecode instruction abstraction.

🛡️ Verification: Tests passed. No logic changed. Added a specific unit test for `method_invocation_target()`.

---
*PR created automatically by Jules for task [11760817213983663733](https://jules.google.com/task/11760817213983663733) started by @madmax983*