### PR TITLE
test(spring-boot): refresh frontier pin — unblock red trunk

### DIFF
--- a/docs/findings/2026-07-10-spring-boot-real-app.md
+++ b/docs/findings/2026-07-10-spring-boot-real-app.md
@@ -53,9 +53,15 @@ With the loader-lane fix in this branch (`5860f6b`, see below), `duke -jar` on
 3. Reaches Spring Boot's **classpath-scanning phase** — the point where the
    framework enumerates classpath resources to discover configuration.
 
-It then stops with:
+It then stops. **Update 2026-07-10 (after #1320):** the gson-natives work in
+#1320 advanced the **app** fixture past the `getSystemResources` rung; the two
+fixtures now diverge on the first blocker:
 
 ```
+# app  (duke-spring-boot-app-3.5.12.jar):
+duke: runtime error: method not found: java/lang/ClassLoader.getSystemClassLoader()Ljava/lang/ClassLoader;
+
+# ladder (duke-spring-boot-ladder-3.5.12.jar) — still parked at the old rung:
 duke: runtime error: method not found: java/lang/ClassLoader.getSystemResources(Ljava/lang/String;)Ljava/util/Enumeration;
 ```
 
@@ -75,7 +81,8 @@ under the default synthetic-stdlib path).
 | # | Blocker (symptom) | Root cause | Status | Owning lane |
 | --- | --- | --- | --- | --- |
 | **0** | `class not found: java/lang/System` (app) / `java/lang/ClassLoader` (ladder) — died before any framework code, at a loader-suffixed key (`java/lang/System\0loader:113`). | `ensure_loaded_inner` recorded per-loader/per-code-source provenance onto **plain synthetic bootstrap singletons**, flipping `is_plain_bootstrap_class` false and desyncing it from `class_key_from_provenance`, which then computed a loader-suffixed key nothing was stored under. | **FIXED here** (`5860f6b`) | classloader/registry (**this lane**) |
-| **1** | `method not found: java/lang/ClassLoader.getSystemResources(Ljava/lang/String;)Ljava/util/Enumeration;` — boot reaches classpath scanning, no banner. | `getSystemResources` is a **missing synthetic method** on the synthetic `java/lang/ClassLoader` in `stdlib.rs`. The resource-enumeration API surface (`getResource(s)`, `getSystemResource(s)`, `getResourceAsStream`) is incomplete. | **OBSERVED — current pin** | synthetic-stdlib / native — `java_lang` (`ClassLoader` resource API) |
+| **1** | `method not found: java/lang/ClassLoader.getSystemResources(Ljava/lang/String;)Ljava/util/Enumeration;` — boot reaches classpath scanning, no banner. | `getSystemResources` is a **missing synthetic method** on the synthetic `java/lang/ClassLoader` in `stdlib.rs`. The resource-enumeration API surface (`getResource(s)`, `getSystemResource(s)`, `getResourceAsStream`) is incomplete. | **CLEARED for app by #1320** (gson natives advanced the app past this rung). **Still OBSERVED for the ladder — current ladder pin.** | synthetic-stdlib / native — `java_lang` (`ClassLoader` resource API) |
+| **1a** | `method not found: java/lang/ClassLoader.getSystemClassLoader()Ljava/lang/ClassLoader;` — app fixture's new first blocker after #1320, still in the classpath-scanning / classloader-bootstrap path, no banner. | `getSystemClassLoader` is another **missing synthetic method** on the synthetic `java/lang/ClassLoader` in `stdlib.rs` — same `ClassLoader` surface as #1, next method the app reaches. | **OBSERVED — current app pin** | synthetic-stdlib / native — `java_lang` (`ClassLoader` static/system-loader API) |
 | **2** | `--real-jdk` probe: getfield slot 10 out of bounds on a `java/net/URL` allocated with 1 slot where real `URL` bytecode expects 13 (`crates/duke-interpreter/src/execution.rs:1600`). | Synthetic-vs-real **object-layout coherence** boundary: `java/net/URL` is allocated synthetically (1 slot) but real `URL` bytecode indexes its full 13-field layout. | **INFERRED** (seen only under `--real-jdk`, past blocker #1) | native / stdlib object-layout — `java_net` (`URL`) |
 | **3** | Resource enumeration + `META-INF/spring.factories` and `META-INF/spring/…AutoConfiguration.imports` discovery returning empty/failing. | Spring's `SpringFactoriesLoader` / `ImportCandidates` walk **every** classpath entry via `ClassLoader.getResources`; requires working nested-jar resource enumeration (depends on #1). | **INFERRED** | java_util + classloader/registry (resource enumeration) |
 | **4** | Heavy `java.lang.reflect` use during auto-configuration: `Constructor.newInstance`, `Method.invoke`, annotation reads, `Class.forName` fan-out. | `SpringApplication.run` instantiates and wires beans almost entirely reflectively; annotation metadata is read via reflection/ASM. | **INFERRED** | reflect (`java_lang_reflect`) + `java_lang` (`Class`) |
@@ -131,7 +138,8 @@ regression witnesses, but the fix is generic.
 | Blocker | Owning lane | Status |
 | --- | --- | --- |
 | #0 provenance-poison on bootstrap singletons | classloader / registry (`registry.rs`) | **DONE (this branch)** |
-| #1 `ClassLoader.getSystemResources` missing | synthetic-stdlib `java_lang` — `ClassLoader` resource API (`stdlib.rs`) | **NEXT** |
+| #1 `ClassLoader.getSystemResources` missing | synthetic-stdlib `java_lang` — `ClassLoader` resource API (`stdlib.rs`) | **CLEARED for app by #1320; still NEXT for ladder** |
+| #1a `ClassLoader.getSystemClassLoader` missing | synthetic-stdlib `java_lang` — `ClassLoader` static/system-loader API (`stdlib.rs`) | **NEXT for app (current pin)** |
 | #2 `java/net/URL` layout coherence | native / stdlib object-layout — `java_net` (`URL`) | inferred |
 | #3 `spring.factories` / `AutoConfiguration.imports` resource enumeration | java_util + classloader/registry | inferred |
 | #4 reflective bean instantiation / annotations | reflect (`java_lang_reflect`) + `java_lang` (`Class`) | inferred |
@@ -152,9 +160,12 @@ fixture:
 - **2 non-ignored PINS** —
   `spring_boot_app_surfaces_next_missing_capability_explicitly`,
   `spring_boot_ladder_surfaces_next_missing_capability_explicitly`. Each asserts
-  the process still fails at **exactly** the current blocker
-  (`CURRENT_BLOCKER = "method not found: java/lang/ClassLoader.getSystemResources(Ljava/lang/String;)Ljava/util/Enumeration;"`).
-  If boot advances (or regresses) past that string, the pin **trips**, forcing a
+  the process still fails at **exactly** the current blocker. As of #1320 the
+  two fixtures diverge, so the pins assert per-fixture constants:
+  `APP_BLOCKER = "method not found: java/lang/ClassLoader.getSystemClassLoader()Ljava/lang/ClassLoader;"`
+  and
+  `LADDER_BLOCKER = "method not found: java/lang/ClassLoader.getSystemResources(Ljava/lang/String;)Ljava/util/Enumeration;"`.
+  If boot advances (or regresses) past those strings, the pin **trips**, forcing a
   re-observe and an update to this doc.
 
 **Repro commands:**

--- a/duke/tests/spring_boot_real_app.rs
+++ b/duke/tests/spring_boot_real_app.rs
@@ -36,13 +36,19 @@ fn spring_boot_fixture(name: &str) -> PathBuf {
 const APP_JAR: &str = "duke-spring-boot-app-3.5.12.jar";
 const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 
-// The post-fix first blocker shared by BOTH fixtures (observed 2026-07-10, after
-// the `ensure_loaded_inner` plain-bootstrap-provenance fix). Both boot into the
-// JarLauncher / Spring Boot classpath-scanning path and land on the same missing
-// synthetic `java/lang/ClassLoader` resource method. This lives in
-// crates/duke-interpreter/src/stdlib.rs (other lane), so it is pinned here rather
-// than fixed. If boot advances past it, re-observe and update this pin.
-const CURRENT_BLOCKER: &str = "method not found: java/lang/ClassLoader.getSystemResources(Ljava/lang/String;)Ljava/util/Enumeration;";
+// Per-fixture first blockers (re-observed 2026-07-10, after #1320 landed the gson
+// natives and advanced the app fixture's boot). Both fixtures boot into the
+// JarLauncher / Spring Boot classpath-scanning path and land on a missing synthetic
+// `java/lang/ClassLoader` method that lives in crates/duke-interpreter/src/stdlib.rs
+// (other lane), so both are pinned here rather than fixed.
+//
+// The two fixtures now diverge: #1320 pushed the APP past the previously-shared
+// `getSystemResources` rung onto `getSystemClassLoader`, while the LADDER still
+// lands on `getSystemResources`. If either boot advances past its pin, re-observe
+// and update. See docs/findings/2026-07-10-spring-boot-real-app.md.
+const APP_BLOCKER: &str =
+    "method not found: java/lang/ClassLoader.getSystemClassLoader()Ljava/lang/ClassLoader;";
+const LADDER_BLOCKER: &str = "method not found: java/lang/ClassLoader.getSystemResources(Ljava/lang/String;)Ljava/util/Enumeration;";
 
 fn run_fixture(jar: &str) -> Output {
     let jar_path = spring_boot_fixture(jar);
@@ -71,8 +77,9 @@ fn combined_output(output: &Output) -> String {
 /// End-to-end CANARY for the real Spring Boot app fixture. Ignored until boot
 /// reaches the started-application line. Un-ignore when the happy path clears.
 #[test]
-#[ignore = "Blocked on missing synthetic java/lang/ClassLoader.getSystemResources \
-            (stdlib lane); keep ignored until the Spring Boot app boot completes. \
+#[ignore = "Blocked on missing synthetic java/lang/ClassLoader.getSystemClassLoader \
+            (stdlib lane; #1320 cleared the earlier getSystemResources rung for the \
+            app); keep ignored until the Spring Boot app boot completes. \
             See docs/findings/2026-07-10-spring-boot-real-app.md"]
 fn spring_boot_app_boots_end_to_end() {
     let output = run_fixture(APP_JAR);
@@ -104,9 +111,9 @@ fn spring_boot_app_surfaces_next_missing_capability_explicitly() {
         "app fixture is expected to still fail at the pinned blocker; output:\n{combined}"
     );
     assert!(
-        combined.contains(CURRENT_BLOCKER),
+        combined.contains(APP_BLOCKER),
         "expected the app fixture to stay pinned at the current first blocker \
-         ({CURRENT_BLOCKER:?}); if it moved, re-observe and update this pin \
+         ({APP_BLOCKER:?}); if it moved, re-observe and update this pin \
          (docs/findings/2026-07-10-spring-boot-real-app.md). Output:\n{combined}"
     );
 }
@@ -149,9 +156,9 @@ fn spring_boot_ladder_surfaces_next_missing_capability_explicitly() {
         "ladder fixture is expected to still fail at the pinned blocker; output:\n{combined}"
     );
     assert!(
-        combined.contains(CURRENT_BLOCKER),
+        combined.contains(LADDER_BLOCKER),
         "expected the ladder fixture to stay pinned at the current first blocker \
-         ({CURRENT_BLOCKER:?}); if it moved, re-observe and update this pin \
+         ({LADDER_BLOCKER:?}); if it moved, re-observe and update this pin \
          (docs/findings/2026-07-10-spring-boot-real-app.md). Output:\n{combined}"
     );
 }


### PR DESCRIPTION
## Fixes red trunk

Trunk went RED: the non-ignored pin `spring_boot_app_surfaces_next_missing_capability_explicitly` in `duke/tests/spring_boot_real_app.rs` started failing because **#1320 (gson natives)** advanced the Spring Boot app fat-jar boot **past** the previously-pinned blocker. Pin tests are designed to trip on forward progress — this PR re-observes the true current frontier and refreshes the pins. Should merge fast to green trunk.

## Before / After

The pins previously asserted a single shared `CURRENT_BLOCKER`:

```
method not found: java/lang/ClassLoader.getSystemResources(Ljava/lang/String;)Ljava/util/Enumeration;
```

#1320 pushed the **app** fixture past that rung. Re-observed empirically (`duke -jar <fixture>`), the two fixtures now diverge:

| Fixture | New first blocker |
| --- | --- |
| `duke-spring-boot-app-3.5.12.jar` | `method not found: java/lang/ClassLoader.getSystemClassLoader()Ljava/lang/ClassLoader;` |
| `duke-spring-boot-ladder-3.5.12.jar` | `method not found: java/lang/ClassLoader.getSystemResources(Ljava/lang/String;)Ljava/util/Enumeration;` (unchanged) |

## How

- `duke/tests/spring_boot_real_app.rs`: split the shared `CURRENT_BLOCKER` const into per-fixture `APP_BLOCKER` (`getSystemClassLoader`) and `LADDER_BLOCKER` (`getSystemResources`); each pin now asserts its own observed string. Updated the app canary's `#[ignore]` reason to name the new `getSystemClassLoader` frontier (ladder canary unchanged — still on `getSystemResources`).
- `docs/findings/2026-07-10-spring-boot-real-app.md`: marked the `getSystemResources` rung CLEARED for the app by #1320, added the new `getSystemClassLoader` rung (#1a) with its owning lane (synthetic-stdlib `java_lang` — `ClassLoader` static/system-loader API), and updated the "how far boot gets", lane-ownership, and test-scaffolding sections to reflect the per-fixture split.

No product/`src` code changed — this is a test-pin + findings-doc refresh only.

## Verification (local-only)

CI runners are dead in this environment; all gates run locally.

- `cargo build --workspace` — clean.
- `cargo fmt --check` — clean.
- `cargo test -p duke --test spring_boot_real_app` — **2 passed / 0 failed / 2 ignored** (both pins now pass, both canaries ignored).
- `cargo test --workspace --no-fail-fast` — **3040 passed / 0 failed / 5 ignored.**
- `RUSTFLAGS="-D warnings" cargo +1.97.0 clippy --workspace --all-targets -- -W clippy::pedantic -W clippy::nursery` — the ONLY lint is a pre-existing `explicit_counter_loop` at `crates/duke-interpreter/src/native/java_lang.rs:1952` introduced by #1320; **not introduced here and not in this diff** — it is owned by and being fixed on #1316. No lint fires in any file this PR edits.

---
_Generated by [Claude Code](https://claude.ai/code/session_014M8TbLCmS8ycns2jyUzbL3)_