### PR TITLE
Real-JDK fence: getCallerClass + VM.initialize natives, allowlist 17→10, System/IO migration scoped

### DIFF
--- a/crates/duke-interpreter/src/native/common.rs
+++ b/crates/duke-interpreter/src/native/common.rs
@@ -9758,6 +9758,9 @@ fn native_needs_stack_snapshot(
     native_desc: &str,
 ) -> bool {
     (native_method == "fillInStackTrace" && native_desc == "()Ljava/lang/Throwable;")
+        || (native_class == "jdk/internal/reflect/Reflection"
+            && native_method == "getCallerClass"
+            && native_desc == "()Ljava/lang/Class;")
         || (native_method == "<init>"
             && matches!(
                 native_desc,

--- a/crates/duke-interpreter/src/native/jdk_internal.rs
+++ b/crates/duke-interpreter/src/native/jdk_internal.rs
@@ -176,3 +176,36 @@ pub(crate) fn native_unsafe_allocate_instance(
     let instance_ref = ops.allocate_instance(heap, out, &class_key)?;
     Ok(Some(Slot::Reference(Some(instance_ref))))
 }
+/// Native: `jdk/internal/reflect/Reflection.getCallerClass()Ljava/lang/Class;`.
+///
+/// Real `HotSpot` semantics: return the `Class` of the method that called the
+/// caller of `getCallerClass` — i.e. skip `getCallerClass`'s own (native) frame
+/// and the immediate `@CallerSensitive` caller frame, returning the frame two
+/// levels up (also skipping reflection/`MethodHandle` machinery frames).
+///
+/// Duke frame model: `control.stack_trace()` holds the Java frames captured at
+/// the native call site, most-recent-first. `getCallerClass` is native and is
+/// not itself represented in that snapshot, so:
+///   `frames[0]` = the (`@CallerSensitive`) method that invoked getCallerClass
+///                 (e.g. `ServiceLoader.load`)
+///   `frames[1]` = that method's caller — the `Class` we must return.
+/// We return the mirror for `frames[1]`. If the stack is too shallow (no
+/// grand-caller, e.g. called directly from the entry frame) we fall back to
+/// `frames[0]`, and to `null` only when the snapshot is empty. This is the
+/// interpretation that lets `java/util/ServiceLoader.load(Ljava/lang/Class;)`
+/// resolve its caller class under `DUKE_REAL_JDK=1`.
+pub(crate) fn native_reflection_get_caller_class(
+    _args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let frames = control.stack_trace();
+    match frames.get(1).or_else(|| frames.first()) {
+        Some(frame) => {
+            let class_ref = allocate_class_object(heap, &frame.class_name)?;
+            Ok(Some(Slot::Reference(Some(class_ref))))
+        }
+        None => Ok(Some(Slot::Reference(None))),
+    }
+}

--- a/crates/duke-interpreter/src/native/jdk_internal.rs
+++ b/crates/duke-interpreter/src/native/jdk_internal.rs
@@ -209,3 +209,35 @@ pub(crate) fn native_reflection_get_caller_class(
         None => Ok(Some(Slot::Reference(None))),
     }
 }
+/// Native: `jdk/internal/misc/VM.initialize()V`.
+///
+/// In `HotSpot` this native saves the VM-supplied system properties into
+/// `VM.savedProps` and records a few tuning constants; it does **not** itself
+/// advance `VM.initLevel`. The boot sequence advances `initLevel` separately via
+/// `VM.initLevel(int)` calls inside `System.initPhase1/2/3`, ending at
+/// `SYSTEM_BOOTED` (== 4) by the time application code runs.
+///
+/// Duke never executes that boot sequence, yet application-time bytecode expects a
+/// fully booted VM. In particular `java/util/ServiceLoader.<init>` calls
+/// `VM.isBooted()`, which returns `initLevel >= SYSTEM_BOOTED`; when it reports
+/// `false`, `ServiceLoader` takes its pre-boot module-bootstrap branch instead of
+/// the normal construction path. `VM.<clinit>` is the one place that runs
+/// `initialize()`, so we fold the boot progression into this native: it seeds
+/// `initLevel = SYSTEM_BOOTED`, making `isBooted()` observe the booted state a
+/// real application would see and letting `ServiceLoader` proceed normally. No
+/// property map is materialized here — nothing on the reached path reads
+/// `savedProps`; if a future path needs it, seed it at that point.
+#[allow(clippy::unnecessary_wraps)] // signature must match `CallbackNativeHandler`
+pub(crate) fn native_vm_initialize(
+    _args: &[Slot],
+    _heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+    ops: &mut dyn CallbackOps,
+) -> Result<Option<Slot>> {
+    // `SYSTEM_BOOTED` is the 4th init-level constant declared in
+    // `jdk/internal/misc/VM` (JAVA_LANG_SYSTEM_INITED=1 .. SYSTEM_BOOTED=4).
+    const SYSTEM_BOOTED: i32 = 4;
+    ops.write_static_field("jdk/internal/misc/VM", "initLevel", Slot::Int(SYSTEM_BOOTED))?;
+    Ok(None)
+}

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -26,20 +26,17 @@ const KEEP_SYNTHETIC: &[&str] = &[
     "java/lang/ThreadGroup",
     "java/lang/Throwable",
     "java/lang/System",
-    // Print/IO stack: `System.out`/`System.err` are allocated synthetically by
-    // `bootstrap_stdlib` (System is KEEP_SYNTHETIC) with the synthetic PrintStream layout.
-    // Keeping the whole stream/writer stack synthetic prevents real JDK bytecode from
-    // running against those synthetically-allocated instances (layout-coherence boundary).
+    // Print/IO stack: the only stream classes actually allocated/registered with a
+    // synthetic layout are `PrintStream` (`System.out`/`System.err`, heap-allocated by
+    // `bootstrap_stdlib` since System is KEEP_SYNTHETIC), `FileOutputStream`, and
+    // `FileInputStream`. Keeping these synthetic prevents real JDK bytecode from running
+    // against those synthetically-allocated instances (layout-coherence boundary). The
+    // rest of the writer stack (FilterOutputStream, BufferedOutputStream, Writer,
+    // OutputStreamWriter, BufferedWriter, PrintWriter, FileDescriptor) is never
+    // synthetically registered or allocated, so it is shadowed by real JDK bytecode.
     "java/io/PrintStream",
-    "java/io/FilterOutputStream",
-    "java/io/BufferedOutputStream",
-    "java/io/Writer",
-    "java/io/OutputStreamWriter",
-    "java/io/BufferedWriter",
-    "java/io/PrintWriter",
     "java/io/FileOutputStream",
     "java/io/FileInputStream",
-    "java/io/FileDescriptor",
     // Duke models `Unsafe` as a fully synthetic set of positional-offset natives
     // (getUnsafe/objectFieldOffset/CAS/get/put). Keeping it synthetic prevents
     // the real `Unsafe.<clinit>` (registerNatives + UnsafeConstants) from running

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -1430,6 +1430,23 @@ fn register_reflection_stdlib(registry: &mut ClassRegistry) {
     );
 }
 
+/// Registers the native handler for `jdk/internal/misc/VM`.
+///
+/// Only the `initialize()V` native is provided; the `VM` class itself is loaded
+/// from the real JDK under `DUKE_REAL_JDK=1` (no synthetic context is registered,
+/// so flag-off behavior is unchanged — the entry is simply unused). `initialize`
+/// is reached from `VM.<clinit>`, itself triggered by `VM.isBooted()` in
+/// `java/util/ServiceLoader.<init>`; see `native_vm_initialize` for how it seeds
+/// the booted init level.
+fn register_vm_stdlib(registry: &mut ClassRegistry) {
+    registry.natives_mut().register_callback(
+        "jdk/internal/misc/VM",
+        "initialize",
+        "()V",
+        native_vm_initialize,
+    );
+}
+
 fn lock_interface_context(name: &str) -> ClassContext {
     ClassContext {
         class_name: name.to_string(),
@@ -3329,6 +3346,7 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
     register_concurrent_hashmap_stdlib(registry);
     register_unsafe_stdlib(registry);
     register_reflection_stdlib(registry);
+    register_vm_stdlib(registry);
     register_locks_stdlib(registry);
     register_sync_primitives_stdlib(registry);
     register_executor_stdlib(registry, heap);

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -1413,6 +1413,23 @@ fn register_unsafe_stdlib(registry: &mut ClassRegistry) {
     }
 }
 
+/// Registers the native handler for `jdk/internal/reflect/Reflection`.
+///
+/// Only the `getCallerClass()` native is provided; the `Reflection` class itself
+/// is loaded from the real JDK under `DUKE_REAL_JDK=1` (no synthetic context is
+/// registered, so flag-off behavior is unchanged — the entry is simply unused).
+/// `getCallerClass` is `@CallerSensitive` machinery reached from
+/// `java/util/ServiceLoader.load(Ljava/lang/Class;)`; see
+/// `native_reflection_get_caller_class` for the frame-walking semantics.
+fn register_reflection_stdlib(registry: &mut ClassRegistry) {
+    registry.natives_mut().register(
+        "jdk/internal/reflect/Reflection",
+        "getCallerClass",
+        "()Ljava/lang/Class;",
+        native_reflection_get_caller_class,
+    );
+}
+
 fn lock_interface_context(name: &str) -> ClassContext {
     ClassContext {
         class_name: name.to_string(),
@@ -3311,6 +3328,7 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
     register_atomic_stdlib(registry);
     register_concurrent_hashmap_stdlib(registry);
     register_unsafe_stdlib(registry);
+    register_reflection_stdlib(registry);
     register_locks_stdlib(registry);
     register_sync_primitives_stdlib(registry);
     register_executor_stdlib(registry, heap);


### PR DESCRIPTION
## Before / After
**Before:** Under `DUKE_REAL_JDK=1`, running the slf4j-simple smoke halted almost immediately — `java/util/ServiceLoader.load` called `jdk/internal/reflect/Reflection.getCallerClass()`, which had no native handler, so the interpreter ran off the empty method body ("fell off end of bytecode without a return instruction"). Separately, the `KEEP_SYNTHETIC` layout-coherence allowlist listed 17 classes, 7 of which were dead entries, and its doc comment misdescribed which classes are actually kept synthetic.

**After:** The slf4j real-jdk path advances two walls further — past `ServiceLoader.load` and past `jdk/internal/misc/VM.`/`isBooted()` — now reaching the `java.lang.Class.getModule()` module-access chain (the next wave). The allowlist is down to 10 (7 verified-inert entries removed) with a corrected doc comment. `HelloWorld` is byte-identical in both default and real-jdk fail-mode.

## How
- **`jdk/internal/reflect/Reflection.getCallerClass()`** (`native/jdk_internal.rs`, registered append-only in `stdlib.rs`): reads the interpreter's most-recent-first stack snapshot (same mechanism `Throwable`/`fillInStackTrace` use). getCallerClass is native and absent from the snapshot, so `frames[0]` is the `@CallerSensitive` caller and `frames[1]` is the Class to return (via the existing `allocate_class_object` mirror helper). A single clause was added to `native_needs_stack_snapshot` in `native/common.rs` so the frame snapshot is captured for this native — this does NOT touch `gather_roots`/`patch_forwarded_slots` or nested-execution setup. No synthetic ClassContext is registered, so flag-off behavior is byte-identical.
- **`KEEP_SYNTHETIC` allowlist 17→10** (`registry.rs`): removed 7 classes that were never synthetically registered and never heap-allocated — `FilterOutputStream`, `BufferedOutputStream`, `Writer`, `OutputStreamWriter`, `BufferedWriter`, `PrintWriter`, `FileDescriptor`. Membership is read only by `should_shadow_synthetic` (reached only from `register()`), and these are never registered, so removal is behaviorally inert — confirmed by the layout audit (live-class picture unchanged before/after) and the test suite (exactly 3037/0/4). The doc comment now states the real fence: `PrintStream` (for the bootstrapped `System.out`/`err`), `FileOutputStream`, `FileInputStream`, plus the lang classes and `Unsafe`.
- **`jdk/internal/misc/VM.initialize()V`** (`native/jdk_internal.rs`, registered append-only in `stdlib.rs`): seeds `initLevel = SYSTEM_BOOTED(4)` so `VM.isBooted()` (called from `ServiceLoader.`) observes a booted VM. Duke never runs the real VM boot sequence, so this native folds that progression into a single side effect. Append-only; flag-off unchanged.

## Verification (local only — CI runners are dead)
- `cargo build`: clean
- `cargo test`: **3037 passed / 0 failed / 4 ignored** (matches baseline — no regression)
- `cargo fmt --check`: clean
- `cargo clippy --all-targets`: no new warnings (2 pre-existing baseline warnings in `tests/oss_jar_smoke.rs` and `tests/real_jdk_shadow.rs`)
- `HelloWorld` default: `Hello, World!`
- `HelloWorld` `DUKE_REAL_JDK=1 DUKE_LAYOUT_CHECK=fail`: `Hello, World!`
- slf4j real-jdk frontier advanced two walls (getCallerClass, VM.initialize); next wall is the `Class.getModule()` module-access chain

Captured gate output:

```
$ cargo build
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.07s

$ cargo test  (aggregated across all binaries)
PASSED=3037 FAILED=0 IGNORED=4

$ cargo fmt --all -- --check
FMT_EXIT=0

$ cargo clippy --all-targets  (only pre-existing baseline warnings)
   --> crates/duke-interpreter/tests/real_jdk_shadow.rs:170:9
warning: `duke-interpreter` (test "real_jdk_shadow") generated 1 warning
   --> crates/duke-interpreter/tests/oss_jar_smoke.rs:177:36
warning: `duke-interpreter` (test "oss_jar_smoke") generated 1 warning

$ duke run tests/fixtures/HelloWorld.class
Hello, World!

$ DUKE_REAL_JDK=1 DUKE_LAYOUT_CHECK=fail duke run tests/fixtures/HelloWorld.class
duke: real-jdk mode enabled (non-allowlisted synthetic stdlib classes load real JDK bytecode)
Hello, World!
```

## Deferred: System.out/err real-layout migration (Target 1 — multi-wave)
Making `java/lang/System` + the print/IO stack leave the fence requires constructing `System.out`/`err` with the REAL `PrintStream` layout (11 instance slots) instead of the synthetic 1-slot instances allocated at bootstrap. That pulls in the entire real print path — `StreamEncoder`, `CharsetEncoder.encode`, `java.nio` buffers, `FileOutputStream.writeBytes([BIIZ)V`→stdout, real `FileDescriptor`, and `System.initPhase1`/`setOut0`/`setErr0`/`registerNatives` — none of which Duke currently implements. Removing `PrintStream` or `System` from the allowlist today deterministically regresses HelloWorld (real getfield at slot ≥ object slot count → layout-incoherence abort under `DUKE_LAYOUT_CHECK=fail`). This is scoped as a dedicated follow-up wave. The slf4j real-jdk frontier's next wave is the module system (`Class.getModule`/`getModifiers`, `Reflection.getClassAccessFlags`, `Module.canUse`).

## Merge notes for this wave
- `stdlib.rs` changes are append-only native registrations; two other lanes (gson, commons-lang3) also append to `stdlib.rs` this wave — expect trivial append-region merge conflicts.
- The `native/common.rs` change is a single clause in `native_needs_stack_snapshot` only; it does NOT touch `gather_roots`/`patch_forwarded_slots` (a GC root-walking fix from the gson lane lands there separately).

---
_Generated by [Claude Code](https://claude.ai/code/session_014Fq3HfbwF9eJMU2LbbXZJA)_

## CI / clippy
The two pre-existing trunk clippy lints under rustc 1.97 (`-W pedantic -W nursery -D warnings`) — `question_mark`, `map_unwrap_or`, `needless_pass_by_value`, `similar_names` — were fixed on trunk by #1318. This branch was rebased onto the post-#1318 trunk and the interim `chore(clippy)` commits were dropped as redundant (zero conflicts). The branch is now **3 commits** on latest trunk: `getCallerClass`, allowlist 17→10, `VM.initialize`. Re-gated after rebase: `cargo test` 3038/0/4, `cargo fmt --check` clean, and the exact CI clippy command (`RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -W clippy::pedantic -W clippy::nursery`) exits 0 with zero warnings; HelloWorld passes in default and `DUKE_REAL_JDK=1 DUKE_LAYOUT_CHECK=fail` modes.