### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,6 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+## 2024-05-25 - [Broken Intra-Doc Links]
+**Confusion:** The `cargo doc` generation failed with `-D warnings` because some intra-doc links in `crates/duke-gc` and `crates/duke-interpreter` were pointing to private items.
+**Clarification:** Fixed the broken intra-doc links in `crates/duke-gc/src/lib.rs` and `crates/duke-interpreter/src/registry.rs` by changing the links to plain backticked strings, as the linked items were private.

--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -1494,7 +1494,7 @@ impl Heap {
 
     /// Lisp-2 sliding mark-compact of the old generation.
     ///
-    /// 1. **Mark** live old objects reachable from `roots` (reuses [`mark_old`]).
+    /// 1. **Mark** live old objects reachable from `roots` (reuses `mark_old`).
     /// 2. **Forward** — assign each live object a new, densely-packed old index
     ///    in ascending (stable, sliding) order; record old→new in an
     ///    `old_forward` map (only for objects that actually move).
@@ -1510,8 +1510,6 @@ impl Heap {
     ///
     /// `identity_hash` and `atomic_payload` ride along with each moved object,
     /// preserving the [`HeapObject`] invariant across relocation.
-    ///
-    /// [`mark_old`]: Self::mark_old
     pub fn compact_old(&mut self, roots: &[Slot]) {
         // Snapshot executor shared state up front: their task queues hold bare
         // OLD refs the mutator never sees, so we both (a) treat them as extra

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -412,7 +412,7 @@ pub struct ClassRegistry {
     /// Best-known runtime `java/lang/ClassLoader` object for each loaded class.
     class_runtime_loaders: HashMap<String, u64>,
     /// Opt-in flag: when true, synthetic stdlib classes that are NOT on the
-    /// [`KEEP_SYNTHETIC`] allowlist and whose real classfile is resolvable via
+    /// `KEEP_SYNTHETIC` allowlist and whose real classfile is resolvable via
     /// [`Self::shadow_loader`] are NOT pre-registered synthetically, so a later
     /// `ensure_loaded` loads their real JDK bytecode instead. Default `false`.
     real_jdk_shadow: bool,
@@ -736,7 +736,7 @@ impl ClassRegistry {
     }
 
     /// Enable "real JDK shadow" mode: synthetic stdlib classes that are not on the
-    /// [`KEEP_SYNTHETIC`] allowlist and whose real classfile is resolvable via `loader`
+    /// `KEEP_SYNTHETIC` allowlist and whose real classfile is resolvable via `loader`
     /// will be skipped by [`Self::register`], letting a later `ensure_loaded` load the
     /// real JDK bytecode. Must be called *before* `bootstrap_stdlib` runs to take effect.
     pub fn enable_real_jdk_shadow(&mut self, loader: Arc<dyn ClassLoader + Send + Sync>) {


### PR DESCRIPTION
* 📖 Chapter: The `duke-gc` and `duke-interpreter` modules
* 🔦 Insight: Clarified and fixed broken intra-doc links pointing to private items that caused `cargo doc` to fail.
* 🧪 Example: Replaced `[`mark_old`]` and `[`KEEP_SYNTHETIC`]` with `` `mark_old` `` and `` `KEEP_SYNTHETIC` `` respectively.
* 🖼️ Preview: Documentation now builds without warnings.

---
*PR created automatically by Jules for task [5796183885941159213](https://jules.google.com/task/5796183885941159213) started by @madmax983*