### PR TITLE
Spike: execute real java.base bytecode from jimage behind --real-jdk flag

### DIFF
--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -21,6 +21,31 @@ use crate::registry::ClassRegistry;
 #[allow(clippy::wildcard_imports)]
 use crate::*;
 
+/// Under real-JDK shadow mode, convert a [`MethodHierarchyLookup::NativeOverride`]
+/// decision into a [`MethodHierarchyLookup::Bytecode`] one when the synthetic native is
+/// masking the real classfile body of a *shadowed* class.
+///
+/// This is a hard no-op unless `resolved` is `NativeOverride` AND real-JDK shadow mode
+/// is on AND a shadowed class in the hierarchy provides a concrete bytecode body — see
+/// [`ClassRegistry::shadowed_bytecode_override`]. With the flag off the shadowed set is
+/// empty, so it always returns `resolved` unchanged.
+fn apply_shadow_override(
+    registry: &mut ClassRegistry,
+    loader: &dyn ClassLoader,
+    resolved: MethodHierarchyLookup,
+    start_class: &str,
+    method_name: &str,
+    method_desc: &str,
+) -> MethodHierarchyLookup {
+    if !matches!(resolved, MethodHierarchyLookup::NativeOverride) {
+        return resolved;
+    }
+    match registry.shadowed_bytecode_override(loader, start_class, method_name, method_desc) {
+        Some((class_name, method_idx)) => MethodHierarchyLookup::Bytecode(class_name, method_idx),
+        None => resolved,
+    }
+}
+
 /// Executes the active method's bytecode instructions to completion or exception.
 ///
 /// This is the central run-loop of the interpreter. It continually fetches the
@@ -417,7 +442,19 @@ pub fn run_execution(
                     &callee_name,
                     &callee_desc,
                 ) {
-                    None
+                    // Under real-JDK shadow mode a synthetic native may be masking the
+                    // real classfile body of a shadowed class — prefer real bytecode when
+                    // the concrete body lives on the callee class itself. No-op with the
+                    // flag off (shadowed_bytecode_override returns None immediately).
+                    registry
+                        .shadowed_bytecode_override(
+                            loader,
+                            &callee_class_key,
+                            &callee_name,
+                            &callee_desc,
+                        )
+                        .filter(|(owning_class, _)| owning_class == &callee_class_key)
+                        .map(|(_, idx)| idx)
                 } else {
                     let ctx = registry.get(&callee_class_key)?;
                     ctx.methods
@@ -1645,6 +1682,17 @@ pub fn run_execution(
                 } else {
                     MethodHierarchyLookup::Missing
                 };
+                // Real-JDK shadow mode: if the synthetic native masks a shadowed class's
+                // real bytecode body, dispatch the real bytecode instead. Walk from the
+                // runtime class when known, else the resolved callee class. No-op off-flag.
+                let resolved = apply_shadow_override(
+                    registry,
+                    loader,
+                    resolved,
+                    virtual_start.as_deref().unwrap_or(&callee_class_key),
+                    &callee_name,
+                    &callee_desc,
+                );
                 let allow_lambda_dispatch = matches!(resolved, MethodHierarchyLookup::Missing);
                 let (dispatch_class, callee_idx) = match resolved {
                     MethodHierarchyLookup::Bytecode(cls, i) => (cls, i),
@@ -2705,6 +2753,16 @@ pub fn run_execution(
                         &callee_desc,
                     ),
                 };
+                // Real-JDK shadow mode: prefer a shadowed class's real bytecode body over
+                // the synthetic native that would otherwise win. No-op when the flag is off.
+                let resolved = apply_shadow_override(
+                    registry,
+                    loader,
+                    resolved,
+                    &actual_class,
+                    &callee_name,
+                    &callee_desc,
+                );
                 let allow_lambda_dispatch = matches!(resolved, MethodHierarchyLookup::Missing);
 
                 let (dispatch_class, callee_idx) =

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -35,6 +35,22 @@ const KEEP_SYNTHETIC: &[&str] = &[
     "java/lang/Float",
     "java/lang/Double",
     "java/lang/Number",
+    // Print/IO stack: `System.out`/`System.err` are allocated synthetically by
+    // `bootstrap_stdlib` (System is KEEP_SYNTHETIC) with the synthetic PrintStream layout.
+    // Keeping the whole stream/writer stack synthetic prevents real JDK bytecode from
+    // running against those synthetically-allocated instances (layout-coherence boundary).
+    "java/io/PrintStream",
+    "java/io/OutputStream",
+    "java/io/FilterOutputStream",
+    "java/io/BufferedOutputStream",
+    "java/io/Writer",
+    "java/io/OutputStreamWriter",
+    "java/io/BufferedWriter",
+    "java/io/PrintWriter",
+    "java/io/InputStream",
+    "java/io/FileOutputStream",
+    "java/io/FileInputStream",
+    "java/io/FileDescriptor",
 ];
 
 fn class_internal_name_fragment(name: &str) -> &str {

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -12,7 +12,30 @@ use std::sync::Arc;
 use duke_loader::{ClassLoader, LocatedResource};
 use duke_runtime::{Error, Result, Slot};
 
-use crate::context::ClassContext;
+use crate::context::{ClassContext, ClassLoadSource};
+
+/// Internal names of classes that MUST remain hand-written synthetic stubs even when
+/// `real_jdk_shadow` is enabled. These roots are entangled with native code that assumes
+/// a specific field/heap layout (special `HeapObject` slots, dense hand-registered natives),
+/// so loading their real JDK bytecode would break those natives.
+const KEEP_SYNTHETIC: &[&str] = &[
+    "java/lang/Object",
+    "java/lang/String",
+    "java/lang/Class",
+    "java/lang/Thread",
+    "java/lang/ThreadGroup",
+    "java/lang/Throwable",
+    "java/lang/System",
+    "java/lang/Integer",
+    "java/lang/Long",
+    "java/lang/Short",
+    "java/lang/Byte",
+    "java/lang/Boolean",
+    "java/lang/Character",
+    "java/lang/Float",
+    "java/lang/Double",
+    "java/lang/Number",
+];
 
 fn class_internal_name_fragment(name: &str) -> &str {
     name.split_once('\0')
@@ -352,6 +375,17 @@ pub struct ClassRegistry {
     class_code_sources: HashMap<String, String>,
     /// Best-known runtime `java/lang/ClassLoader` object for each loaded class.
     class_runtime_loaders: HashMap<String, u64>,
+    /// Opt-in flag: when true, synthetic stdlib classes that are NOT on the
+    /// [`KEEP_SYNTHETIC`] allowlist and whose real classfile is resolvable via
+    /// [`Self::shadow_loader`] are NOT pre-registered synthetically, so a later
+    /// `ensure_loaded` loads their real JDK bytecode instead. Default `false`.
+    real_jdk_shadow: bool,
+    /// Loader consulted during [`Self::register`] to decide whether a real classfile
+    /// exists for a candidate synthetic class. Only used when `real_jdk_shadow` is true.
+    shadow_loader: Option<Arc<dyn ClassLoader + Send + Sync>>,
+    /// Internal names of synthetic classes that were skipped (shadowed by real JDK
+    /// bytecode) — collected for later measurement.
+    shadowed_classes: Vec<String>,
     /// Storage for execution telemetry (e.g. instruction counts, GC pause times).
     ///
     /// The [`TelemetryStore`](duke_telemetry::TelemetryStore) collects performance metrics
@@ -383,6 +417,9 @@ impl ClassRegistry {
             archive_loaders: HashMap::new(),
             class_code_sources: HashMap::new(),
             class_runtime_loaders: HashMap::new(),
+            real_jdk_shadow: false,
+            shadow_loader: None,
+            shadowed_classes: Vec::new(),
             #[cfg(feature = "telemetry")]
             telemetry: duke_telemetry::TelemetryStore::default(),
         }
@@ -654,9 +691,50 @@ impl ClassRegistry {
         &mut self.natives
     }
 
+    /// Enable "real JDK shadow" mode: synthetic stdlib classes that are not on the
+    /// [`KEEP_SYNTHETIC`] allowlist and whose real classfile is resolvable via `loader`
+    /// will be skipped by [`Self::register`], letting a later `ensure_loaded` load the
+    /// real JDK bytecode. Must be called *before* `bootstrap_stdlib` runs to take effect.
+    pub fn enable_real_jdk_shadow(&mut self, loader: Arc<dyn ClassLoader + Send + Sync>) {
+        self.real_jdk_shadow = true;
+        self.shadow_loader = Some(loader);
+    }
+
+    /// Whether real-JDK shadow mode is enabled.
+    #[must_use]
+    pub const fn real_jdk_shadow_enabled(&self) -> bool {
+        self.real_jdk_shadow
+    }
+
+    /// Internal names of synthetic classes that were shadowed (skipped) by real JDK
+    /// bytecode under real-JDK shadow mode.
+    #[must_use]
+    pub fn shadowed_classes(&self) -> &[String] {
+        &self.shadowed_classes
+    }
+
     /// Register a pre-built `ClassContext`.
     pub fn register(&mut self, ctx: ClassContext) {
+        if self.should_shadow_synthetic(&ctx) {
+            if std::env::var_os("DUKE_REAL_JDK_DEBUG").is_some() {
+                eprintln!("[real-jdk] shadowing synthetic {}", ctx.class_name);
+            }
+            self.shadowed_classes.push(ctx.class_name.clone());
+            return;
+        }
         self.classes.insert(ctx.class_name.clone(), ctx);
+    }
+
+    /// Decide whether a synthetic `ClassContext` should be skipped so its real JDK
+    /// bytecode is loaded on demand instead. Only ever true when `real_jdk_shadow` is on.
+    fn should_shadow_synthetic(&self, ctx: &ClassContext) -> bool {
+        self.real_jdk_shadow
+            && ctx.load_source == ClassLoadSource::Synthetic
+            && !KEEP_SYNTHETIC.contains(&ctx.class_name.as_str())
+            && self
+                .shadow_loader
+                .as_ref()
+                .is_some_and(|loader| loader.find_class(&ctx.class_name).is_ok())
     }
 
     /// Get a reference to a loaded class.

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -386,6 +386,9 @@ pub struct ClassRegistry {
     /// Internal names of synthetic classes that were skipped (shadowed by real JDK
     /// bytecode) — collected for later measurement.
     shadowed_classes: Vec<String>,
+    /// O(1) membership mirror of [`Self::shadowed_classes`] (internal names), used by
+    /// [`Self::is_shadowed`] during native-vs-bytecode dispatch decisions.
+    shadowed_set: HashSet<String>,
     /// Storage for execution telemetry (e.g. instruction counts, GC pause times).
     ///
     /// The [`TelemetryStore`](duke_telemetry::TelemetryStore) collects performance metrics
@@ -420,6 +423,7 @@ impl ClassRegistry {
             real_jdk_shadow: false,
             shadow_loader: None,
             shadowed_classes: Vec::new(),
+            shadowed_set: HashSet::new(),
             #[cfg(feature = "telemetry")]
             telemetry: duke_telemetry::TelemetryStore::default(),
         }
@@ -719,10 +723,81 @@ impl ClassRegistry {
             if std::env::var_os("DUKE_REAL_JDK_DEBUG").is_some() {
                 eprintln!("[real-jdk] shadowing synthetic {}", ctx.class_name);
             }
+            self.shadowed_set.insert(ctx.class_name.clone());
             self.shadowed_classes.push(ctx.class_name.clone());
             return;
         }
         self.classes.insert(ctx.class_name.clone(), ctx);
+    }
+
+    /// Whether `class` (any provenance-keyed form) is a synthetic class that was
+    /// shadowed by real JDK bytecode under real-JDK shadow mode. Always `false` when
+    /// the flag is off (the shadowed set is empty), so callers are no-ops in that case.
+    #[must_use]
+    pub fn is_shadowed(&self, class: &str) -> bool {
+        self.shadowed_set
+            .contains(class_internal_name_fragment(class))
+    }
+
+    /// Under real-JDK shadow mode, resolve the real classfile bytecode body that a
+    /// synthetic native is masking for a *shadowed* class.
+    ///
+    /// Walks the class hierarchy from `start_class` (ignoring registered native
+    /// overrides — that is the whole point) and returns `Some((owning_class_key,
+    /// method_idx))` for the first concrete (non-abstract, non-`native`) bytecode
+    /// method whose owning class [`Self::is_shadowed`]. Returns `None` when shadow mode
+    /// is off, when the resolved body is classfile-`native`/abstract-only, or when the
+    /// owning class is not shadowed (e.g. a `KEEP_SYNTHETIC` root) — in every such case
+    /// the caller keeps the synthetic native. This is a hard no-op when the flag is off.
+    pub fn shadowed_bytecode_override(
+        &mut self,
+        loader: &dyn ClassLoader,
+        start_class: &str,
+        method_name: &str,
+        method_desc: &str,
+    ) -> Option<(String, usize)> {
+        if !self.real_jdk_shadow {
+            return None;
+        }
+        let mut current = if self.contains(start_class) {
+            start_class.to_string()
+        } else {
+            self.class_key_from_source(start_class, Some(start_class))
+        };
+        let mut visited = HashSet::new();
+        loop {
+            if !visited.insert(current.clone()) {
+                return None; // circular hierarchy — bail
+            }
+            if !self.contains(&current) {
+                let _ = self.ensure_loaded_from(&current, Some(start_class), loader);
+                current = self.class_key_from_source(&current, Some(start_class));
+            }
+            let ctx = self.classes.get(&current)?;
+            if let Some(idx) = ctx
+                .methods
+                .iter()
+                .position(|m| m.name == method_name && m.descriptor == method_desc)
+            {
+                let method = &ctx.methods[idx];
+                if method.is_native {
+                    // Real classfile declares this method `native` — no bytecode body
+                    // to run, so fall back to the synthetic native.
+                    return None;
+                }
+                if !method.is_abstract {
+                    // Concrete bytecode body. Only bypass the synthetic native when the
+                    // owning class is itself shadowed; otherwise keep the native.
+                    return self.is_shadowed(&current).then_some((current, idx));
+                }
+                // Abstract override — keep walking supers for a concrete body.
+            }
+            let super_class = self.classes.get(&current)?.super_class.clone();
+            match super_class {
+                Some(s) => current = s,
+                None => return None,
+            }
+        }
     }
 
     /// Decide whether a synthetic `ClassContext` should be skipped so its real JDK

--- a/crates/duke-interpreter/tests/real_jdk_shadow.rs
+++ b/crates/duke-interpreter/tests/real_jdk_shadow.rs
@@ -1,0 +1,147 @@
+//! Integration tests for the opt-in "real JDK shadow" mode on [`ClassRegistry`].
+//!
+//! When the flag is OFF (the default), `bootstrap_stdlib` must register every
+//! synthetic stdlib class exactly as before. When the flag is ON, synthetic
+//! classes that are NOT on the keep-synthetic allowlist and whose real classfile
+//! is resolvable from the JDK jimage are skipped, so a later `ensure_loaded`
+//! loads their real JDK bytecode instead.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use duke_gc::Heap;
+use duke_interpreter::{ClassLoadSource, ClassRegistry, bootstrap_stdlib};
+use duke_loader::{BootstrapLoader, ClassLoader};
+
+/// Locate a JDK jimage (`lib/modules`), preferring `JAVA_HOME`.
+fn jdk_modules_path() -> Option<PathBuf> {
+    let from_java_home = std::env::var_os("JAVA_HOME")
+        .map(PathBuf::from)
+        .map(|path| path.join("lib/modules"));
+    let fallbacks = [
+        PathBuf::from("/usr/lib/jvm/java-21-openjdk-amd64/lib/modules"),
+        PathBuf::from("/usr/lib/jvm/default-java/lib/modules"),
+    ];
+    from_java_home
+        .into_iter()
+        .chain(fallbacks)
+        .find(|path| path.exists())
+}
+
+/// Build a jimage-backed loader, or `None` when no JDK jimage is present.
+fn jimage_loader() -> Option<Arc<dyn ClassLoader + Send + Sync>> {
+    let modules = jdk_modules_path()?;
+    let loader = BootstrapLoader::new(&modules, Vec::<PathBuf>::new()).ok()?;
+    Some(Arc::new(loader))
+}
+
+/// Allowlisted roots that MUST stay synthetic regardless of the flag.
+const KEEP_SYNTHETIC_SAMPLE: &[&str] = &[
+    "java/lang/String",
+    "java/lang/Object",
+    "java/lang/System",
+    "java/lang/Integer",
+    "java/lang/Class",
+    "java/lang/Thread",
+];
+
+/// Flag OFF (default): full synthetic stdlib registered, nothing shadowed.
+#[test]
+fn flag_off_registers_synthetic_stdlib_and_shadows_nothing() {
+    let mut registry = ClassRegistry::new();
+    let mut heap = Heap::new();
+    bootstrap_stdlib(&mut registry, &mut heap);
+
+    assert!(
+        !registry.real_jdk_shadow_enabled(),
+        "real-jdk shadow must be off by default"
+    );
+    assert!(
+        registry.shadowed_classes().is_empty(),
+        "nothing should be shadowed when the flag is off, got {:?}",
+        registry.shadowed_classes()
+    );
+
+    // A core synthetic root is present and synthetic.
+    let string = registry
+        .get("java/lang/String")
+        .expect("java/lang/String synthetic stub should be registered");
+    assert_eq!(string.load_source, ClassLoadSource::Synthetic);
+}
+
+/// Flag ON: non-allowlisted synthetics backed by a real classfile are skipped,
+/// the allowlist is protected, and a shadowed class loads as real bytecode.
+#[test]
+fn flag_on_shadows_non_allowlisted_synthetics_but_protects_allowlist() {
+    let Some(loader) = jimage_loader() else {
+        eprintln!("skipping flag_on test: no JDK jimage (lib/modules) available");
+        return;
+    };
+
+    let mut registry = ClassRegistry::new();
+    let mut heap = Heap::new();
+    registry.enable_real_jdk_shadow(Arc::clone(&loader));
+    bootstrap_stdlib(&mut registry, &mut heap);
+
+    assert!(registry.real_jdk_shadow_enabled());
+
+    // Allowlisted roots MUST remain synthetic even with the flag on, and must
+    // never be recorded as shadowed.
+    for keep in KEEP_SYNTHETIC_SAMPLE {
+        let ctx = registry
+            .get(keep)
+            .unwrap_or_else(|_| panic!("{keep} should remain registered synthetically"));
+        assert_eq!(
+            ctx.load_source,
+            ClassLoadSource::Synthetic,
+            "{keep} must stay synthetic under real-jdk shadow"
+        );
+        assert!(
+            !registry.shadowed_classes().iter().any(|c| c == keep),
+            "{keep} must not be shadowed"
+        );
+    }
+
+    // With a real JDK jimage, at least one non-allowlisted synthetic should have
+    // been shadowed (its real classfile exists in java.base).
+    assert!(
+        !registry.shadowed_classes().is_empty(),
+        "expected some synthetic stdlib classes to be shadowed by real JDK bytecode"
+    );
+
+    // Every shadowed class: absent from the registry (so ensure_loaded will fetch
+    // real bytecode) and resolvable from the jimage.
+    for name in registry.shadowed_classes() {
+        assert!(
+            registry.get(name).is_err(),
+            "shadowed class {name} should not be pre-registered synthetically"
+        );
+        assert!(
+            loader.find_class(name).is_ok(),
+            "shadowed class {name} must be resolvable from the jimage"
+        );
+        assert!(
+            !KEEP_SYNTHETIC_SAMPLE.contains(&name.as_str()),
+            "allowlisted class {name} must never be shadowed"
+        );
+    }
+
+    // A shadowed class loads as real Classfile bytecode via ensure_loaded.
+    let name = registry
+        .shadowed_classes()
+        .first()
+        .cloned()
+        .expect("at least one shadowed class");
+    let loaded = registry
+        .ensure_loaded(&name, loader.as_ref())
+        .expect("ensure_loaded should succeed for a jimage class");
+    assert!(loaded, "ensure_loaded should load {name} from the jimage");
+    let ctx = registry
+        .get(&name)
+        .expect("shadowed class should be registered after ensure_loaded");
+    assert_eq!(
+        ctx.load_source,
+        ClassLoadSource::Classfile,
+        "{name} should now be real classfile bytecode"
+    );
+}

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -111,6 +111,62 @@ fn extract_jar_flag(args: &mut Vec<String>) -> Option<String> {
     jar
 }
 
+/// Strip `--real-jdk` / `--no-real-jdk` from `args` and return whether "real JDK
+/// shadow" mode is requested. Defaults to the `DUKE_REAL_JDK=1` env var; CLI wins.
+fn extract_real_jdk_flag(args: &mut Vec<String>) -> bool {
+    let mut enabled = matches!(std::env::var("DUKE_REAL_JDK").as_deref(), Ok("1"));
+    args.retain(|arg| {
+        if arg == "--real-jdk" {
+            enabled = true;
+            return false;
+        }
+        if arg == "--no-real-jdk" {
+            enabled = false;
+            return false;
+        }
+        true
+    });
+    enabled
+}
+
+/// Build a jimage-backed loader (`BootstrapLoader`) used solely to decide, during
+/// `bootstrap_stdlib`, whether a real JDK classfile exists for a synthetic class.
+/// Returns `None` when no JDK jimage is available.
+fn make_shadow_loader(
+    jdk_home: Option<&str>,
+) -> Option<std::sync::Arc<dyn ClassLoader + Send + Sync>> {
+    let home = jdk_home?;
+    let modules = std::path::Path::new(home).join("lib").join("modules");
+    if !modules.exists() {
+        return None;
+    }
+    match BootstrapLoader::new(&modules, Vec::<std::path::PathBuf>::new()) {
+        Ok(bl) => Some(std::sync::Arc::new(bl)),
+        Err(e) => {
+            eprintln!("duke: warning: cannot open JDK modules for real-jdk shadow ({e})");
+            None
+        }
+    }
+}
+
+/// Enable real-JDK shadow mode on `registry` when requested. Must run *before*
+/// `bootstrap_stdlib`. Warns and does nothing if no jimage loader is available.
+fn apply_real_jdk_shadow(registry: &mut ClassRegistry, real_jdk: bool, jdk_home: Option<&str>) {
+    if !real_jdk {
+        return;
+    }
+    if let Some(loader) = make_shadow_loader(jdk_home) {
+        eprintln!(
+            "duke: real-jdk mode enabled (non-allowlisted synthetic stdlib classes load real JDK bytecode)"
+        );
+        registry.enable_real_jdk_shadow(loader);
+    } else {
+        eprintln!(
+            "duke: warning: --real-jdk requested but no JDK jimage loader is available (need --jdk=<path> or JAVA_HOME pointing at a JDK with lib/modules); continuing with synthetic stdlib"
+        );
+    }
+}
+
 /// Build a class loader: `BootstrapLoader` (JDK jimage + app dir) when JDK path
 /// is known, or plain `DirectoryLoader` otherwise.
 struct CliLoader(Box<dyn ClassLoader + Send + Sync>);
@@ -271,6 +327,7 @@ fn main() {
     let telemetry = extract_telemetry_flag(&mut args);
     let mermaid_dest = extract_mermaid_heap_flag(&mut args);
     let jdk_home = extract_jdk_flag(&mut args);
+    let real_jdk = extract_real_jdk_flag(&mut args);
     let jdwp_cfg = extract_jdwp_flag(&mut args);
     let jar_path = extract_jar_flag(&mut args);
 
@@ -338,6 +395,10 @@ fn main() {
         eprintln!("         --telemetry-md[=p]  dump telemetry Markdown report after execution");
         eprintln!("         --jdk=<path>        JDK home for loading real JDK classes");
         eprintln!("         (also reads JAVA_HOME env var)");
+        eprintln!(
+            "         --real-jdk          load real JDK bytecode for non-allowlisted stdlib classes"
+        );
+        eprintln!("         (also enabled by DUKE_REAL_JDK=1; needs a JDK jimage)");
         process::exit(1);
     }
 
@@ -415,6 +476,7 @@ fn main() {
             telemetry,
             mermaid_dest,
             jdk_home.as_deref(),
+            real_jdk,
         );
         return;
     }
@@ -542,13 +604,13 @@ fn main() {
 
     // Dispatch `exec`: run a static method and print the result.
     if args.len() >= 4 && args[1] == "exec" {
-        exec_method(&args[2..], telemetry, mermaid_dest, jdk_home.as_deref());
+        exec_method(&args[2..], telemetry, mermaid_dest, jdk_home.as_deref(), real_jdk);
         return;
     }
 
     // Dispatch `run`: execute main(String[]) entry point.
     if args.len() >= 3 && args[1] == "run" {
-        run_main(&args[2..], telemetry, mermaid_dest, jdk_home.as_deref());
+        run_main(&args[2..], telemetry, mermaid_dest, jdk_home.as_deref(), real_jdk);
         return;
     }
 
@@ -661,6 +723,7 @@ fn exec_method(
     telemetry: Option<TelemetryDest>,
     mermaid_dest: Option<MermaidDest>,
     jdk_home: Option<&str>,
+    real_jdk: bool,
 ) {
     if args.len() < 2 {
         eprintln!("Usage: duke exec <classfile.class> <method> [int-arg...]");
@@ -717,6 +780,7 @@ fn exec_method(
         .unwrap_or_else(|| std::path::Path::new("."));
     let loader = make_loader(jdk_home, &[parent.to_path_buf()]);
     let mut heap = Heap::new();
+    apply_real_jdk_shadow(&mut registry, real_jdk, jdk_home);
     bootstrap_stdlib(&mut registry, &mut heap);
 
     let mut stdout = std::io::stdout();
@@ -765,6 +829,7 @@ fn run_main(
     telemetry: Option<TelemetryDest>,
     mermaid_dest: Option<MermaidDest>,
     jdk_home: Option<&str>,
+    real_jdk: bool,
 ) {
     if args.is_empty() {
         eprintln!("Usage: duke run <classfile.class> [string-arg...]");
@@ -792,6 +857,7 @@ fn run_main(
         .unwrap_or_else(|| std::path::Path::new("."));
     let loader = make_loader(jdk_home, &[parent.to_path_buf()]);
     let mut heap = Heap::new();
+    apply_real_jdk_shadow(&mut registry, real_jdk, jdk_home);
     bootstrap_stdlib(&mut registry, &mut heap);
 
     // Build String[] args array on the heap.
@@ -847,6 +913,7 @@ fn run_jar(
     telemetry: Option<TelemetryDest>,
     mermaid_dest: Option<MermaidDest>,
     jdk_home: Option<&str>,
+    real_jdk: bool,
 ) {
     let jar = std::path::Path::new(jar_path);
     let reader = ZipReader::open(jar).unwrap_or_else(|e| {
@@ -875,6 +942,7 @@ fn run_jar(
 
     let mut registry = ClassRegistry::new();
     let mut heap = Heap::new();
+    apply_real_jdk_shadow(&mut registry, real_jdk, jdk_home);
     bootstrap_stdlib(&mut registry, &mut heap);
     let jar_code_source = std::fs::canonicalize(jar).unwrap_or_else(|_| jar.to_path_buf());
     registry.set_default_code_source(jar_code_source.to_string_lossy().to_string());


### PR DESCRIPTION
**Before / After.** Today Duke's `java.*` stdlib is entirely hand-written synthetic classes backed by ~1,244 Rust natives; every missing JDK method is whack-a-mole, and a real jimage class loader is plumbed but never wins because synthetics shadow it. **After (opt-in `--real-jdk` / `DUKE_REAL_JDK=1`):** classes not on a keep-synthetic allowlist load and execute their **real** JDK 21 `java.base` bytecode from the jimage. Default behavior (flag off) is byte-for-byte unchanged.

**Verdict — is real java.base execution viable as the path off synthetic whack-a-mole?** Qualified yes. It works only when migration is *coherent per object-graph*: a class must get BOTH the real classfile layout AND real bytecode dispatch — a half-migration (real layout, synthetic natives) produces silent wrong answers. Once coherent (this PR's Phase 3), real `java.util.HashMap` executes correctly end-to-end. Crucially, the blocker pattern changes character: instead of an open-ended stream of missing synthetic *methods*, real bytecode bottoms out on a small, **enumerable set of true JVM native primitives** (`Unsafe` intrinsics, `Float.floatToRawIntBits`, `Runtime.availableProcessors`, `System.arraycopy`). That's a finite native floor — a tractable target list rather than infinite whack-a-mole.

**What works under the flag**
- **HelloWorld** — works (print/IO stack kept synthetic so it stays layout-coherent with synthetic `System.out`).
- **HashMap** — real `put/get/hash/putVal/containsKey/remove` bytecode runs and is correct (`testPutAndGet`->30, `testContainsKey`->1, `testRemove`->1); eliminates the Phase-2 silent wrong answers.
- **ArrayList** — real constructor chain + `add`/`grow` execute; **one native away** (`java/lang/Float.floatToRawIntBits(F)I`, reached via real `Math.<clinit>` from `ArrayList.grow`).
- **slf4j-simple smoke** — advances past its long-standing baseline wall `java/util/ArrayList.<init>(I)V` into real `org/slf4j/LoggerFactory`, `SubstituteServiceProvider`, and real `java/util/concurrent/ConcurrentHashMap` / `java/lang/Runtime`.

**Blocker list (the finite native floor real bytecode hits — all owned by the native.rs/stdlib.rs session; intentionally NOT added here)**
1. `java/lang/Float.floatToRawIntBits(F)I` — blocks real ArrayList.
2. `java/lang/Runtime.availableProcessors()I` — blocks slf4j (real `ConcurrentHashMap.<clinit>`).
3. `jdk/internal/misc/Unsafe.{objectFieldOffset, compareAndSetReference, getReferenceAcquire, putReferenceRelease}` — the deeper `ConcurrentHashMap` wall just past #2.
4. **Layout-coherence boundary** — synthetic KEEP_SYNTHETIC roots can't hand objects to real bytecode that expects the real field layout (regressed HelloWorld when `PrintStream` went real against a synthetic 1-field `System.out`). Mitigated by keeping the print/IO stack synthetic; longer-term fix is real-allocating those roots or matching synthetic field order to the classfile.

**How**
- `crates/duke-interpreter/src/registry.rs` — `KEEP_SYNTHETIC` allowlist (native-entangled roots: Object/String/Class/Thread/Throwable/System/boxes + print/IO stack); `real_jdk_shadow` flag + `shadow_loader`; `register()` skips the synthetic `ClassContext` for non-allowlisted classes when the jimage has a real classfile; `shadowed_set`/`is_shadowed`/`shadowed_bytecode_override` for dispatch.
- `crates/duke-interpreter/src/execution.rs` — `apply_shadow_override` at the three native-vs-bytecode dispatch sites (invokestatic/special/virtual/interface): a synthetic-native decision is converted to real bytecode when a shadowed class provides a concrete body. Hard no-op when the flag is off (shadowed set empty).
- `duke/src/main.rs` — `--real-jdk` / `--no-real-jdk` / `DUKE_REAL_JDK` env; builds a jimage shadow loader; warns if requested without a jimage.
- The existing `ClassLoadSource` enum and jimage parse->register pipeline are reused unchanged. **Zero edits to `stdlib.rs` / `native.rs`.**

**Testing**
- Flag OFF byte-for-byte unchanged: `cargo test --workspace` -> **2976 passed / 0 failed** (baseline ~2974). `oss_jar_smoke` -> 2 passed / 2 ignored, same `ArrayList.<init>(I)V` blocker.
- New `crates/duke-interpreter/tests/real_jdk_shadow.rs` -> 2/2 (flag-off no-op + flag-on shadows a real class as `Classfile`).
- Flag ON measured manually against the JDK 21 jimage (HelloWorld, ArrayList, HashMap, slf4j) — results above.

**Follow-ups this spike scopes out**
- Add the 3 native primitives above (native.rs session) to unblock ArrayList + push slf4j deeper.
- Decide the layout-coherence strategy for KEEP_SYNTHETIC roots so the allowlist can shrink over time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9f45wteHqgoCqzscRxF6j)_