### PR TITLE
Route Spring Boot fat JARs to bundled JarLauncher when Main-Class is absent

### DIFF
--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -838,9 +838,31 @@ fn run_main(
 // Jar
 // ---------------------------------------------------------------------------
 
+/// Internal binary name of the Spring Boot fat-JAR launcher.
+const SPRING_BOOT_JAR_LAUNCHER: &str = "org/springframework/boot/loader/launch/JarLauncher";
+
+/// Detect a bundled Spring Boot launcher inside an archive.
+///
+/// A Spring Boot fat JAR is launched through `JarLauncher`, which reflectively
+/// boots the application declared by the `Start-Class` manifest attribute. When
+/// the archive bundles the launcher classes but omits an explicit `Main-Class`,
+/// this returns the launcher's internal (slash-separated) binary name so the
+/// caller can route to it as the entry class.
+///
+/// Returns `None` when the archive contains no recognizable launcher.
+fn detect_spring_boot_launcher(reader: &ZipReader) -> Option<String> {
+    let launcher_entry = format!("{SPRING_BOOT_JAR_LAUNCHER}.class");
+    if reader.get_entry(&launcher_entry).is_some() {
+        return Some(SPRING_BOOT_JAR_LAUNCHER.to_string());
+    }
+    None
+}
+
 /// `duke -jar <file.jar> [string-arg...]`
 ///
 /// Reads `META-INF/MANIFEST.MF` to discover `Main-Class`, then executes it.
+/// When no `Main-Class` is declared, falls back to a bundled Spring Boot
+/// launcher (see [`detect_spring_boot_launcher`]).
 fn run_jar(
     jar_path: &str,
     string_args: &[&str],
@@ -860,8 +882,14 @@ fn run_jar(
             process::exit(1);
         });
     let main_class = duke_loader::parse_main_class(&manifest_bytes).unwrap_or_else(|| {
-        eprintln!("duke: no Main-Class attribute in '{jar_path}' manifest");
-        process::exit(1);
+        // No explicit Main-Class. A Spring Boot fat JAR is normally launched via its
+        // bundled `JarLauncher`, but some archives (e.g. the loader library itself)
+        // ship the launcher without declaring it in the manifest. Fall back to
+        // detecting the launcher and routing to it directly.
+        detect_spring_boot_launcher(&reader).unwrap_or_else(|| {
+            eprintln!("duke: no Main-Class attribute in '{jar_path}' manifest");
+            process::exit(1);
+        })
     });
 
     // Build classpath: the JAR itself + its parent directory (for auxiliary classes).

--- a/duke/tests/spring_boot_jar.rs
+++ b/duke/tests/spring_boot_jar.rs
@@ -1,0 +1,221 @@
+//! CLI-level integration tests for the `duke -jar` Spring Boot launch path.
+//!
+//! These drive the real `duke` binary through `run_jar`, exercising both a
+//! genuine fat JAR (`Main-Class: JarLauncher` + `Start-Class` + `BOOT-INF`) and
+//! the launcher-detection fallback (an archive that bundles `JarLauncher`
+//! without declaring a `Main-Class`).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use duke_loader::ZipReader;
+
+const JAR_LAUNCHER_ENTRY: &str = "org/springframework/boot/loader/launch/JarLauncher.class";
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR points at the `duke` crate; the workspace root is its parent.
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn spring_boot_loader_jar() -> PathBuf {
+    repo_root().join("spring-boot-loader-3.5.12.jar")
+}
+
+fn hello_world_class() -> Vec<u8> {
+    std::fs::read(repo_root().join("tests/fixtures/HelloWorld.class"))
+        .expect("read HelloWorld.class fixture")
+}
+
+/// Standard CRC-32 (matching the zip spec), used to build STORED zip entries.
+fn zip_crc32(data: &[u8]) -> u32 {
+    let mut crc: u32 = 0xFFFF_FFFF;
+    for &byte in data {
+        crc ^= u32::from(byte);
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}
+
+/// Build a minimal uncompressed (STORED) zip from the given entries.
+fn build_stored_zip(entries: &[(String, Vec<u8>)]) -> Vec<u8> {
+    const LOCAL_SIGNATURE: u32 = 0x0403_4b50;
+    const CD_SIGNATURE: u32 = 0x0201_4b50;
+    const EOCD_SIGNATURE: u32 = 0x0605_4b50;
+    const METHOD_STORED: u16 = 0;
+
+    let count = u16::try_from(entries.len()).expect("entry count fits in u16");
+    let mut zip = Vec::new();
+    let mut local_offsets = Vec::with_capacity(entries.len());
+
+    for (name, content) in entries {
+        let crc = zip_crc32(content);
+        let size = u32::try_from(content.len()).expect("entry size fits in u32");
+        let name_bytes = name.as_bytes();
+
+        local_offsets.push(u32::try_from(zip.len()).expect("offset fits in u32"));
+        zip.extend_from_slice(&LOCAL_SIGNATURE.to_le_bytes());
+        zip.extend_from_slice(&20_u16.to_le_bytes());
+        zip.extend_from_slice(&0_u16.to_le_bytes());
+        zip.extend_from_slice(&METHOD_STORED.to_le_bytes());
+        zip.extend_from_slice(&0_u16.to_le_bytes());
+        zip.extend_from_slice(&0_u16.to_le_bytes());
+        zip.extend_from_slice(&crc.to_le_bytes());
+        zip.extend_from_slice(&size.to_le_bytes());
+        zip.extend_from_slice(&size.to_le_bytes());
+        zip.extend_from_slice(
+            &u16::try_from(name_bytes.len())
+                .expect("name length fits in u16")
+                .to_le_bytes(),
+        );
+        zip.extend_from_slice(&0_u16.to_le_bytes());
+        zip.extend_from_slice(name_bytes);
+        zip.extend_from_slice(content);
+    }
+
+    let cd_offset = u32::try_from(zip.len()).expect("central directory offset fits in u32");
+    for (index, (name, content)) in entries.iter().enumerate() {
+        let crc = zip_crc32(content);
+        let size = u32::try_from(content.len()).expect("entry size fits in u32");
+        let name_bytes = name.as_bytes();
+
+        zip.extend_from_slice(&CD_SIGNATURE.to_le_bytes());
+        zip.extend_from_slice(&20_u16.to_le_bytes());
+        zip.extend_from_slice(&20_u16.to_le_bytes());
+        zip.extend_from_slice(&0_u16.to_le_bytes());
+        zip.extend_from_slice(&METHOD_STORED.to_le_bytes());
+        zip.extend_from_slice(&0_u16.to_le_bytes());
+        zip.extend_from_slice(&0_u16.to_le_bytes());
+        zip.extend_from_slice(&crc.to_le_bytes());
+        zip.extend_from_slice(&size.to_le_bytes());
+        zip.extend_from_slice(&size.to_le_bytes());
+        zip.extend_from_slice(
+            &u16::try_from(name_bytes.len())
+                .expect("name length fits in u16")
+                .to_le_bytes(),
+        );
+        zip.extend_from_slice(&0_u16.to_le_bytes());
+        zip.extend_from_slice(&0_u16.to_le_bytes());
+        zip.extend_from_slice(&0_u16.to_le_bytes());
+        zip.extend_from_slice(&0_u16.to_le_bytes());
+        zip.extend_from_slice(&0_u32.to_le_bytes());
+        zip.extend_from_slice(&local_offsets[index].to_le_bytes());
+        zip.extend_from_slice(name_bytes);
+    }
+    let cd_size = u32::try_from(zip.len()).expect("central directory size fits in u32") - cd_offset;
+
+    zip.extend_from_slice(&EOCD_SIGNATURE.to_le_bytes());
+    zip.extend_from_slice(&0_u16.to_le_bytes());
+    zip.extend_from_slice(&0_u16.to_le_bytes());
+    zip.extend_from_slice(&count.to_le_bytes());
+    zip.extend_from_slice(&count.to_le_bytes());
+    zip.extend_from_slice(&cd_size.to_le_bytes());
+    zip.extend_from_slice(&cd_offset.to_le_bytes());
+    zip.extend_from_slice(&0_u16.to_le_bytes());
+
+    zip
+}
+
+/// Read every entry of the repo-root Spring Boot loader library, decompressed.
+fn spring_boot_loader_entries() -> Vec<(String, Vec<u8>)> {
+    let reader = ZipReader::open(&spring_boot_loader_jar()).expect("open spring-boot-loader jar");
+    reader
+        .entry_names()
+        .filter(|name| !name.ends_with('/'))
+        .map(|name| {
+            let bytes = reader.read_entry(name).expect("read loader entry");
+            (name.to_string(), bytes)
+        })
+        .collect()
+}
+
+/// Write `bytes` to a uniquely named temp file with a `.jar` suffix.
+fn write_temp_jar(tag: &str, bytes: &[u8]) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "duke_cli_boot_{tag}_{}.jar",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos()
+    ));
+    std::fs::write(&path, bytes).expect("write temp jar");
+    path
+}
+
+/// A real fat JAR launched through the CLI boots its `Start-Class` main.
+#[test]
+fn real_fat_jar_launches_via_cli() {
+    let mut entries = spring_boot_loader_entries();
+    entries.push((
+        "META-INF/MANIFEST.MF".to_string(),
+        b"Manifest-Version: 1.0\r\nMain-Class: org.springframework.boot.loader.launch.JarLauncher\r\nStart-Class: HelloWorld\r\n\r\n"
+            .to_vec(),
+    ));
+    entries.push((
+        "BOOT-INF/classes/HelloWorld.class".to_string(),
+        hello_world_class(),
+    ));
+
+    let jar_path = write_temp_jar("fat", &build_stored_zip(&entries));
+    let output = Command::new(env!("CARGO_BIN_EXE_duke"))
+        .arg("-jar")
+        .arg(&jar_path)
+        .output()
+        .expect("run duke -jar on synthetic fat jar");
+    std::fs::remove_file(&jar_path).ok();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("Hello, World!"),
+        "expected fat jar to boot Start-Class main; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        !stderr.contains("no Main-Class attribute"),
+        "fat jar with explicit Main-Class must not hit the no-Main-Class path; stderr={stderr:?}"
+    );
+}
+
+/// An archive bundling `JarLauncher` but declaring no `Main-Class` is routed to
+/// the launcher via the detection fallback, rather than aborting with the
+/// `no Main-Class attribute` error.
+#[test]
+fn launcher_detection_fallback_routes_without_main_class() {
+    let entries = spring_boot_loader_entries();
+    assert!(
+        entries.iter().any(|(name, _)| name == JAR_LAUNCHER_ENTRY),
+        "loader library should contain the JarLauncher class"
+    );
+
+    // Manifest deliberately omits Main-Class and Start-Class.
+    let mut with_manifest = entries;
+    with_manifest.push((
+        "META-INF/MANIFEST.MF".to_string(),
+        b"Manifest-Version: 1.0\r\n\r\n".to_vec(),
+    ));
+
+    let jar_path = write_temp_jar("fallback", &build_stored_zip(&with_manifest));
+    let output = Command::new(env!("CARGO_BIN_EXE_duke"))
+        .arg("-jar")
+        .arg(&jar_path)
+        .output()
+        .expect("run duke -jar on launcher-only jar");
+    std::fs::remove_file(&jar_path).ok();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // The fallback must engage: we should never see the no-Main-Class abort, and
+    // we should never see a "cannot load class JarLauncher" error (it loads fine).
+    assert!(
+        !stderr.contains("no Main-Class attribute"),
+        "launcher detection should route to JarLauncher, not abort; stderr={stderr:?}"
+    );
+    assert!(
+        !stderr.contains("cannot load class"),
+        "JarLauncher should load from the archive; stderr={stderr:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Wires up the CLI launch path for Spring Boot fat JARs. The runtime support (`ZipLoader` mounting `BOOT-INF/classes/` + `BOOT-INF/lib/*.jar`, the `JarLauncher` execution path, and all required natives) was already implemented and tested; the only gap was CLI wiring in `duke/src/main.rs::run_jar`.

## Before / After

- **Before:** `duke -jar <spring-boot-jar>` on an archive with no `Main-Class` in its manifest aborted with `duke: no Main-Class attribute in '<jar>' manifest` and exited 1 — even when the archive bundled the Spring Boot `JarLauncher`.
- **After:** when no `Main-Class` is declared, `run_jar` detects a bundled `org/springframework/boot/loader/launch/JarLauncher.class` and routes to it as the entry class. Real fat JARs (explicit `Main-Class: JarLauncher` + `Start-Class` + populated `BOOT-INF`) launch fully and boot their application main. The `no Main-Class attribute` error is now emitted only when neither a `Main-Class` nor a detectable launcher exists.

## Changes

- `duke/src/main.rs`
  - New helper `detect_spring_boot_launcher(reader: &ZipReader) -> Option<String>` — cheaply probes for the launcher entry via `ZipReader::get_entry` and returns the launcher's internal (slash-separated) binary name.
  - `run_jar` now falls back to `detect_spring_boot_launcher` when `parse_main_class` returns `None`, preserving the original error message for the truly-no-launcher case.
- `duke/tests/spring_boot_jar.rs` (new) — CLI-level integration tests driving the real `duke -jar` binary:
  - `real_fat_jar_launches_via_cli`: builds a synthetic fat JAR (loader classes + `Main-Class: JarLauncher` + `Start-Class: HelloWorld` + `BOOT-INF/classes/HelloWorld.class`) and asserts it prints `Hello, World!`.
  - `launcher_detection_fallback_routes_without_main_class`: builds a launcher-bearing archive with a manifest that omits `Main-Class`, and asserts the fallback routes to `JarLauncher` (no `no Main-Class attribute` / `cannot load class` error).

## Caveat

The repo-root `spring-boot-loader-3.5.12.jar` is the loader **library**, not a fat JAR — it has no `Main-Class`, no `Start-Class`, and no `BOOT-INF`. With this change `duke -jar spring-boot-loader-3.5.12.jar` now routes into `JarLauncher` (instead of aborting on the missing `Main-Class`), which then fails Java-side because there is no application/`Start-Class` to boot. That is expected.

## Verification

- `cargo build` clean.
- `cargo test --workspace`: 2976 passed / 0 failed / 3 ignored (baseline 2974, +2 new tests).
- `cargo clippy --workspace --all-targets`: no warnings.
- `duke -jar tests/fixtures/hello.jar` still prints `Hello, World!`.
- `duke -jar spring-boot-loader-3.5.12.jar` now prints `duke: runtime error: java exception: java/lang/IllegalStateException` instead of the no-Main-Class abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148DBXTQLYWhmAUMaWSCnrH

---
_Generated by [Claude Code](https://claude.ai/code/session_0148DBXTQLYWhmAUMaWSCnrH)_