### PR TITLE
⚒️ Forge: Refactor resolve_attributes to use let-else

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,6 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+**[Extract Guard Clause]
+**Learning:** `resolve_attributes` in `crates/duke-classfile/src/parser.rs` used a match block to extract raw attributes, with a catch-all arm containing `_ => continue`. This triggered `clippy::manual_let_else` and added unnecessary indentation.
+**Action:** Always replace early-return match statements extracting values from Enums/Options with `let...else` guard clauses to flatten the structure.

--- a/crates/duke-classfile/src/parser.rs
+++ b/crates/duke-classfile/src/parser.rs
@@ -413,10 +413,10 @@ fn parse_attribute(c: &mut Cursor<'_>, _cp_len: usize) -> Result<AttributeInfo> 
 pub fn resolve_attributes(attrs: &mut [AttributeInfo], pool: &[Option<CpEntry>]) -> Result<()> {
     for attr in attrs.iter_mut() {
         let name = cp_utf8(pool, attr.name_index)?;
-        let raw = match &mut attr.data {
-            AttributeData::Raw(b) => std::mem::take(b),
-            _ => continue, // already resolved
+        let AttributeData::Raw(b) = &mut attr.data else {
+            continue; // already resolved
         };
+        let raw = std::mem::take(b);
         attr.data = decode_known_attribute(name, &raw)?;
     }
     Ok(())


### PR DESCRIPTION
🚮 Smell: `resolve_attributes` in `crates/duke-classfile/src/parser.rs` used a manual `match` block with a catch-all arm containing `_ => continue` to extract raw attributes.
✨ Solution: Replaced the `match` block with an idiomatic `let...else` guard clause.
🧼 Benefit: Flattens the structure, reduces cognitive load, and aligns with the `clippy::manual_let_else` lint.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [10776842752587568519](https://jules.google.com/task/10776842752587568519) started by @madmax983*