### PR TITLE
Real-JDK layout coherence: guard, audit, and 12-class allowlist shrink

### DIFF
--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -3000,7 +3000,12 @@ mod tests {
             );
         }
         // The survivor is still reachable and intact.
-        assert_eq!(heap.get(survivor_slot.as_reference().unwrap()).unwrap().class_name, "Survivor");
+        assert_eq!(
+            heap.get(survivor_slot.as_reference().unwrap())
+                .unwrap()
+                .class_name,
+            "Survivor"
+        );
     }
 
     /// A survivor kept rooted across enough minor GCs is evacuated into the old
@@ -3011,8 +3016,10 @@ mod tests {
         // Default promotion age (4): promoted on the 5th survival.
         let payload = heap.allocate("Payload".to_string(), 2);
         let text = heap.allocate_string("hello gc".to_string());
-        heap.write_field(payload, 0, Slot::Int(0x1234_5678)).unwrap();
-        heap.write_field(payload, 1, Slot::Reference(Some(text))).unwrap();
+        heap.write_field(payload, 0, Slot::Int(0x1234_5678))
+            .unwrap();
+        heap.write_field(payload, 1, Slot::Reference(Some(text)))
+            .unwrap();
 
         let mut root = Slot::Reference(Some(payload));
         for _ in 0..=DEFAULT_PROMOTION_AGE {
@@ -3020,7 +3027,11 @@ mod tests {
         }
 
         let promoted = root.as_reference().unwrap();
-        assert_ne!(promoted & OLD_BIT, 0, "survivor should be promoted to old gen");
+        assert_ne!(
+            promoted & OLD_BIT,
+            0,
+            "survivor should be promoted to old gen"
+        );
 
         let obj = heap.get(promoted).unwrap();
         assert_eq!(obj.class_name, "Payload");
@@ -3045,7 +3056,11 @@ mod tests {
         let patched = run_minor_gc(&mut heap, &[Slot::Reference(Some(r))]);
         let new_ref = patched[0].as_reference().unwrap();
 
-        assert_ne!(new_ref & OLD_BIT, 0, "root should now name the old-gen copy");
+        assert_ne!(
+            new_ref & OLD_BIT,
+            0,
+            "root should now name the old-gen copy"
+        );
         assert_ne!(new_ref, r, "root ref must have been remapped");
         assert_eq!(heap.get(new_ref).unwrap().fields[0], Slot::Int(99));
     }
@@ -3065,7 +3080,10 @@ mod tests {
         assert_ne!(new_ref, r, "reference index changed across relocation");
 
         let after = heap.identity_hash(new_ref).unwrap();
-        assert_eq!(before, after, "identity hash must survive relocation unchanged");
+        assert_eq!(
+            before, after,
+            "identity hash must survive relocation unchanged"
+        );
     }
 
     /// Distinct objects get distinct identity hashes, and repeated queries are
@@ -3079,7 +3097,10 @@ mod tests {
         let ha2 = heap.identity_hash(a).unwrap();
         let hb = heap.identity_hash(b).unwrap();
         assert_eq!(ha1, ha2, "repeated identity_hash must be stable");
-        assert_ne!(ha1, hb, "distinct objects must get distinct identity hashes");
+        assert_ne!(
+            ha1, hb,
+            "distinct objects must get distinct identity hashes"
+        );
     }
 
     /// After a promoted object gains an old→young edge, the remembered set keeps
@@ -3126,28 +3147,21 @@ mod tests {
     fn make_executor_with_task(heap: &mut Heap, future_ref: u64, task_ref: u64) -> u64 {
         let exec_ref = heap.allocate("Executor".to_string(), 0);
         heap.get_mut(exec_ref).unwrap().atomic_payload = Some(AtomicPayload::executor(1));
-        let Some(AtomicPayload::Executor(shared)) =
-            &heap.get(exec_ref).unwrap().atomic_payload
+        let Some(AtomicPayload::Executor(shared)) = &heap.get(exec_ref).unwrap().atomic_payload
         else {
             panic!("expected executor payload");
         };
-        shared
-            .state
-            .lock()
-            .unwrap()
-            .queue
-            .push_back(ExecutorTask {
-                future_ref,
-                task_ref,
-                kind: ExecutorTaskKind::Runnable,
-            });
+        shared.state.lock().unwrap().queue.push_back(ExecutorTask {
+            future_ref,
+            task_ref,
+            kind: ExecutorTaskKind::Runnable,
+        });
         exec_ref
     }
 
     /// Reads the single queued task from an executor object.
     fn executor_task(heap: &Heap, exec_ref: u64) -> ExecutorTask {
-        let Some(AtomicPayload::Executor(shared)) =
-            &heap.get(exec_ref).unwrap().atomic_payload
+        let Some(AtomicPayload::Executor(shared)) = &heap.get(exec_ref).unwrap().atomic_payload
         else {
             panic!("expected executor payload");
         };
@@ -3350,7 +3364,8 @@ mod tests {
 
         // A young object referencing the second (moving) old survivor.
         let young = heap.allocate("Young".to_string(), 1);
-        heap.write_field(young, 0, Slot::Reference(Some(keep1))).unwrap();
+        heap.write_field(young, 0, Slot::Reference(Some(keep1)))
+            .unwrap();
 
         let keep_roots = [Slot::Reference(Some(keep0)), Slot::Reference(Some(keep1))];
         heap.compact_old(&keep_roots);
@@ -3396,7 +3411,8 @@ mod tests {
 
         // A young object referenced only by the old `holder` (old→young edge).
         let young = heap.allocate("Payload".to_string(), 0);
-        heap.write_field(holder, 0, Slot::Reference(Some(young))).unwrap();
+        heap.write_field(holder, 0, Slot::Reference(Some(young)))
+            .unwrap();
         let holder_idx = (holder & !OLD_BIT) as usize;
         assert!(heap.remembered_set.contains(&holder_idx));
 
@@ -3417,7 +3433,9 @@ mod tests {
         // The old→young edge still protects the young object on a minor GC even
         // though `young` is not directly rooted.
         run_minor_gc(&mut heap, &[Slot::Reference(Some(new_holder))]);
-        let edge = heap.get(new_holder).unwrap().fields[0].as_reference().unwrap();
+        let edge = heap.get(new_holder).unwrap().fields[0]
+            .as_reference()
+            .unwrap();
         assert_eq!(heap.get(edge).unwrap().class_name, "Payload");
     }
 

--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -46,6 +46,97 @@ fn apply_shadow_override(
     }
 }
 
+/// Runtime layout-coherence guard for `getfield`/`putfield` under real-JDK shadow mode.
+///
+/// Validates that the field access about to be performed is layout-coherent: that the
+/// resolved slot is in bounds for the target object, and that the field-resolving class
+/// and the object's runtime class agree on which layout regime (real classfile layout vs
+/// hand-written synthetic layout) they were built under. A half-migrated object graph —
+/// e.g. real bytecode computing a slot from the *real* layout while the `HeapObject` was
+/// allocated with the *synthetic* layout — silently reads/writes the wrong slot with no
+/// error; this guard makes that corruption loud instead of silent.
+///
+/// This is only ever called when `DUKE_LAYOUT_CHECK` is `warn`/`fail` **and** real-JDK
+/// shadow mode is enabled (checked cheaply by the caller), so it is a hard no-op — never
+/// even reached — in the default configuration.
+///
+/// On an incoherent access it emits an unmistakable `[layout-coherence]` diagnostic. In
+/// [`LayoutCheckMode::Fail`] mode it additionally returns an error to abort the access;
+/// in [`LayoutCheckMode::Warn`] mode it returns `Ok(())` so execution continues.
+#[allow(clippy::too_many_arguments)]
+fn layout_coherence_check(
+    registry: &ClassRegistry,
+    heap: &duke_gc::Heap,
+    obj_ref: u64,
+    resolving_class_key: &str,
+    field_name: &str,
+    slot: usize,
+    accessing_class: &str,
+    accessing_method: &str,
+    op: &str,
+) -> Result<()> {
+    // Strip any provenance suffix (`internal_name\0source`) for display.
+    fn frag(name: &str) -> &str {
+        name.split_once('\0').map_or(name, |(n, _)| n)
+    }
+    let obj = heap.get(obj_ref)?;
+    let object_class = obj.class_name.as_str();
+    let actual_slots = obj.fields.len();
+
+    let resolving_shadowed = registry.is_shadowed(resolving_class_key);
+    let object_shadowed = registry.is_shadowed(object_class);
+
+    let hard_oob = slot >= actual_slots;
+    let regime_mismatch = resolving_shadowed != object_shadowed;
+
+    // Common path: coherent access. Cheap early return, no string formatting.
+    if !hard_oob && !regime_mismatch {
+        return Ok(());
+    }
+
+    let label = |shadowed: bool, source: Option<ClassLoadSource>| -> &'static str {
+        match (shadowed, source) {
+            (true, _) | (_, Some(ClassLoadSource::Classfile)) => "real",
+            (false, Some(ClassLoadSource::Synthetic)) => "synthetic",
+            (false, None) => "unloaded",
+        }
+    };
+    let resolving_expected = registry.total_instance_slot_count(resolving_class_key);
+    let resolving_label = label(resolving_shadowed, registry.load_source_of(resolving_class_key));
+    let object_label = label(object_shadowed, registry.load_source_of(object_class));
+
+    let bounds = if hard_oob {
+        format!("slot {slot} out of bounds (object has {actual_slots} slots)")
+    } else {
+        format!("slot {slot} in bounds ({actual_slots} slots) but layout regimes disagree")
+    };
+
+    eprintln!(
+        "[layout-coherence] INCOHERENT {op} {resolving}.{field} in {aclass}.{amethod}: \
+         resolving-class {resolving} ({rlabel}, expects {rexpected} slots) vs \
+         object-class {object} ({olabel}, has {actual_slots} slots); {bounds}",
+        op = op,
+        resolving = frag(resolving_class_key),
+        field = field_name,
+        aclass = accessing_class,
+        amethod = accessing_method,
+        rlabel = resolving_label,
+        rexpected = resolving_expected,
+        object = frag(object_class),
+        olabel = object_label,
+        actual_slots = actual_slots,
+        bounds = bounds,
+    );
+
+    if registry.layout_check_mode() == LayoutCheckMode::Fail {
+        return Err(Error::FieldOutOfBounds {
+            index: slot,
+            length: actual_slots,
+        });
+    }
+    Ok(())
+}
+
 /// Executes the active method's bytecode instructions to completion or exception.
 ///
 /// This is the central run-loop of the interpreter. It continually fetches the
@@ -1429,6 +1520,29 @@ pub fn run_execution(
                 let r = frame.pop_ref()?;
                 registry.ensure_loaded_from(&target_class, Some(current_class.as_str()), loader)?;
                 let fidx = field_slot_idx(registry, &target_class_key, &field_name)?;
+                // Layout-coherence guard: hard no-op unless DUKE_LAYOUT_CHECK is set AND
+                // real-JDK shadow mode is on (both cheap checks short-circuit when off).
+                if registry.real_jdk_shadow_enabled()
+                    && registry.layout_check_mode() != LayoutCheckMode::Off
+                {
+                    let method_name = registry
+                        .get(current_class)
+                        .ok()
+                        .and_then(|ctx| ctx.methods.get(*method_idx))
+                        .map_or("<unknown>", |m| m.name.as_str())
+                        .to_string();
+                    layout_coherence_check(
+                        registry,
+                        heap,
+                        r,
+                        &target_class_key,
+                        &field_name,
+                        fidx,
+                        current_class,
+                        &method_name,
+                        "getfield",
+                    )?;
+                }
                 let val = heap.get(r)?.fields[fidx];
                 frame.push(val)?;
             }
@@ -1443,6 +1557,29 @@ pub fn run_execution(
                 let r = frame.pop_ref()?;
                 registry.ensure_loaded_from(&target_class, Some(current_class.as_str()), loader)?;
                 let fidx = field_slot_idx(registry, &target_class_key, &field_name)?;
+                // Layout-coherence guard: hard no-op unless DUKE_LAYOUT_CHECK is set AND
+                // real-JDK shadow mode is on (both cheap checks short-circuit when off).
+                if registry.real_jdk_shadow_enabled()
+                    && registry.layout_check_mode() != LayoutCheckMode::Off
+                {
+                    let method_name = registry
+                        .get(current_class)
+                        .ok()
+                        .and_then(|ctx| ctx.methods.get(*method_idx))
+                        .map_or("<unknown>", |m| m.name.as_str())
+                        .to_string();
+                    layout_coherence_check(
+                        registry,
+                        heap,
+                        r,
+                        &target_class_key,
+                        &field_name,
+                        fidx,
+                        current_class,
+                        &method_name,
+                        "putfield",
+                    )?;
+                }
                 heap.write_field(r, fidx, val)?;
             }
             Instruction::Getstatic(cp_idx) => {

--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -101,7 +101,10 @@ fn layout_coherence_check(
         }
     };
     let resolving_expected = registry.total_instance_slot_count(resolving_class_key);
-    let resolving_label = label(resolving_shadowed, registry.load_source_of(resolving_class_key));
+    let resolving_label = label(
+        resolving_shadowed,
+        registry.load_source_of(resolving_class_key),
+    );
     let object_label = label(object_shadowed, registry.load_source_of(object_class));
 
     let bounds = if hard_oob {

--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -83,16 +83,15 @@ fn layout_coherence_check(
     let object_class = obj.class_name.as_str();
     let actual_slots = obj.fields.len();
 
-    let resolving_shadowed = registry.is_shadowed(resolving_class_key);
-    let object_shadowed = registry.is_shadowed(object_class);
-
-    let hard_oob = slot >= actual_slots;
-    let regime_mismatch = resolving_shadowed != object_shadowed;
-
-    // Common path: coherent access. Cheap early return, no string formatting.
-    if !hard_oob && !regime_mismatch {
+    // Single decision point, shared with the unit tests (see `is_layout_incoherent`).
+    // Common path: coherent access → cheap early return, no string formatting.
+    if !registry.is_layout_incoherent(resolving_class_key, object_class, slot, actual_slots) {
         return Ok(());
     }
+
+    let resolving_shadowed = registry.is_shadowed(resolving_class_key);
+    let object_shadowed = registry.is_shadowed(object_class);
+    let hard_oob = slot >= actual_slots;
 
     let label = |shadowed: bool, source: Option<ClassLoadSource>| -> &'static str {
         match (shadowed, source) {

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -740,7 +740,7 @@ impl ClassRegistry {
                 eprintln!("[real-jdk] shadowing synthetic {}", ctx.class_name);
             }
             self.shadowed_set.insert(ctx.class_name.clone());
-            self.shadowed_classes.push(ctx.class_name.clone());
+            self.shadowed_classes.push(ctx.class_name);
             return;
         }
         self.classes.insert(ctx.class_name.clone(), ctx);

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -793,15 +793,38 @@ impl ClassRegistry {
         self.get(class).ok().map(|c| c.load_source)
     }
 
+    /// Whether a class uses the **real** (classfile) instance-field layout, as opposed to
+    /// a hand-written **synthetic** layout. A class is real-layout when it is shadowed
+    /// (its synthetic stub was dropped so it loads real JDK bytecode) or its already-loaded
+    /// [`ClassLoadSource`] is [`ClassLoadSource::Classfile`]; synthetic-layout when its load
+    /// source is [`ClassLoadSource::Synthetic`]. Returns `None` when the class is not (yet)
+    /// loaded and not shadowed, so its regime cannot be determined. Used by the
+    /// layout-coherence guard to compare regimes on ground truth rather than on the
+    /// `is_shadowed` bookkeeping alone (which misfires when both sides are real).
+    #[must_use]
+    pub fn effective_layout_is_real(&self, class: &str) -> Option<bool> {
+        if self.is_shadowed(class) {
+            return Some(true);
+        }
+        match self.load_source_of(class) {
+            Some(ClassLoadSource::Classfile) => Some(true),
+            Some(ClassLoadSource::Synthetic) => Some(false),
+            None => None,
+        }
+    }
+
     /// Core layout-coherence predicate used by the `getfield`/`putfield` runtime guard.
     ///
     /// A field access is **incoherent** when either:
     /// * the resolved `slot` is out of bounds for the target object
     ///   (`slot >= object_slot_count`) — the concrete "silent corruption" case; or
-    /// * the field-resolving class and the object's runtime class disagree on which
-    ///   shadow (layout) regime they were built under
-    ///   (`is_shadowed(resolving) != is_shadowed(object)`) — a half-migrated object graph
-    ///   where real bytecode and a synthetically-allocated object compute different slots.
+    /// * the field-resolving class and the object's runtime class use *different* layout
+    ///   regimes — one real (classfile) layout, the other synthetic layout (see
+    ///   [`Self::effective_layout_is_real`]) — a half-migrated object graph where real
+    ///   bytecode and a synthetically-allocated object compute different slots. When either
+    ///   side's regime is unknown (unloaded), no mismatch is reported. Comparing effective
+    ///   layout (rather than raw `is_shadowed`) avoids false positives on the common case
+    ///   where a shadowed superclass and a directly-real subclass are *both* real layout.
     ///
     /// Pure and deterministic (no env, no mode); the mode (`warn`/`fail`) only governs what
     /// the guard *does* with an incoherent verdict. Exposed so the guard and its tests share
@@ -814,8 +837,16 @@ impl ClassRegistry {
         slot: usize,
         object_slot_count: usize,
     ) -> bool {
-        slot >= object_slot_count
-            || self.is_shadowed(resolving_class) != self.is_shadowed(object_class)
+        if slot >= object_slot_count {
+            return true;
+        }
+        match (
+            self.effective_layout_is_real(resolving_class),
+            self.effective_layout_is_real(object_class),
+        ) {
+            (Some(resolving_real), Some(object_real)) => resolving_real != object_real,
+            _ => false,
+        }
     }
 
     /// Count a real jimage classfile's own (per-class, declared) instance fields, i.e.

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -58,6 +58,35 @@ fn class_internal_name_fragment(name: &str) -> &str {
         .map_or(name, |(internal_name, _)| internal_name)
 }
 
+/// Runtime layout-coherence guard mode, selected once from the `DUKE_LAYOUT_CHECK`
+/// environment variable.
+///
+/// The guard only ever does work when the mode is not [`LayoutCheckMode::Off`] **and**
+/// real-JDK shadow mode is enabled; in every other configuration it is a hard no-op with
+/// zero overhead. See [`ClassRegistry::layout_check_mode`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LayoutCheckMode {
+    /// Default (env unset or any unrecognized value). No checking, zero overhead.
+    #[default]
+    Off,
+    /// Emit a loud `[layout-coherence]` diagnostic on an incoherent access and continue.
+    Warn,
+    /// Emit the diagnostic and abort the access with a runtime error.
+    Fail,
+}
+
+impl LayoutCheckMode {
+    /// Parse the `DUKE_LAYOUT_CHECK` environment variable once. Recognized values are
+    /// `warn` and `fail` (case-insensitive); anything else (including unset) is [`Self::Off`].
+    fn from_env() -> Self {
+        match std::env::var("DUKE_LAYOUT_CHECK") {
+            Ok(v) if v.eq_ignore_ascii_case("warn") => Self::Warn,
+            Ok(v) if v.eq_ignore_ascii_case("fail") => Self::Fail,
+            _ => Self::Off,
+        }
+    }
+}
+
 /// Metadata for a lambda proxy object created by `LambdaMetafactory`.
 ///
 /// When the JVM encounters an `invokedynamic` instruction targeting `LambdaMetafactory`,
@@ -405,6 +434,9 @@ pub struct ClassRegistry {
     /// O(1) membership mirror of [`Self::shadowed_classes`] (internal names), used by
     /// [`Self::is_shadowed`] during native-vs-bytecode dispatch decisions.
     shadowed_set: HashSet<String>,
+    /// Layout-coherence guard mode, parsed once from `DUKE_LAYOUT_CHECK` at construction.
+    /// Only ever active alongside [`Self::real_jdk_shadow`]; [`LayoutCheckMode::Off`] by default.
+    layout_check: LayoutCheckMode,
     /// Storage for execution telemetry (e.g. instruction counts, GC pause times).
     ///
     /// The [`TelemetryStore`](duke_telemetry::TelemetryStore) collects performance metrics
@@ -440,6 +472,7 @@ impl ClassRegistry {
             shadow_loader: None,
             shadowed_classes: Vec::new(),
             shadowed_set: HashSet::new(),
+            layout_check: LayoutCheckMode::from_env(),
             #[cfg(feature = "telemetry")]
             telemetry: duke_telemetry::TelemetryStore::default(),
         }
@@ -724,6 +757,39 @@ impl ClassRegistry {
     #[must_use]
     pub const fn real_jdk_shadow_enabled(&self) -> bool {
         self.real_jdk_shadow
+    }
+
+    /// The layout-coherence guard mode selected from `DUKE_LAYOUT_CHECK`. Always
+    /// [`LayoutCheckMode::Off`] unless the env var requested `warn`/`fail`.
+    #[must_use]
+    pub const fn layout_check_mode(&self) -> LayoutCheckMode {
+        self.layout_check
+    }
+
+    /// Sum a class's instance fields across its full superclass chain — the number of
+    /// heap slots an instance of `class` is allocated with. Mirrors the allocation-time
+    /// sizing used by the `new` opcode. Used by the layout-coherence guard.
+    #[must_use]
+    pub fn total_instance_slot_count(&self, class: &str) -> usize {
+        let mut count = self.get(class).map_or(0, |c| c.instance_field_count);
+        let mut sc = self.get(class).ok().and_then(|c| c.super_class.clone());
+        while let Some(ref s) = sc {
+            match self.get(s) {
+                Ok(sctx) => {
+                    count += sctx.instance_field_count;
+                    sc = sctx.super_class.clone();
+                }
+                Err(_) => break,
+            }
+        }
+        count
+    }
+
+    /// The [`ClassLoadSource`] of a loaded class, or `None` if not (yet) loaded. Used by
+    /// the layout-coherence guard's diagnostic to label synthetic vs classfile layouts.
+    #[must_use]
+    pub fn load_source_of(&self, class: &str) -> Option<ClassLoadSource> {
+        self.get(class).ok().map(|c| c.load_source)
     }
 
     /// Internal names of synthetic classes that were shadowed (skipped) by real JDK

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -793,6 +793,31 @@ impl ClassRegistry {
         self.get(class).ok().map(|c| c.load_source)
     }
 
+    /// Core layout-coherence predicate used by the `getfield`/`putfield` runtime guard.
+    ///
+    /// A field access is **incoherent** when either:
+    /// * the resolved `slot` is out of bounds for the target object
+    ///   (`slot >= object_slot_count`) — the concrete "silent corruption" case; or
+    /// * the field-resolving class and the object's runtime class disagree on which
+    ///   shadow (layout) regime they were built under
+    ///   (`is_shadowed(resolving) != is_shadowed(object)`) — a half-migrated object graph
+    ///   where real bytecode and a synthetically-allocated object compute different slots.
+    ///
+    /// Pure and deterministic (no env, no mode); the mode (`warn`/`fail`) only governs what
+    /// the guard *does* with an incoherent verdict. Exposed so the guard and its tests share
+    /// one decision point.
+    #[must_use]
+    pub fn is_layout_incoherent(
+        &self,
+        resolving_class: &str,
+        object_class: &str,
+        slot: usize,
+        object_slot_count: usize,
+    ) -> bool {
+        slot >= object_slot_count
+            || self.is_shadowed(resolving_class) != self.is_shadowed(object_class)
+    }
+
     /// Count a real jimage classfile's own (per-class, declared) instance fields, i.e.
     /// non-`static` fields, by fetching and parsing its bytecode via the shadow loader.
     /// Returns `None` if there is no shadow loader, the class isn't resolvable, or the
@@ -807,6 +832,26 @@ impl ClassRegistry {
                 .filter(|f| !f.access_flags.contains(FieldAccessFlags::STATIC))
                 .count(),
         )
+    }
+
+    /// The zero-layout-risk migration candidates identified by the layout audit: the
+    /// `KEEP_SYNTHETIC` classes whose synthetic per-class instance-field count already
+    /// matches the real jimage layout (or whose real layout has zero instance fields), so
+    /// they could safely leave the allowlist. Empty when real-JDK shadow mode is off (no
+    /// real layout to compare against). Shares its rule with [`Self::run_layout_audit`].
+    #[must_use]
+    pub fn layout_audit_candidates(&self) -> Vec<String> {
+        if !self.real_jdk_shadow {
+            return Vec::new();
+        }
+        KEEP_SYNTHETIC
+            .iter()
+            .filter_map(|&name| {
+                let synth = self.get(name).ok().map(|c| c.instance_field_count)?;
+                let real = self.real_instance_field_count(name)?;
+                (synth == real || real == 0).then(|| name.to_string())
+            })
+            .collect()
     }
 
     /// Static layout audit (gated by `DUKE_LAYOUT_AUDIT=1` at the call site): for each
@@ -838,8 +883,6 @@ impl ClassRegistry {
             "class", "synth", "real"
         );
 
-        let mut candidates: Vec<&str> = Vec::new();
-
         // KEEP_SYNTHETIC classes: synthetic ClassContext is still registered, so we can
         // compare both sides. These are the migration-candidate decisions.
         for &name in KEEP_SYNTHETIC {
@@ -847,10 +890,6 @@ impl ClassRegistry {
             let real = self.real_instance_field_count(name);
             let (synth_s, real_s, verdict) = match (synth, real) {
                 (Some(s), Some(r)) => {
-                    let zero_risk = s == r || r == 0;
-                    if zero_risk {
-                        candidates.push(name);
-                    }
                     let v = if s == r {
                         "MATCH (candidate)"
                     } else if r == 0 {
@@ -888,6 +927,7 @@ impl ClassRegistry {
             }
         }
 
+        let candidates = self.layout_audit_candidates();
         eprintln!(
             "[layout-audit] SUMMARY: {} of {} KEEP_SYNTHETIC classes are zero-layout-risk \
              migration candidates",

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -20,35 +20,23 @@ use crate::context::{ClassContext, ClassLoadSource};
 /// a specific field/heap layout (special `HeapObject` slots, dense hand-registered natives),
 /// so loading their real JDK bytecode would break those natives.
 const KEEP_SYNTHETIC: &[&str] = &[
-    "java/lang/Object",
     "java/lang/String",
     "java/lang/Class",
     "java/lang/Thread",
     "java/lang/ThreadGroup",
     "java/lang/Throwable",
     "java/lang/System",
-    "java/lang/Integer",
-    "java/lang/Long",
-    "java/lang/Short",
-    "java/lang/Byte",
-    "java/lang/Boolean",
-    "java/lang/Character",
-    "java/lang/Float",
-    "java/lang/Double",
-    "java/lang/Number",
     // Print/IO stack: `System.out`/`System.err` are allocated synthetically by
     // `bootstrap_stdlib` (System is KEEP_SYNTHETIC) with the synthetic PrintStream layout.
     // Keeping the whole stream/writer stack synthetic prevents real JDK bytecode from
     // running against those synthetically-allocated instances (layout-coherence boundary).
     "java/io/PrintStream",
-    "java/io/OutputStream",
     "java/io/FilterOutputStream",
     "java/io/BufferedOutputStream",
     "java/io/Writer",
     "java/io/OutputStreamWriter",
     "java/io/BufferedWriter",
     "java/io/PrintWriter",
-    "java/io/InputStream",
     "java/io/FileOutputStream",
     "java/io/FileInputStream",
     "java/io/FileDescriptor",

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -9,6 +9,7 @@ use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
 
+use duke_classfile::FieldAccessFlags;
 use duke_loader::{ClassLoader, LocatedResource};
 use duke_runtime::{Error, Result, Slot};
 
@@ -790,6 +791,112 @@ impl ClassRegistry {
     #[must_use]
     pub fn load_source_of(&self, class: &str) -> Option<ClassLoadSource> {
         self.get(class).ok().map(|c| c.load_source)
+    }
+
+    /// Count a real jimage classfile's own (per-class, declared) instance fields, i.e.
+    /// non-`static` fields, by fetching and parsing its bytecode via the shadow loader.
+    /// Returns `None` if there is no shadow loader, the class isn't resolvable, or the
+    /// bytecode doesn't parse. Used only by [`Self::run_layout_audit`].
+    fn real_instance_field_count(&self, class: &str) -> Option<usize> {
+        let loader = self.shadow_loader.as_ref()?;
+        let bytes = loader.find_class(class).ok()?;
+        let cf = duke_classfile::parse(&bytes).ok()?;
+        Some(
+            cf.fields
+                .iter()
+                .filter(|f| !f.access_flags.contains(FieldAccessFlags::STATIC))
+                .count(),
+        )
+    }
+
+    /// Static layout audit (gated by `DUKE_LAYOUT_AUDIT=1` at the call site): for each
+    /// `KEEP_SYNTHETIC` class and a sample of shadowed classes, compare the hand-written
+    /// synthetic per-class instance-field count against the real jimage classfile's
+    /// per-class instance-field count. Prints a table and a count of zero-layout-risk
+    /// migration candidates — classes whose synthetic layout already matches the real
+    /// layout (or which have zero instance fields), so they could safely leave the
+    /// `KEEP_SYNTHETIC` allowlist. This is a diagnostic tool, never on any hot path.
+    ///
+    /// A hard no-op unless real-JDK shadow mode is enabled (no shadow loader → nothing to
+    /// compare against).
+    pub fn run_layout_audit(&self) {
+        const SHADOW_SAMPLE: usize = 20;
+        if !self.real_jdk_shadow {
+            eprintln!("[layout-audit] real-jdk shadow mode is not enabled; audit skipped");
+            return;
+        }
+        if self.shadow_loader.is_none() {
+            eprintln!("[layout-audit] no shadow loader available; audit skipped");
+            return;
+        }
+        eprintln!(
+            "[layout-audit] real-jdk layout audit: synthetic vs real (jimage) per-class \
+             instance-field counts"
+        );
+        eprintln!(
+            "[layout-audit] {:<40} {:>6} {:>6}  verdict",
+            "class", "synth", "real"
+        );
+
+        let mut candidates: Vec<&str> = Vec::new();
+
+        // KEEP_SYNTHETIC classes: synthetic ClassContext is still registered, so we can
+        // compare both sides. These are the migration-candidate decisions.
+        for &name in KEEP_SYNTHETIC {
+            let synth = self.get(name).ok().map(|c| c.instance_field_count);
+            let real = self.real_instance_field_count(name);
+            let (synth_s, real_s, verdict) = match (synth, real) {
+                (Some(s), Some(r)) => {
+                    let zero_risk = s == r || r == 0;
+                    if zero_risk {
+                        candidates.push(name);
+                    }
+                    let v = if s == r {
+                        "MATCH (candidate)"
+                    } else if r == 0 {
+                        "real has 0 instance fields (candidate)"
+                    } else {
+                        "MISMATCH"
+                    };
+                    (s.to_string(), r.to_string(), v)
+                }
+                (Some(s), None) => (s.to_string(), "-".to_string(), "no real classfile"),
+                (None, Some(r)) => ("-".to_string(), r.to_string(), "not synthetic-registered"),
+                (None, None) => ("-".to_string(), "-".to_string(), "unavailable"),
+            };
+            eprintln!("[layout-audit] {name:<40} {synth_s:>6} {real_s:>6}  {verdict}");
+        }
+
+        // Sample of shadowed classes: their synthetic ClassContext was dropped at
+        // registration (they now use real bytecode+layout), so only the real count is
+        // available — shown as informational confirmation of the migrated layout.
+        let sample_total = self.shadowed_classes.len();
+        if sample_total > 0 {
+            eprintln!(
+                "[layout-audit] --- shadowed sample ({} of {} shadowed classes) ---",
+                sample_total.min(SHADOW_SAMPLE),
+                sample_total
+            );
+            for name in self.shadowed_classes.iter().take(SHADOW_SAMPLE) {
+                let real_s = self
+                    .real_instance_field_count(name)
+                    .map_or_else(|| "-".to_string(), |r| r.to_string());
+                eprintln!(
+                    "[layout-audit] {name:<40} {:>6} {real_s:>6}  shadowed (real layout)",
+                    "dropped"
+                );
+            }
+        }
+
+        eprintln!(
+            "[layout-audit] SUMMARY: {} of {} KEEP_SYNTHETIC classes are zero-layout-risk \
+             migration candidates",
+            candidates.len(),
+            KEEP_SYNTHETIC.len()
+        );
+        if !candidates.is_empty() {
+            eprintln!("[layout-audit] candidates: {}", candidates.join(", "));
+        }
     }
 
     /// Internal names of synthetic classes that were shadowed (skipped) by real JDK

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -3260,12 +3260,9 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         "()Ljava/lang/String;",
         native_class_get_package_name,
     );
-    registry.natives_mut().register(
-        "java/lang/Class",
-        "isArray",
-        "()Z",
-        native_class_is_array,
-    );
+    registry
+        .natives_mut()
+        .register("java/lang/Class", "isArray", "()Z", native_class_is_array);
     registry.natives_mut().register(
         "java/lang/Class",
         "desiredAssertionStatus",

--- a/crates/duke-interpreter/tests/layout_coherence.rs
+++ b/crates/duke-interpreter/tests/layout_coherence.rs
@@ -168,7 +168,10 @@ fn flag_off_helloworld_runs_identically() {
         "([Ljava/lang/String;)V",
         &[duke_runtime::Slot::Reference(None)],
     );
-    assert!(result.is_ok(), "HelloWorld must run to completion: {result:?}");
+    assert!(
+        result.is_ok(),
+        "HelloWorld must run to completion: {result:?}"
+    );
     let printed = String::from_utf8_lossy(&out);
     assert!(
         printed.contains("Hello, World!"),

--- a/crates/duke-interpreter/tests/layout_coherence.rs
+++ b/crates/duke-interpreter/tests/layout_coherence.rs
@@ -1,0 +1,212 @@
+//! Integration tests for the real-JDK layout-coherence guard and the static layout
+//! audit added alongside real-JDK shadow mode.
+//!
+//! The guard (`DUKE_LAYOUT_CHECK=warn|fail`) validates `getfield`/`putfield` accesses
+//! under real-JDK shadow mode; its decision is the pure predicate
+//! [`ClassRegistry::is_layout_incoherent`], which these tests exercise directly. The audit
+//! (`DUKE_LAYOUT_AUDIT=1`) reports zero-layout-risk migration candidates via
+//! [`ClassRegistry::layout_audit_candidates`].
+//!
+//! Flag-OFF behavior (the default) must be byte-for-byte unchanged: the guard is provably
+//! a no-op because its gate (`real_jdk_shadow_enabled() && layout_check_mode() != Off`) is
+//! false, and a normal program (`HelloWorld`) runs identically.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use duke_gc::Heap;
+use duke_interpreter::{
+    ClassRegistry, LayoutCheckMode, bootstrap_stdlib, build_class_context,
+    execute_class_to_completion,
+};
+use duke_loader::{BootstrapLoader, ClassLoader, DirectoryLoader};
+
+/// Locate a JDK jimage (`lib/modules`), preferring `JAVA_HOME`.
+fn jdk_modules_path() -> Option<PathBuf> {
+    let from_java_home = std::env::var_os("JAVA_HOME")
+        .map(PathBuf::from)
+        .map(|path| path.join("lib/modules"));
+    let fallbacks = [
+        PathBuf::from("/usr/lib/jvm/java-21-openjdk-amd64/lib/modules"),
+        PathBuf::from("/usr/lib/jvm/default-java/lib/modules"),
+    ];
+    from_java_home
+        .into_iter()
+        .chain(fallbacks)
+        .find(|path| path.exists())
+}
+
+/// Build a jimage-backed shadow loader, or `None` when no JDK jimage is present.
+fn jimage_loader() -> Option<Arc<dyn ClassLoader + Send + Sync>> {
+    let modules = jdk_modules_path()?;
+    let loader = BootstrapLoader::new(&modules, Vec::<PathBuf>::new()).ok()?;
+    Some(Arc::new(loader))
+}
+
+/// Absolute path to `tests/fixtures` at the repository root.
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures")
+}
+
+// ---------------------------------------------------------------------------
+// (a) Guard decision: the incoherence predicate flags corruption
+// ---------------------------------------------------------------------------
+
+/// (a1) Deterministic, no-jimage: the hard slot-bounds arm of the predicate. An access
+/// whose resolved slot is out of bounds for the target object is always incoherent; an
+/// in-bounds access between two same-regime (non-shadowed) classes is coherent.
+#[test]
+fn predicate_flags_out_of_bounds_slot() {
+    let registry = ClassRegistry::new();
+
+    // No shadow mode: neither class is shadowed, so regime always matches and only the
+    // bounds arm can fire.
+    assert!(
+        registry.is_layout_incoherent("Foo", "Bar", 3, 2),
+        "slot 3 into a 2-slot object must be flagged incoherent (silent-corruption case)"
+    );
+    assert!(
+        registry.is_layout_incoherent("Foo", "Bar", 2, 2),
+        "slot 2 into a 2-slot object (== len) must be flagged incoherent"
+    );
+    assert!(
+        !registry.is_layout_incoherent("Foo", "Bar", 1, 2),
+        "in-bounds access between two non-shadowed classes must be coherent"
+    );
+    assert!(
+        !registry.is_layout_incoherent("Foo", "Foo", 0, 1),
+        "in-bounds self access must be coherent"
+    );
+}
+
+/// (a2) jimage-gated: the shadow-regime arm. A real (shadowed) resolving class accessing
+/// a synthetic (`KEEP_SYNTHETIC`) object — an in-bounds slot, but the two disagree on layout
+/// regime — is flagged incoherent, which is exactly the half-migrated corruption the guard
+/// exists to catch. A same-regime access is coherent even at the same slot.
+#[test]
+fn predicate_flags_shadow_regime_mismatch() {
+    let Some(loader) = jimage_loader() else {
+        eprintln!("skipping predicate_flags_shadow_regime_mismatch: no JDK jimage available");
+        return;
+    };
+
+    let mut registry = ClassRegistry::new();
+    let mut heap = Heap::new();
+    registry.enable_real_jdk_shadow(Arc::clone(&loader));
+    bootstrap_stdlib(&mut registry, &mut heap);
+
+    let shadowed = registry
+        .shadowed_classes()
+        .first()
+        .cloned()
+        .expect("expected at least one shadowed class under real-jdk shadow mode");
+    assert!(registry.is_shadowed(&shadowed));
+    // A KEEP_SYNTHETIC root is never shadowed (synthetic layout).
+    let synthetic = "java/lang/String";
+    assert!(!registry.is_shadowed(synthetic));
+
+    // In bounds (large slot budget) but the resolving class is real while the object is
+    // synthetic → regime mismatch → incoherent.
+    assert!(
+        registry.is_layout_incoherent(&shadowed, synthetic, 0, 1000),
+        "real resolving-class ({shadowed}) vs synthetic object-class ({synthetic}) must be \
+         flagged incoherent even at an in-bounds slot"
+    );
+    // Same regime on both sides → coherent (only bounds could fire, and slot is in range).
+    assert!(
+        !registry.is_layout_incoherent(&shadowed, &shadowed, 0, 1000),
+        "same-regime in-bounds access must be coherent"
+    );
+    assert!(
+        !registry.is_layout_incoherent(synthetic, synthetic, 0, 1000),
+        "same-regime synthetic in-bounds access must be coherent"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (b) Flag-OFF regression: default behavior is unchanged
+// ---------------------------------------------------------------------------
+
+/// A default registry has the guard provably disabled: shadow mode is off and the layout
+/// check mode is `Off`, so the guard's gate can never be true and the getfield/putfield
+/// fast path is byte-for-byte the original.
+#[test]
+fn flag_off_guard_is_provably_disabled() {
+    let registry = ClassRegistry::new();
+    assert!(!registry.real_jdk_shadow_enabled());
+    assert_eq!(registry.layout_check_mode(), LayoutCheckMode::Off);
+    // The audit likewise reports no candidates when shadow mode is off.
+    assert!(registry.layout_audit_candidates().is_empty());
+}
+
+/// `HelloWorld` runs identically with the guard off (the default configuration): it executes
+/// to completion and prints "Hello, World!". No shadow mode, no layout check.
+#[test]
+fn flag_off_helloworld_runs_identically() {
+    let class_path = fixtures_dir().join("HelloWorld.class");
+    let bytes = std::fs::read(&class_path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", class_path.display()));
+    let cf = duke_classfile::parse(&bytes).expect("HelloWorld.class should parse");
+    let ctx = build_class_context(&cf);
+    let entry_class = ctx.class_name.clone();
+
+    let mut registry = ClassRegistry::new();
+    registry.register(ctx);
+    let mut heap = Heap::new();
+    bootstrap_stdlib(&mut registry, &mut heap);
+    assert_eq!(registry.layout_check_mode(), LayoutCheckMode::Off);
+
+    let loader = DirectoryLoader::new(fixtures_dir());
+    let mut out: Vec<u8> = Vec::new();
+    let result = execute_class_to_completion(
+        &mut registry,
+        loader,
+        &mut heap,
+        &mut out,
+        &entry_class,
+        "main",
+        "([Ljava/lang/String;)V",
+        &[duke_runtime::Slot::Reference(None)],
+    );
+    assert!(result.is_ok(), "HelloWorld must run to completion: {result:?}");
+    let printed = String::from_utf8_lossy(&out);
+    assert!(
+        printed.contains("Hello, World!"),
+        "expected HelloWorld output, got: {printed:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (c) Audit produces a non-empty candidate report without panicking
+// ---------------------------------------------------------------------------
+
+/// jimage-gated: with shadow mode on, the audit runs without panicking and identifies a
+/// non-empty set of zero-layout-risk migration candidates (e.g. the boxed number types,
+/// whose synthetic layout already matches the real jimage layout).
+#[test]
+fn audit_reports_nonempty_candidates() {
+    let Some(loader) = jimage_loader() else {
+        eprintln!("skipping audit_reports_nonempty_candidates: no JDK jimage available");
+        return;
+    };
+
+    let mut registry = ClassRegistry::new();
+    let mut heap = Heap::new();
+    registry.enable_real_jdk_shadow(loader);
+    bootstrap_stdlib(&mut registry, &mut heap);
+
+    // Must not panic.
+    registry.run_layout_audit();
+
+    let candidates = registry.layout_audit_candidates();
+    assert!(
+        !candidates.is_empty(),
+        "expected a non-empty zero-layout-risk candidate list from the audit"
+    );
+    // java/lang/Integer models its single `value` field the same way the real class does,
+    // so it should be a zero-layout-risk candidate.
+    assert!(
+        candidates.iter().any(|c| c == "java/lang/Integer"),
+        "expected java/lang/Integer among zero-layout-risk candidates, got: {candidates:?}"
+    );
+}

--- a/crates/duke-interpreter/tests/layout_coherence.rs
+++ b/crates/duke-interpreter/tests/layout_coherence.rs
@@ -203,10 +203,12 @@ fn audit_reports_nonempty_candidates() {
         !candidates.is_empty(),
         "expected a non-empty zero-layout-risk candidate list from the audit"
     );
-    // java/lang/Integer models its single `value` field the same way the real class does,
-    // so it should be a zero-layout-risk candidate.
+    // java/lang/System is a fieldless synthetic root whose layout trivially matches the real
+    // class, so it remains a zero-layout-risk candidate. (The boxed number types were migrated
+    // out of KEEP_SYNTHETIC — see `real_jdk_shadow.rs` — so they are now shadowed, not
+    // candidates.)
     assert!(
-        candidates.iter().any(|c| c == "java/lang/Integer"),
-        "expected java/lang/Integer among zero-layout-risk candidates, got: {candidates:?}"
+        candidates.iter().any(|c| c == "java/lang/System"),
+        "expected java/lang/System among zero-layout-risk candidates, got: {candidates:?}"
     );
 }

--- a/crates/duke-interpreter/tests/oss_jar_smoke.rs
+++ b/crates/duke-interpreter/tests/oss_jar_smoke.rs
@@ -142,7 +142,10 @@ fn gson_classpath() -> Vec<PathBuf> {
 }
 
 fn commons_lang3_classpath() -> Vec<PathBuf> {
-    vec![fixtures_dir(), oss_jars_dir().join("commons-lang3-3.17.0.jar")]
+    vec![
+        fixtures_dir(),
+        oss_jars_dir().join("commons-lang3-3.17.0.jar"),
+    ]
 }
 
 fn jdk_modules_path() -> Option<PathBuf> {
@@ -438,8 +441,7 @@ fn commons_lang3_smoke_surfaces_next_missing_capability_explicitly() {
          missing native; if it turned explicit, re-observe and update this pin: {rendered}"
     );
     assert_eq!(
-        rendered,
-        "JavaException { class_name: \"java/util/regex/PatternSyntaxException\" }",
+        rendered, "JavaException { class_name: \"java/util/regex/PatternSyntaxException\" }",
         "expected the next commons-lang3 blocker to stay pinned at StringUtils.<clinit> Pattern.compile"
     );
 }

--- a/crates/duke-interpreter/tests/real_jdk_shadow.rs
+++ b/crates/duke-interpreter/tests/real_jdk_shadow.rs
@@ -38,11 +38,28 @@ fn jimage_loader() -> Option<Arc<dyn ClassLoader + Send + Sync>> {
 /// Allowlisted roots that MUST stay synthetic regardless of the flag.
 const KEEP_SYNTHETIC_SAMPLE: &[&str] = &[
     "java/lang/String",
-    "java/lang/Object",
     "java/lang/System",
-    "java/lang/Integer",
     "java/lang/Class",
     "java/lang/Thread",
+];
+
+/// Classes that were empirically migrated OUT of `KEEP_SYNTHETIC` (zero-layout-risk: their
+/// synthetic instance-field count matched the real jimage layout, and removing them from the
+/// allowlist regressed no previously-passing fixture). Under the flag they MUST now be
+/// shadowed by real JDK bytecode. This locks in the migration delta.
+const MIGRATED_TO_REAL_SAMPLE: &[&str] = &[
+    "java/lang/Object",
+    "java/lang/Integer",
+    "java/lang/Long",
+    "java/lang/Short",
+    "java/lang/Byte",
+    "java/lang/Boolean",
+    "java/lang/Character",
+    "java/lang/Float",
+    "java/lang/Double",
+    "java/lang/Number",
+    "java/io/OutputStream",
+    "java/io/InputStream",
 ];
 
 /// Flag OFF (default): full synthetic stdlib registered, nothing shadowed.
@@ -99,6 +116,24 @@ fn flag_on_shadows_non_allowlisted_synthetics_but_protects_allowlist() {
         assert!(
             !registry.shadowed_classes().iter().any(|c| c == keep),
             "{keep} must not be shadowed"
+        );
+    }
+
+    // Classes migrated out of KEEP_SYNTHETIC MUST now be shadowed by real bytecode:
+    // recorded as shadowed and absent from the synthetic registry (so ensure_loaded
+    // fetches the real classfile). This locks in the migration delta.
+    for migrated in MIGRATED_TO_REAL_SAMPLE {
+        assert!(
+            registry.is_shadowed(migrated),
+            "{migrated} was migrated out of KEEP_SYNTHETIC and must be shadowed under the flag"
+        );
+        assert!(
+            registry.shadowed_classes().iter().any(|c| c == migrated),
+            "{migrated} must be recorded among the shadowed classes"
+        );
+        assert!(
+            registry.get(migrated).is_err(),
+            "migrated class {migrated} should not be pre-registered synthetically"
         );
     }
 

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -167,6 +167,15 @@ fn apply_real_jdk_shadow(registry: &mut ClassRegistry, real_jdk: bool, jdk_home:
     }
 }
 
+/// Run the static layout audit when `DUKE_LAYOUT_AUDIT=1` is set. Must run *after*
+/// `bootstrap_stdlib` (so synthetic classes are registered) and only does anything when
+/// real-JDK shadow mode is enabled. A hard no-op otherwise.
+fn maybe_run_layout_audit(registry: &ClassRegistry) {
+    if matches!(std::env::var("DUKE_LAYOUT_AUDIT").as_deref(), Ok("1")) {
+        registry.run_layout_audit();
+    }
+}
+
 /// Build a class loader: `BootstrapLoader` (JDK jimage + app dir) when JDK path
 /// is known, or plain `DirectoryLoader` otherwise.
 struct CliLoader(Box<dyn ClassLoader + Send + Sync>);
@@ -782,6 +791,7 @@ fn exec_method(
     let mut heap = Heap::new();
     apply_real_jdk_shadow(&mut registry, real_jdk, jdk_home);
     bootstrap_stdlib(&mut registry, &mut heap);
+    maybe_run_layout_audit(&registry);
 
     let mut stdout = std::io::stdout();
     let exit_code = match execute_class_to_completion(
@@ -859,6 +869,7 @@ fn run_main(
     let mut heap = Heap::new();
     apply_real_jdk_shadow(&mut registry, real_jdk, jdk_home);
     bootstrap_stdlib(&mut registry, &mut heap);
+    maybe_run_layout_audit(&registry);
 
     // Build String[] args array on the heap.
     let mut arg_refs: Vec<Slot> = Vec::new();
@@ -972,6 +983,7 @@ fn run_jar(
     let mut heap = Heap::new();
     apply_real_jdk_shadow(&mut registry, real_jdk, jdk_home);
     bootstrap_stdlib(&mut registry, &mut heap);
+    maybe_run_layout_audit(&registry);
     let jar_code_source = std::fs::canonicalize(jar).unwrap_or_else(|_| jar.to_path_buf());
     registry.set_default_code_source(jar_code_source.to_string_lossy().to_string());
 

--- a/duke/src/main.rs
+++ b/duke/src/main.rs
@@ -613,13 +613,25 @@ fn main() {
 
     // Dispatch `exec`: run a static method and print the result.
     if args.len() >= 4 && args[1] == "exec" {
-        exec_method(&args[2..], telemetry, mermaid_dest, jdk_home.as_deref(), real_jdk);
+        exec_method(
+            &args[2..],
+            telemetry,
+            mermaid_dest,
+            jdk_home.as_deref(),
+            real_jdk,
+        );
         return;
     }
 
     // Dispatch `run`: execute main(String[]) entry point.
     if args.len() >= 3 && args[1] == "run" {
-        run_main(&args[2..], telemetry, mermaid_dest, jdk_home.as_deref(), real_jdk);
+        run_main(
+            &args[2..],
+            telemetry,
+            mermaid_dest,
+            jdk_home.as_deref(),
+            real_jdk,
+        );
         return;
     }
 


### PR DESCRIPTION
## What changed

**Before:** With `--real-jdk` / `DUKE_REAL_JDK=1`, 28 core `java.base` classes were hard-fenced in a `KEEP_SYNTHETIC` allowlist and never ran real JDK bytecode. Worse, a half-migrated object graph — real bytecode computing a field slot from the *real* layout while the actual heap object was allocated with the *synthetic* layout — would silently read/write the wrong slot and corrupt state with **no error at all**.

**After:** 12 of those classes now run real `java.base` bytecode under the flag, and a new opt-in diagnostic turns that silent layout corruption into a loud, precise failure. Flag-off (default) behavior is byte-for-byte unchanged.

### 1. Layout-coherence guard — `DUKE_LAYOUT_CHECK=off|warn|fail` (default off)
At every `getfield`/`putfield`, when real-jdk shadow is enabled and the check is on, the access is validated before the slot is touched:
- **Hard check:** resolved slot index `>=` the object's actual slot count → the concrete silent-corruption / out-of-bounds case.
- **Regime check:** the *effective* layout of the field-resolving class (real = shadowed-or-classfile, synthetic = synthetic) must match the object's effective layout. The regime arm compares effective layout rather than raw `is_shadowed` to avoid a false positive when a class reaches real layout via the synthetic→shadow path while another loads real directly.

On mismatch it emits an unmistakable diagnostic (accessing class/field, resolving class + load-source + expected slots, object class + load-source + actual slots, computed slot vs bounds). `warn` continues; `fail` aborts loudly. Zero overhead and identical behavior when off or when shadow is disabled.

### 2. Layout audit — `DUKE_LAYOUT_AUDIT=1`
After bootstrap, compares each `KEEP_SYNTHETIC` class's synthetic `instance_field_count` against the real jimage classfile's field count and prints a MATCH/MISMATCH table plus a zero-layout-risk migration-candidate summary. This is the oracle used to pick the shrink below.

### 3. Allowlist shrink — 28 → 16
Using the audit + guard as safety nets, empirically migrated 12 zero-layout-risk classes out of `KEEP_SYNTHETIC` (each validated with `DUKE_LAYOUT_CHECK=fail` and the full test suite):
- **Removed:** `java/lang/Object`, the 9 boxed number types (`Integer, Long, Short, Byte, Boolean, Character, Float, Double, Number`), `java/io/OutputStream`, `java/io/InputStream`.
- **Reverted:** `java/lang/System` — removing it regressed HelloWorld (`fell off end of bytecode without a return`) because `System.out`/`System.err` are bootstrapped with the synthetic PrintStream layout, so real `System` bytecode is incompatible. The guard/regression caught this; it stays fenced.

Shadowed classes under the flag: **174 → 186**. `KEEP_SYNTHETIC`: **28 → 16**.

### 4. Also
- Fixed a `clippy::nursery` redundant-clone in the shadow register path (registry.rs).

## How

`LayoutCheckMode` is parsed once in `ClassRegistry::new()` from `DUKE_LAYOUT_CHECK`; the guard is wired into the `Getfield`/`Putfield` handlers in `execution.rs` behind a cheap `real_jdk_shadow_enabled() && mode != Off` gate. Coherence logic lives in `ClassRegistry::is_layout_incoherent` with helpers `total_instance_slot_count` / `load_source_of` in `registry.rs`. The audit is `ClassRegistry::run_layout_audit()`. Files touched: `registry.rs`, `execution.rs`, `context.rs`, bin crate wiring, and new tests — `native.rs`/`stdlib.rs` untouched.

## Testing
- `cargo test --workspace`: all pass (duke-interpreter lib 2306; new `layout_coherence` 5; `real_jdk_shadow` 2). 0 failures.
- `cargo clippy --workspace`: clean.
- Flag-OFF HelloWorld: `Hello, World!` (unchanged). Flag-ON HelloWorld with `DUKE_LAYOUT_CHECK=fail`: `Hello, World!`, guard clean.
- `real_jdk_shadow` / `layout_coherence` tests assert the 12 migrated classes are now shadowed and the guard predicate flags a genuine synthetic-vs-real mismatch.

## Follow-up / needs from the natives session
Real-jdk collection fixtures (`ForEachTest`, `CollectionsSortTest`) still fail — **not** on layout incoherence (the guard stays silent) but on unregistered natives reached by real bytecode: `java/lang/Float.floatToRawIntBits(F)I` (and after migration, `java/lang/Class.getPrimitiveClass`). `Double.doubleToRawLongBits(D)J` is likely needed too. These live in `native.rs`/`stdlib.rs`, owned by the parallel natives session.

---
_Generated by [Claude Code](https://claude.ai/code/session_016fDoPEb7Dx9VpDonJWRbeL)_