### PR TITLE
Regex unicode-block translation + Class.getPrimitiveClass + Stream.collect Collector protocol

### DIFF
--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -3396,9 +3396,16 @@ pub fn run_execution(
                                     Err(other) => return Err(other),
                                 }
                                 if gc_allowed && heap.should_gc() {
-                                    let roots = gather_roots(frame, call_stack, registry, string_intern);
+                                    let roots =
+                                        gather_roots(frame, call_stack, registry, string_intern);
                                     heap.collect(&roots);
-                                    patch_forwarded_slots(frame, call_stack, registry, heap, string_intern);
+                                    patch_forwarded_slots(
+                                        frame,
+                                        call_stack,
+                                        registry,
+                                        heap,
+                                        string_intern,
+                                    );
                                 }
                                 frame.push(Slot::Reference(Some(new_ref)))?;
                                 *idx += 1;

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -8553,6 +8553,44 @@ pub(crate) fn native_class_is_array(
     Ok(Some(Slot::Int(i32::from(internal_name.starts_with('[')))))
 }
 
+/// Native: `Class.getPrimitiveClass(String)Class` — static factory returning the
+/// `Class` mirror for a primitive type name ("int", "long", ...).
+///
+/// Returns the same string-keyed mirror that
+/// [`initialize_primitive_wrapper_type_field`] uses for `Integer.TYPE` etc.,
+/// so `int.class` and `Integer.TYPE` share object identity across the runtime.
+pub(crate) fn native_class_get_primitive_class(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let name_ref = extract_ref_arg(args, 0)?;
+    let name = heap
+        .get(name_ref)?
+        .string_value
+        .clone()
+        .ok_or(Error::NullPointerException)?;
+    let descriptor = match name.as_str() {
+        "int" => "I",
+        "long" => "J",
+        "float" => "F",
+        "double" => "D",
+        "boolean" => "Z",
+        "byte" => "B",
+        "char" => "C",
+        "short" => "S",
+        "void" => "V",
+        _ => {
+            return Err(Error::JavaException {
+                class_name: "java/lang/ClassNotFoundException".to_string(),
+            });
+        }
+    };
+    let class_ref = allocate_class_object(heap, descriptor)?;
+    Ok(Some(Slot::Reference(Some(class_ref))))
+}
+
 /// Native: `Class.desiredAssertionStatus()` - Duke currently runs with assertions disabled.
 pub(crate) fn native_class_desired_assertion_status(
     args: &[Slot],

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -28089,6 +28089,124 @@ fn expand_ascii_case_insensitive(pattern: &str) -> String {
     out
 }
 
+/// Unicode block table: normalized Java `In…` name → inclusive codepoint range.
+/// Seeded with the commons-lang3 blocker plus a few neighbours; extend as more
+/// libraries demand blocks. `Character.UnicodeBlock.forName` normalizes names by
+/// stripping spaces/hyphens/underscores and uppercasing, which `normalize_block_name`
+/// mirrors, so every key here is already normalized.
+const UNICODE_BLOCKS: &[(&str, u32, u32)] = &[
+    ("COMBININGDIACRITICALMARKS", 0x0300, 0x036F),
+    ("BASICLATIN", 0x0000, 0x007F),
+    ("LATIN1SUPPLEMENT", 0x0080, 0x00FF),
+    ("GREEKANDCOPTIC", 0x0370, 0x03FF),
+    ("CYRILLIC", 0x0400, 0x04FF),
+];
+
+/// Normalize a Java Unicode block name the way `Character.UnicodeBlock.forName`
+/// does: drop spaces, hyphens and underscores, then uppercase.
+fn normalize_block_name(name: &str) -> String {
+    name.chars()
+        .filter(|c| !matches!(c, ' ' | '-' | '_'))
+        .flat_map(char::to_uppercase)
+        .collect()
+}
+
+/// Translate one `\p{name}` / `\P{name}` property token into Rust regex syntax.
+/// `negated` is true for `\P`; `in_class` is true when the token sits inside an
+/// existing `[...]` class. Returns `Err` (a `PatternSyntaxException`) for an
+/// unknown block name, matching real Java's `Pattern.compile`.
+fn translate_one_property(name: &str, negated: bool, in_class: bool) -> Result<String> {
+    if let Some(block) = name.strip_prefix("In") {
+        // Unicode block: Rust has no block support, so expand to a codepoint range.
+        let norm = normalize_block_name(block);
+        let (start, end) = UNICODE_BLOCKS
+            .iter()
+            .find(|(key, _, _)| *key == norm)
+            .map(|(_, start, end)| (*start, *end))
+            .ok_or_else(|| {
+                regex_pattern_syntax_error(format!("Unknown character block name {{{block}}}"))
+            })?;
+        let range = format!("\\x{{{start:04X}}}-\\x{{{end:04X}}}");
+        if negated {
+            // `[^...]` works both at top level and nested inside another class.
+            Ok(format!("[^{range}]"))
+        } else if in_class {
+            Ok(range)
+        } else {
+            Ok(format!("[{range}]"))
+        }
+    } else if let Some(script) = name.strip_prefix("Is") {
+        // Script or binary property: strip Java's `Is` and let Rust validate.
+        let sigil = if negated { 'P' } else { 'p' };
+        Ok(format!("\\{sigil}{{{script}}}"))
+    } else {
+        // General category / POSIX / anything else: Rust uses the same names.
+        let sigil = if negated { 'P' } else { 'p' };
+        Ok(format!("\\{sigil}{{{name}}}"))
+    }
+}
+
+/// Rewrite Java `\p{…}` / `\P{…}` property classes into Rust-regex-compatible
+/// syntax, translating Unicode blocks (`\p{InXxx}`) to explicit codepoint ranges
+/// and stripping the `Is` script prefix. Escaping- and class-aware. Unknown
+/// block names return `Err`, matching Java's `PatternSyntaxException`.
+fn translate_property_classes(pattern: &str) -> Result<String> {
+    let chars: Vec<char> = pattern.chars().collect();
+    let mut out = String::with_capacity(pattern.len());
+    let mut i = 0;
+    let mut class_depth: usize = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        if c == '\\' {
+            let next = chars.get(i + 1).copied();
+            if matches!(next, Some('p' | 'P')) && chars.get(i + 2) == Some(&'{') {
+                let sigil = next.expect("checked by matches!");
+                let mut j = i + 3;
+                let mut name = String::new();
+                while j < chars.len() && chars[j] != '}' {
+                    name.push(chars[j]);
+                    j += 1;
+                }
+                if j >= chars.len() {
+                    // Unterminated `{`; leave verbatim and let the regex builder report it.
+                    out.push(c);
+                    out.push(sigil);
+                    out.push('{');
+                    out.push_str(&name);
+                    break;
+                }
+                let translated = translate_one_property(&name, sigil == 'P', class_depth > 0)?;
+                out.push_str(&translated);
+                i = j + 1;
+                continue;
+            }
+            // Ordinary escape (including `\\`): copy the pair verbatim so an
+            // escaped backslash before `p` is not mistaken for a property token.
+            out.push(c);
+            if let Some(n) = next {
+                out.push(n);
+                i += 2;
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+        match c {
+            '[' => {
+                class_depth += 1;
+                out.push(c);
+            }
+            ']' if class_depth > 0 => {
+                class_depth -= 1;
+                out.push(c);
+            }
+            _ => out.push(c),
+        }
+        i += 1;
+    }
+    Ok(out)
+}
+
 /// Helper: compile a regex from a pattern string.
 /// Returns `Err` with `JavaException` on bad pattern.
 fn compile_java_regex(pattern: &str) -> Result<regex::Regex> {
@@ -28100,7 +28218,8 @@ fn compile_java_regex_with_flags(pattern: &str, flags: i32) -> Result<regex::Reg
     let mut source = if flags & PATTERN_LITERAL != 0 {
         regex::escape(pattern)
     } else {
-        translate_java_named_groups(pattern)
+        let named = translate_java_named_groups(pattern);
+        translate_property_classes(&named)?
     };
     let ascii_case_insensitive =
         flags & PATTERN_CASE_INSENSITIVE != 0 && flags & PATTERN_UNICODE_CASE == 0;

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -28489,6 +28489,36 @@ fn last_match_bounds(heap: &duke_gc::Heap, m_ref: u64) -> Result<(usize, usize)>
     ))
 }
 
+/// Convert a UTF-8 byte offset within `input` to a UTF-16 code-unit offset.
+/// The `regex` crate yields byte offsets, but every match index Java's `Matcher`
+/// exposes (`start()`/`end()`) is a UTF-16 code-unit offset. They coincide for
+/// ASCII but diverge for multi-byte characters (e.g. combining marks matched by
+/// `\p{InCombiningDiacriticalMarks}`), so the Java-visible getters must convert.
+fn byte_to_utf16_index(input: &str, byte_idx: usize) -> usize {
+    let clamped = byte_idx.min(input.len());
+    input[..clamped].chars().map(char::len_utf16).sum()
+}
+
+/// Like `matcher_group_bounds`, but returns bounds as UTF-16 code-unit offsets so
+/// they match Java's `Matcher.start()`/`end()` semantics. Used only by the
+/// Java-visible index getters; internal consumers keep byte offsets.
+fn matcher_group_bounds_java(
+    heap: &duke_gc::Heap,
+    m_ref: u64,
+    group: MatcherGroup<'_>,
+) -> Result<Option<(usize, usize)>> {
+    let Some((start, end)) = matcher_group_bounds(heap, m_ref, group)? else {
+        return Ok(None);
+    };
+    let Some((_, _, input)) = matcher_pattern_input_text(heap, m_ref)? else {
+        return Ok(Some((start, end)));
+    };
+    Ok(Some((
+        byte_to_utf16_index(&input, start),
+        byte_to_utf16_index(&input, end),
+    )))
+}
+
 fn matcher_group_bounds(
     heap: &duke_gc::Heap,
     m_ref: u64,
@@ -28693,7 +28723,7 @@ pub(crate) fn native_matcher_start(
     _control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
     let m_ref = extract_ref_arg(args, 0)?;
-    let start = matcher_group_bounds(heap, m_ref, MatcherGroup::Index(0))?
+    let start = matcher_group_bounds_java(heap, m_ref, MatcherGroup::Index(0))?
         .map_or(-1, |(start, _)| i32::try_from(start).unwrap_or(i32::MAX));
     Ok(Some(Slot::Int(start)))
 }
@@ -28712,7 +28742,7 @@ pub(crate) fn native_matcher_start_name(
         .string_value
         .clone()
         .unwrap_or_default();
-    let start = matcher_group_bounds(heap, m_ref, MatcherGroup::Name(&name))?
+    let start = matcher_group_bounds_java(heap, m_ref, MatcherGroup::Name(&name))?
         .map_or(-1, |(start, _)| i32::try_from(start).unwrap_or(i32::MAX));
     Ok(Some(Slot::Int(start)))
 }
@@ -28725,7 +28755,7 @@ pub(crate) fn native_matcher_end(
     _control: &mut NativeControl,
 ) -> Result<Option<Slot>> {
     let m_ref = extract_ref_arg(args, 0)?;
-    let end = matcher_group_bounds(heap, m_ref, MatcherGroup::Index(0))?
+    let end = matcher_group_bounds_java(heap, m_ref, MatcherGroup::Index(0))?
         .map_or(-1, |(_, end)| i32::try_from(end).unwrap_or(i32::MAX));
     Ok(Some(Slot::Int(end)))
 }
@@ -28744,7 +28774,7 @@ pub(crate) fn native_matcher_end_name(
         .string_value
         .clone()
         .unwrap_or_default();
-    let end = matcher_group_bounds(heap, m_ref, MatcherGroup::Name(&name))?
+    let end = matcher_group_bounds_java(heap, m_ref, MatcherGroup::Name(&name))?
         .map_or(-1, |(_, end)| i32::try_from(end).unwrap_or(i32::MAX));
     Ok(Some(Slot::Int(end)))
 }

--- a/crates/duke-interpreter/src/native.rs
+++ b/crates/duke-interpreter/src/native.rs
@@ -6668,6 +6668,96 @@ pub(crate) fn native_stream_collect(
         heap.get_mut(list_ref)?.fields[0] = Slot::Int(size);
         heap.get_mut(list_ref)?.fields.extend(elems);
         Ok(Some(Slot::Reference(Some(list_ref))))
+    } else if !collector_class.starts_with("duke/util/") {
+        // A real `java.util.stream.Collector` implementation (not one of Duke's
+        // synthetic `duke/util/*` markers) — e.g. a third-party collector such as
+        // commons-lang3 `LangCollectors.joining`. Drive the standard Collector
+        // protocol so the finisher actually runs, instead of returning the raw
+        // element container:
+        //   container = supplier().get();
+        //   for elem in elems { accumulator().accept(container, elem); }
+        //   result = finisher().apply(container);
+        let collector_ref = extract_ref_arg(args, 1)?;
+        let collector_slot = Slot::Reference(Some(collector_ref));
+
+        // container = collector.supplier().get()
+        let supplier = ops
+            .invoke(
+                heap,
+                out,
+                &collector_class,
+                "supplier",
+                "()Ljava/util/function/Supplier;",
+                vec![collector_slot],
+            )?
+            .unwrap_or(Slot::Reference(None));
+        let Slot::Reference(Some(supplier_ref)) = supplier else {
+            return Err(Error::NullPointerException);
+        };
+        let supplier_class = heap.get(supplier_ref)?.class_name.clone();
+        let container = ops
+            .invoke(
+                heap,
+                out,
+                &supplier_class,
+                "get",
+                "()Ljava/lang/Object;",
+                vec![supplier],
+            )?
+            .unwrap_or(Slot::Reference(None));
+
+        // accumulator = collector.accumulator()
+        let accumulator = ops
+            .invoke(
+                heap,
+                out,
+                &collector_class,
+                "accumulator",
+                "()Ljava/util/function/BiConsumer;",
+                vec![collector_slot],
+            )?
+            .unwrap_or(Slot::Reference(None));
+        let Slot::Reference(Some(acc_ref)) = accumulator else {
+            return Err(Error::NullPointerException);
+        };
+        let acc_class = heap.get(acc_ref)?.class_name.clone();
+        for elem in elems {
+            ops.invoke(
+                heap,
+                out,
+                &acc_class,
+                "accept",
+                "(Ljava/lang/Object;Ljava/lang/Object;)V",
+                vec![accumulator, container, elem],
+            )?;
+        }
+
+        // result = collector.finisher().apply(container)
+        let finisher = ops
+            .invoke(
+                heap,
+                out,
+                &collector_class,
+                "finisher",
+                "()Ljava/util/function/Function;",
+                vec![collector_slot],
+            )?
+            .unwrap_or(Slot::Reference(None));
+        let Slot::Reference(Some(fin_ref)) = finisher else {
+            // No finisher (should not happen for a well-formed Collector) — the
+            // container itself is the result (IDENTITY_FINISH semantics).
+            return Ok(Some(container));
+        };
+        let fin_class = heap.get(fin_ref)?.class_name.clone();
+        let result = ops.invoke(
+            heap,
+            out,
+            &fin_class,
+            "apply",
+            "(Ljava/lang/Object;)Ljava/lang/Object;",
+            vec![finisher, container],
+        )?;
+        Ok(result.or(Some(Slot::Reference(None))))
     } else {
         // ToListCollector (default): collect into ArrayList.
         let list_ref = heap.allocate("java/util/ArrayList".to_string(), 1);

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -3359,6 +3359,12 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         .register("java/lang/Class", "isArray", "()Z", native_class_is_array);
     registry.natives_mut().register(
         "java/lang/Class",
+        "getPrimitiveClass",
+        "(Ljava/lang/String;)Ljava/lang/Class;",
+        native_class_get_primitive_class,
+    );
+    registry.natives_mut().register(
+        "java/lang/Class",
         "desiredAssertionStatus",
         "()Z",
         native_class_desired_assertion_status,

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -2972,12 +2972,12 @@ fn stack_ops_dup2_x1_category2_long_over_int() {
     let instrs = vec![
         (0, Instruction::Bipush(3)), // int 3 (value2)
         (1, Instruction::Bipush(7)),
-        (2, Instruction::I2l),     // 7L (value1); stack: [3, 7L]
-        (3, Instruction::Dup2X1),  // → [7L, 3, 7L]
-        (4, Instruction::L2i),     // top 7L → 7; [7L, 3, 7]
-        (5, Instruction::Iadd),    // 3+7 = 10; [7L, 10]
-        (6, Instruction::I2l),     // [7L, 10L]
-        (7, Instruction::Ladd),    // 7+10 = 17L
+        (2, Instruction::I2l),    // 7L (value1); stack: [3, 7L]
+        (3, Instruction::Dup2X1), // → [7L, 3, 7L]
+        (4, Instruction::L2i),    // top 7L → 7; [7L, 3, 7]
+        (5, Instruction::Iadd),   // 3+7 = 10; [7L, 10]
+        (6, Instruction::I2l),    // [7L, 10L]
+        (7, Instruction::Ladd),   // 7+10 = 17L
         (8, Instruction::Lreturn),
     ];
     let r = execute(&instrs, &[], vec![], 10, 2).unwrap();

--- a/crates/duke-interpreter/tests/oss_jar_smoke.rs
+++ b/crates/duke-interpreter/tests/oss_jar_smoke.rs
@@ -428,11 +428,15 @@ fn gson_smoke_runs_real_jar_bytecode() {
     );
 }
 
-// commons-lang3's happy path blocks *inside* org/apache/commons/lang3/StringUtils's
-// static initializer: STRIP_ACCENTS_PATTERN = Pattern.compile("\\p{InCombiningDiacriticalMarks}+").
-// Duke's regex engine rejects the \p{InCombiningDiacriticalMarks} Unicode block, so
-// the blocker surfaces as a thrown java/util/regex/PatternSyntaxException rather than
-// an explicit missing-native. We deterministically pin that exact first blocker.
+// commons-lang3 now clears the former StringUtils.<clinit> regex blocker
+// (STRIP_ACCENTS_PATTERN = Pattern.compile("\\p{InCombiningDiacriticalMarks}+"),
+// now supported by native.rs translate_property_classes) and advances into
+// StringUtils.join. The next blocker is a thrown java/lang/ClassCastException:
+// a `checkcast (String)` inside org/apache/commons/lang3/StringUtils sees a
+// java/util/ArrayList where a java/lang/String is expected — a collections
+// modeling gap distinct from the regex work. We deterministically pin that exact
+// first blocker; if it turns into an explicit missing-native or moves again,
+// re-observe and update this pin.
 #[test]
 fn commons_lang3_smoke_surfaces_next_missing_capability_explicitly() {
     let smoke = run_commons_lang3_smoke();
@@ -443,17 +447,18 @@ fn commons_lang3_smoke_surfaces_next_missing_capability_explicitly() {
 
     assert!(
         !is_explicit_missing_slf4j_capability(&rendered),
-        "commons-lang3's first blocker is currently a thrown Java exception, not a \
+        "commons-lang3's next blocker is currently a thrown Java exception, not a \
          missing native; if it turned explicit, re-observe and update this pin: {rendered}"
     );
     assert_eq!(
-        rendered, "JavaException { class_name: \"java/util/regex/PatternSyntaxException\" }",
-        "expected the next commons-lang3 blocker to stay pinned at StringUtils.<clinit> Pattern.compile"
+        rendered, "JavaException { class_name: \"java/lang/ClassCastException\" }",
+        "expected the next commons-lang3 blocker to stay pinned at the StringUtils.join \
+         checkcast (ArrayList vs String) now that the regex blocker is cleared"
     );
 }
 
 #[test]
-#[ignore = "Blocked on PatternSyntaxException from StringUtils.<clinit> Pattern.compile(\\p{InCombiningDiacriticalMarks}+); keep ignored until commons-lang3 happy path executes."]
+#[ignore = "Regex blocker cleared; now blocked on a ClassCastException at a StringUtils.join checkcast (ArrayList vs String); keep ignored until commons-lang3 happy path executes."]
 fn commons_lang3_smoke_runs_real_jar_bytecode() {
     let smoke = run_commons_lang3_smoke();
 

--- a/crates/duke-interpreter/tests/oss_jar_smoke.rs
+++ b/crates/duke-interpreter/tests/oss_jar_smoke.rs
@@ -428,15 +428,14 @@ fn gson_smoke_runs_real_jar_bytecode() {
     );
 }
 
-// commons-lang3 now clears the former StringUtils.<clinit> regex blocker
-// (STRIP_ACCENTS_PATTERN = Pattern.compile("\\p{InCombiningDiacriticalMarks}+"),
-// now supported by native.rs translate_property_classes) and advances into
-// StringUtils.join. The next blocker is a thrown java/lang/ClassCastException:
-// a `checkcast (String)` inside org/apache/commons/lang3/StringUtils sees a
-// java/util/ArrayList where a java/lang/String is expected — a collections
-// modeling gap distinct from the regex work. We deterministically pin that exact
-// first blocker; if it turns into an explicit missing-native or moves again,
-// re-observe and update this pin.
+// commons-lang3 has now cleared both the former StringUtils.<clinit> regex
+// blocker and the subsequent StringUtils.join ClassCastException (a real
+// java.util.stream.Collector — LangCollectors.joining — is now driven through
+// its supplier/accumulator/finisher protocol by native_stream_collect instead
+// of returning the raw ArrayList container). StringUtils.join executes; the
+// next blocker is StringUtils.capitalize reaching an unimplemented native,
+// java/lang/Character.toTitleCase(I)I. We deterministically pin that exact
+// first blocker; if it moves again, re-observe and update this pin.
 #[test]
 fn commons_lang3_smoke_surfaces_next_missing_capability_explicitly() {
     let smoke = run_commons_lang3_smoke();
@@ -446,19 +445,19 @@ fn commons_lang3_smoke_surfaces_next_missing_capability_explicitly() {
     let rendered = render_smoke_error(&err);
 
     assert!(
-        !is_explicit_missing_slf4j_capability(&rendered),
-        "commons-lang3's next blocker is currently a thrown Java exception, not a \
-         missing native; if it turned explicit, re-observe and update this pin: {rendered}"
+        is_explicit_missing_slf4j_capability(&rendered),
+        "commons-lang3's next blocker is now an explicit missing native; if it \
+         changed shape, re-observe and update this pin: {rendered}"
     );
     assert_eq!(
-        rendered, "JavaException { class_name: \"java/lang/ClassCastException\" }",
-        "expected the next commons-lang3 blocker to stay pinned at the StringUtils.join \
-         checkcast (ArrayList vs String) now that the regex blocker is cleared"
+        rendered, "Unsupported native: java/lang/Character.toTitleCase(I)I",
+        "expected the next commons-lang3 blocker to stay pinned at StringUtils.capitalize's \
+         Character.toTitleCase now that the StringUtils.join ClassCastException is cleared"
     );
 }
 
 #[test]
-#[ignore = "Regex blocker cleared; now blocked on a ClassCastException at a StringUtils.join checkcast (ArrayList vs String); keep ignored until commons-lang3 happy path executes."]
+#[ignore = "Regex blocker and StringUtils.join ClassCastException cleared; now blocked on missing native java/lang/Character.toTitleCase(I)I in StringUtils.capitalize; keep ignored until commons-lang3 happy path executes."]
 fn commons_lang3_smoke_runs_real_jar_bytecode() {
     let smoke = run_commons_lang3_smoke();
 

--- a/crates/duke-interpreter/tests/regex_unicode_blocks.rs
+++ b/crates/duke-interpreter/tests/regex_unicode_blocks.rs
@@ -268,10 +268,10 @@ fn non_property_pattern_is_unchanged() {
 // ---------------------------------------------------------------------------
 // End-to-end canary through the real Pattern.compile native path.
 //
-// Ignored until the native.rs `translate_property_classes` wiring described in
-// docs/findings/2026-07-09-regex-unicode-blocks.md lands. Once it does, run:
-//   cargo test -p duke-interpreter --test regex_unicode_blocks -- --ignored
-// and un-ignore.
+// The native.rs `translate_property_classes` wiring (plus the Matcher UTF-16
+// match-index conversion) described in
+// docs/findings/2026-07-09-regex-unicode-blocks.md has landed, so this runs by
+// default now.
 // ---------------------------------------------------------------------------
 
 fn repo_root() -> PathBuf {
@@ -296,9 +296,6 @@ fn jdk_modules_path() -> Option<PathBuf> {
 }
 
 #[test]
-#[ignore = "Blocked on native.rs translate_property_classes wiring (see \
-            docs/findings/2026-07-09-regex-unicode-blocks.md); un-ignore once the \
-            regex engine supports \\p{InBlockName}."]
 fn regex_unicode_block_pattern_executes_end_to_end() {
     let Some(modules_path) = jdk_modules_path() else {
         eprintln!("skipping: no JDK lib/modules found");

--- a/crates/duke-interpreter/tests/regex_unicode_blocks.rs
+++ b/crates/duke-interpreter/tests/regex_unicode_blocks.rs
@@ -166,7 +166,9 @@ fn combining_diacritical_marks_block_matches_marks() {
     let re = compile("\\p{InCombiningDiacriticalMarks}+");
     // 'e' + combining acute (U+0301) + combining grave (U+0300) + 'x'.
     let input = "e\u{0301}\u{0300}x";
-    let m = re.find(input).expect("should match the run of combining marks");
+    let m = re
+        .find(input)
+        .expect("should match the run of combining marks");
     assert_eq!(m.as_str(), "\u{0301}\u{0300}");
     // Negative: plain ASCII has no combining marks.
     assert!(!re.is_match("abc"));
@@ -201,7 +203,10 @@ fn unknown_block_name_is_rejected() {
         err.contains("Unknown character block name"),
         "expected a Java-style block error, got: {err}"
     );
-    assert!(err.contains("NotARealBlockName"), "error should name the bad block: {err}");
+    assert!(
+        err.contains("NotARealBlockName"),
+        "error should name the bad block: {err}"
+    );
 }
 
 #[test]
@@ -222,8 +227,14 @@ fn block_name_normalization_is_lenient() {
 
 #[test]
 fn script_is_prefix_is_stripped() {
-    assert_eq!(translate_property_classes("\\p{IsLatin}+").unwrap(), "\\p{Latin}+");
-    assert_eq!(translate_property_classes("\\P{IsGreek}").unwrap(), "\\P{Greek}");
+    assert_eq!(
+        translate_property_classes("\\p{IsLatin}+").unwrap(),
+        "\\p{Latin}+"
+    );
+    assert_eq!(
+        translate_property_classes("\\P{IsGreek}").unwrap(),
+        "\\P{Greek}"
+    );
     let re = compile("\\p{IsLatin}+");
     assert!(re.is_match("abc"));
     assert!(!re.is_match("\u{0391}")); // Greek capital alpha


### PR DESCRIPTION
## What changes

**Before:** Java regexes using `\p{InCombiningDiacriticalMarks}`, `\p{IsAlpha}`, POSIX classes, etc. failed to compile (`PatternSyntaxException`), blocking commons-lang3 `StringUtils.<clinit>`; real-JDK collection fixtures (`ForEachTest`, `CollectionsSortTest`, `ConcurrentHashMapStaticInitTest`) died on `method not found: java/lang/Class.getPrimitiveClass`; and commons-lang3 `StringUtils.join` threw a `ClassCastException`.

**After:** those regexes translate to the Rust `regex` crate and compile; real-JDK `ForEachTest` runs to completion under `--real-jdk`; commons-lang3 gets through `StringUtils.<clinit>` and `join`.

## What landed
1. **`cargo fmt --all`** — trunk had accumulated formatting debt: the #1307–#1312 wave merged while the CI runners were stalled (no runner ever picked up the `Format` job), so `cargo fmt --all --check` was failing on trunk. This commit reformats the affected lines in `execution.rs`, `tests.rs`, and `regex_unicode_blocks.rs` (formatting only, no logic change).
2. **Regex property-class translation** (building on the reference impl from #1310) — `\p{InXxx}` Unicode blocks, `\p{IsXxx}`, and POSIX classes are now translated in `compile_java_regex_with_flags`. The `regex_unicode_blocks` e2e canary is un-ignored and green (11 passed, golden-verified against Java 21).
3. **`Matcher.start()`/`end()` now report UTF-16 code-unit offsets** (previously raw UTF-8 byte offsets). ASCII coincided, so this only surfaced with the canary's combining marks; internal byte-offset consumers (append/replace/iterate) are unchanged.
4. **`Class.getPrimitiveClass(String)`** — returns the primitive `Class` mirror (`int`/`long`/`float`/`double`/`boolean`/`byte`/`char`/`short`/`void`), identity-consistent with `Integer.TYPE` et al. Unblocks the real-JDK collection fixtures; `ForEachTest` now fully passes.
5. **`Stream.collect` now drives the real `java.util.stream.Collector` protocol** (`supplier`/`accumulator`/`finisher`) for non-synthetic collectors, not just Duke's `duke/util/*` markers. commons-lang3's `StringUtils.join` used `LangCollectors.joining` and was getting back the raw container `ArrayList` instead of the joined `String`; it now returns the correct `String`.

## Frontiers moved (report-only, out of scope here)
- commons-lang3 now advances past `join` to a missing `java/lang/Character.toTitleCase(I)I` native (was a `ClassCastException`) — test pin updated.
- `CollectionsSortTest` / `ConcurrentHashMapStaticInitTest` advance past `getPrimitiveClass` to `fell off end of bytecode without a return`.
- The predicted `java/lang/reflect/Array.newInstance` native is still NOT reached, so it was intentionally not implemented (no unreachable code).

## Note
No `execution.rs` logic changes (commit 1 only reformats it), so no functional overlap with PR #1311. **CI caveat:** the repo's Actions runners are currently stalled — every check on recent commits sits `queued` and never executes — so this PR's checks will likely also sit pending until the runners are restored. Verified locally instead (commands below).

## Verification (local)
- `cargo test --workspace`: **3037 passed / 0 failed / 4 ignored**.
- `cargo fmt --all --check`: clean.
- `cargo clippy --workspace --all-targets -W clippy::pedantic -W clippy::nursery`: clean for this diff (the 2 remaining warnings are pre-existing in untouched test helpers).
- `duke run tests/fixtures/HelloWorld.class` → `Hello, World!`.
- real-JDK: `ForEachTest` `getPrimitiveClass not found` → fully passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALmhuYd8aEL9eaqFYdsviv)_