### PR TITLE
perf(interpreter): hoist per-instruction env read out of opcode loop

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -227,3 +227,63 @@ The benchmarks include `make_env` setup (class parse + bootstrap) in total time.
 - **Remaining bottleneck**: `bootstrap_stdlib` at ~251 µs × iterations dominates all benchmarks.
   Options: lazy registration (register natives on first use), pre-built registry snapshot,
   or splitting benchmark setup so only the relevant subset is bootstrapped.
+
+## 2026-07-11: Hot-loop regression fix — hoist trace-flag env read + drop per-fetch clone
+
+Date: 2026-07-11
+Hardware: CI container
+Duke version: trunk @ `0d937e4` + interpreter hot-loop fixes
+HotSpot version: OpenJDK (system `java`)
+
+### Root cause
+
+The main opcode dispatch loop in `crates/duke-interpreter/src/execution.rs` performed two
+avoidable operations on **every** bytecode dispatch:
+
+1. **`std::env::var_os("DUKE_TRACE_EXEC")` per instruction (dominant).** The trace-gate at
+   the top of the loop read the env var unconditionally on every opcode. On Unix `var_os`
+   takes the process-wide `ENV_LOCK` and linearly scans `environ`; with the key absent (the
+   normal case) it scans the entire environment and returns `None` — the slowest path. In a
+   cargo/criterion process (large environment) this measured ~150 ns/dispatch, i.e. far more
+   than the ~1-3 ns opcode it guarded. benchSum runs ~4.5M dispatches, benchFib ~2.1M.
+2. **`Instruction::clone()` per fetch.** The fetch cloned the ~32-byte `Instruction` enum
+   though the dispatch `match` only borrows it.
+
+### Fixes (behavior-identical, interpreter-only)
+
+- **Fix #1:** read `DUKE_TRACE_EXEC` once into a `bool` before `loop {` and gate the trace
+  block on it. Nothing mutates that env var mid-run (a tracer sets it before execution), so
+  the trace output is identical.
+- **Fix #2:** bind the fetched instruction by reference (`let Some(&(pc, ref instr)) = …`)
+  and `match instr` instead of `instr.clone()`. NLL releases the borrow before the
+  invoke/return arms reassign the instruction stream, so no clone is needed and no wider
+  refactor was required.
+
+### Wall-clock (median of 7, `duke exec` release binary — includes startup + parse + bootstrap)
+
+| Benchmark | Before (ms) | After (ms) | Speedup | HS JIT (median/5) | Duke/HS before → after |
+|-----------|-------------|------------|---------|-------------------|------------------------|
+| benchSum (500k int adds)        | 1280 | 612 | 2.09x | 44 | 28x → 14x |
+| benchFib (fib(25), ~243k calls) | 708  | 389 | 1.82x | 42 | 15x → 9x  |
+
+### Criterion (median, `--sample-size 10 --measurement-time 8`; isolates the execution loop)
+
+| Benchmark | Before (ms) | After (ms) | Speedup |
+|-----------|-------------|------------|---------|
+| benchSum  | 757  | 83.5 | 9.06x |
+| benchFib  | 404  | 75.7 | 5.34x |
+
+The criterion improvement is proportionally larger than wall-clock because criterion strips
+the fixed process/startup/bootstrap cost, exposing the per-instruction loop where the env
+read dominated. Gate: `cargo test --workspace` = 3042 passed / 0 failed / 4 ignored;
+`cargo fmt --all --check` clean; `cargo +1.97.0 clippy --workspace --all-targets
+-W pedantic -W nursery` clean.
+
+### Follow-ups (out of this lane's scope)
+
+- Two `String` clones of the class name per method call — `cached.class_name.clone()`
+  (execution.rs invokestatic fast path) and `class_name: current_class.clone()` inside
+  `activate_method_state` (`native/common.rs`). Converting class keys to `Arc<str>` would
+  turn these into ref-count bumps (~485k allocs saved on benchFib), but the type flows
+  through `native/common.rs`/`registry.rs`, which are owned by other lanes — deferred.
+- `bootstrap_stdlib` (~251 µs) remains the standing wall-clock startup term (stdlib.rs).

--- a/benchmarks/compare.sh
+++ b/benchmarks/compare.sh
@@ -7,11 +7,31 @@ set -e
 BENCHMARKS_DIR="benchmarks"
 CLASS="$BENCHMARKS_DIR/BenchmarkSuite.class"
 
+# Number of runs per measurement; reported value is the median (odd N recommended).
+RUNS="${RUNS:-7}"
+
 echo "Building Duke (release)..."
 cargo build --release --quiet 2>&1
 DUKE="./target/release/duke"
 
+# median <ms...> : print the median of the integer millisecond samples passed as args.
+median() {
+    printf '%s\n' "$@" | sort -n | awk '{a[NR]=$0} END{print a[int((NR+1)/2)]}'
+}
+
+# median_ms <command...> : time the command RUNS times, return the median wall-clock ms.
+median_ms() {
+    local samples=()
+    local i secs
+    for ((i = 0; i < RUNS; i++)); do
+        secs=$( { TIMEFORMAT='%R'; time "$@" > /dev/null 2>/dev/null; } 2>&1 )
+        samples+=("$(echo "$secs" | LC_NUMERIC=C awk '{printf "%.0f", $1 * 1000}')")
+    done
+    median "${samples[@]}"
+}
+
 echo ""
+echo "Reporting median of ${RUNS} runs per cell (override with RUNS=N)."
 printf "%-30s %10s %12s %14s %12s\n" "Benchmark" "Duke (ms)" "HS JIT (ms)" "HS -Xint (ms)" "Duke/JIT"
 printf "%s\n" "$(printf '=%.0s' {1..80})"
 
@@ -19,17 +39,10 @@ for ENTRY in "sum:benchSum" "fib:benchFib" "arraylist:benchArrayList" "hashmap:b
     ARG="${ENTRY%%:*}"
     METHOD="${ENTRY##*:}"
 
-    # Time Duke
-    DUKE_SECS=$( { TIMEFORMAT='%R'; time "$DUKE" exec "$CLASS" "$METHOD" > /dev/null 2>/dev/null; } 2>&1 )
-    DUKE_MS=$(echo "$DUKE_SECS" | LC_NUMERIC=C awk '{printf "%.0f", $1 * 1000}')
-
-    # Time HotSpot JIT
-    HS_SECS=$( { TIMEFORMAT='%R'; time java -cp "$BENCHMARKS_DIR" BenchmarkSuite "$ARG" > /dev/null 2>/dev/null; } 2>&1 )
-    HS_MS=$(echo "$HS_SECS" | LC_NUMERIC=C awk '{printf "%.0f", $1 * 1000}')
-
-    # Time HotSpot -Xint (interpreter only, no JIT)
-    XI_SECS=$( { TIMEFORMAT='%R'; time java -Xint -cp "$BENCHMARKS_DIR" BenchmarkSuite "$ARG" > /dev/null 2>/dev/null; } 2>&1 )
-    XI_MS=$(echo "$XI_SECS" | LC_NUMERIC=C awk '{printf "%.0f", $1 * 1000}')
+    # Median wall-clock for Duke, HotSpot JIT, and HotSpot -Xint (interpreter only).
+    DUKE_MS=$(median_ms "$DUKE" exec "$CLASS" "$METHOD")
+    HS_MS=$(median_ms java -cp "$BENCHMARKS_DIR" BenchmarkSuite "$ARG")
+    XI_MS=$(median_ms java -Xint -cp "$BENCHMARKS_DIR" BenchmarkSuite "$ARG")
 
     # Ratio
     RATIO=$(echo "$DUKE_MS $HS_MS" | awk '{if ($2 > 0) printf "%.0fx", $1/$2; else print "N/A"}')

--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -218,6 +218,13 @@ pub fn run_execution(
 
     let mut remaining = quantum.unwrap_or(usize::MAX);
 
+    // Hoisted out of the opcode loop: reading this env var per-instruction cost a
+    // full process-wide `environ` scan (ENV_LOCK + linear search) on every
+    // dispatch, dominating the interpreter's hot loop. Nothing mutates
+    // `DUKE_TRACE_EXEC` mid-run — a tracer sets it before execution — so reading
+    // it once at loop entry is observationally identical.
+    let trace_exec = std::env::var_os("DUKE_TRACE_EXEC").is_some();
+
     loop {
         if remaining == 0 {
             return Ok(ExecutionOutcome::Yield);
@@ -231,7 +238,7 @@ pub fn run_execution(
             (pc, instr.clone())
         };
 
-        if std::env::var_os("DUKE_TRACE_EXEC").is_some() {
+        if trace_exec {
             let method_name = registry
                 .get(current_class)
                 .ok()

--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -231,11 +231,8 @@ pub fn run_execution(
         }
         remaining = remaining.saturating_sub(1);
 
-        let (pc, instr) = {
-            let Some(&(pc, ref instr)) = instructions.get(*idx) else {
-                return Err(Error::FellOffEnd);
-            };
-            (pc, instr.clone())
+        let Some(&(pc, ref instr)) = instructions.get(*idx) else {
+            return Err(Error::FellOffEnd);
         };
 
         if trace_exec {
@@ -473,12 +470,12 @@ pub fn run_execution(
         #[cfg(feature = "telemetry")]
         #[allow(clippy::used_underscore_binding)]
         let (_telem_name, _telem_pc, _telem_start) = {
-            let name = instr_name(&instr);
+            let name = instr_name(instr);
             let pc_val = pc;
             (name, pc_val, std::time::Instant::now())
         };
 
-        match &instr {
+        match instr {
             // ---- invokestatic ----
             Instruction::Invokestatic(cp_idx) => {
                 if let Some(cached) = dispatch_cache


### PR DESCRIPTION
## Before / After
The interpreter dispatch loop was reading the `DUKE_TRACE_EXEC` environment variable on **every executed instruction** — before the opcode `match`. On Unix a `var_os` miss locks the process env lock and linearly scans all of `environ` (~117–150 ns), which for arithmetic-heavy code dwarfed the ~1–3 ns of real opcode work. It was ~60–70% of loop time.

After: the flag is read once before the loop into a `bool`; the trace block is gated on it. Tracing behaves identically (on when `DUKE_TRACE_EXEC` is set at process start). Also removed a per-fetch clone of the `Instruction` enum (now matched by reference).

Measured on this CI container (medians):

| Metric | benchSum | benchFib |
|---|---|---|
| Wall-clock before | 1280 ms | 708 ms |
| Wall-clock after | 612 ms (2.1x) | 389 ms (1.8x) |
| Criterion before | 757 ms | 404 ms |
| Criterion after | 83.5 ms (9.1x) | 75.7 ms (5.3x) |
| Duke/HotSpot -Xint ratio | 28x → 14x | 15x → 9x |

The criterion win is larger than wall-clock because criterion strips fixed startup/bootstrap, exposing the per-dispatch loop where the env read dominated.

## How
- `crates/duke-interpreter/src/execution.rs`: hoisted `std::env::var_os("DUKE_TRACE_EXEC")` to a `let trace_exec: bool` before `loop {`; gated the trace block on it. Verified no other per-instruction env reads in the crate.
- Same file: instruction fetch now binds by reference and `match instr` instead of `instr.clone()` — NLL releases the borrow before the invoke/return arms reassign the instruction stream, so no cascading changes. Compiles in both default and `--features telemetry` builds.
- `benchmarks/RESULTS.md`: dated 2026-07-11 entry with root cause + before/after tables.
- `benchmarks/compare.sh`: now reports median-of-N (default 7) per cell instead of a single run.

## Testing / Gate
- `cargo test --workspace`: **3042 passed, 0 failed, 4 ignored** (unchanged from baseline).
- `cargo fmt --all -- --check`: clean.
- `RUSTFLAGS="-D warnings" cargo +1.97.0 clippy --workspace --all-targets -- -W clippy::pedantic -W clippy::nursery`: clean.
- Behavior byte-identical — pure interpreter tuning.

## Follow-ups (out of this lane)
- Two per-call class-name `String` clones (~485k allocs on benchFib) live in `native/common.rs` + `registry.rs` (owned by other lanes) — `Arc<str>` class keys would eliminate them.
- `benchmarks/compare.sh`'s Duke column hardcodes `./target/release/duke` and reads 0 when `CARGO_TARGET_DIR` is overridden (pre-existing path assumption, not changed here).

Commits: 74095d4 (trace hoist), d2b7144 (instr match-by-ref), a99f62f (RESULTS + compare.sh).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKwNCBqFjh5G2wNscZ7cgH)_