### PR TITLE
feat(classloader): climb Spring Boot boot ladder — getSystemResources, getSystemClassLoader, loadClass

### DIFF
--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -2970,15 +2970,19 @@ pub fn run_execution(
                     if let MethodHierarchyLookup::Bytecode(dispatch_class, callee_idx) = resolved {
                         (dispatch_class, callee_idx)
                     } else {
-                        // Check native registry — try actual class then interface class.
-                        let native_kind = lookup_registered_native_kind(
+                        // Check native registry, walking the super chain from the
+                        // actual class then the interface class. The walk lets
+                        // inherited `java/lang/Object` natives (e.g. `getClass`)
+                        // resolve for an interface-typed callsite whose receiver
+                        // class declares no such native of its own.
+                        let native_kind = lookup_native_kind_in_super_chain(
                             registry,
                             &actual_class,
                             &callee_name,
                             &callee_desc,
                         )
                         .or_else(|| {
-                            lookup_registered_native_kind(
+                            lookup_native_kind_in_super_chain(
                                 registry,
                                 &callee_class_key,
                                 &callee_name,

--- a/crates/duke-interpreter/src/native/common.rs
+++ b/crates/duke-interpreter/src/native/common.rs
@@ -11405,6 +11405,29 @@ fn lookup_registered_native_kind(
         })
 }
 
+/// Walk `start_class` and its super chain looking for a registered native handler
+/// for `method_name`/`method_desc`. Mirrors the super-chain walk used by
+/// invokevirtual so inherited `java/lang/Object` natives (e.g. `getClass`) resolve
+/// even when the receiver is reached through an interface-typed callsite whose own
+/// class declares no such native.
+fn lookup_native_kind_in_super_chain(
+    registry: &ClassRegistry,
+    start_class: &str,
+    method_name: &str,
+    method_desc: &str,
+) -> Option<HandlerKind> {
+    let mut current = Some(start_class.to_string());
+    while let Some(ref class) = current {
+        if let Some(handler) =
+            lookup_registered_native_kind(registry, class, method_name, method_desc)
+        {
+            return Some(handler);
+        }
+        current = registry.get(class).ok().and_then(|ctx| ctx.super_class.clone());
+    }
+    None
+}
+
 /// Walk the class hierarchy to find a bytecode method by name and descriptor,
 /// stopping early if an exact native override owns that slot.
 fn resolve_method_in_hierarchy_lookup(

--- a/crates/duke-interpreter/src/native/java_lang.rs
+++ b/crates/duke-interpreter/src/native/java_lang.rs
@@ -711,15 +711,16 @@ pub(crate) fn native_class_for_name_with_loader(
         .clone()
         .ok_or(Error::NullPointerException)?;
     let internal_name = binary_name_to_internal_name(&binary_name);
-    let (load_result, class_key) = match args.get(2) {
-        Some(Slot::Reference(Some(loader_ref))) => (
-            ops.ensure_loaded_with_runtime_loader(heap, *loader_ref, &internal_name),
-            ops.class_key_for_runtime_loader(heap, *loader_ref, &internal_name)?,
-        ),
-        Some(Slot::Reference(None)) | None => (
-            ops.ensure_loaded(&internal_name),
-            ops.class_key_for_loaded_class(&internal_name)?,
-        ),
+    // Determine the loader argument and attempt to load the class. The class key
+    // must be computed lazily (only after a successful load): computing it eagerly
+    // can itself raise `ClassNotFound` for an unloaded class, and that error would
+    // bypass the conversion below and surface as a fatal runtime error instead of a
+    // catchable `ClassNotFoundException`. Real code (e.g. commons-logging's backend
+    // probing) relies on `Class.forName` throwing a catchable exception for absent
+    // classes, so the not-found case must always resolve to a Java exception.
+    let loader_arg = match args.get(2) {
+        Some(Slot::Reference(loader)) => *loader,
+        None => None,
         _ => {
             return Err(Error::TypeMismatch {
                 expected: "Reference",
@@ -727,8 +728,18 @@ pub(crate) fn native_class_for_name_with_loader(
             });
         }
     };
+    let load_result = match loader_arg {
+        Some(loader_ref) => ops.ensure_loaded_with_runtime_loader(heap, loader_ref, &internal_name),
+        None => ops.ensure_loaded(&internal_name),
+    };
     match load_result {
         Ok(()) => {
+            let class_key = match loader_arg {
+                Some(loader_ref) => {
+                    ops.class_key_for_runtime_loader(heap, loader_ref, &internal_name)?
+                }
+                None => ops.class_key_for_loaded_class(&internal_name)?,
+            };
             let class_ref = allocate_class_object(heap, &class_key)?;
             Ok(Some(Slot::Reference(Some(class_ref))))
         }

--- a/crates/duke-interpreter/src/native/java_lang.rs
+++ b/crates/duke-interpreter/src/native/java_lang.rs
@@ -852,6 +852,56 @@ pub(crate) fn native_class_loader_get_resources(
     let enum_ref = allocate_resource_enumeration(heap, resources)?;
     Ok(Some(Slot::Reference(Some(enum_ref))))
 }
+/// Native: static `ClassLoader.getSystemResources(String)` — mirrors
+/// `native_class_loader_get_resources` but resolves against the system/bootstrap
+/// loader (passing `None`), matching `getSystemResourceAsStream` semantics.
+pub(crate) fn native_class_loader_get_system_resources(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+    ops: &mut dyn CallbackOps,
+) -> Result<Option<Slot>> {
+    let requested_name = string_arg(args, 0, heap)?;
+    let classpath = classpath_debug_label(None);
+    let Some(resolved_name) = normalize_resource_name(&requested_name) else {
+        log_resource_lookup_miss(&requested_name, "<system>", &classpath);
+        let enum_ref = allocate_resource_enumeration(heap, Vec::new())?;
+        return Ok(Some(Slot::Reference(Some(enum_ref))));
+    };
+    let resources = ops.find_resource_entries(heap, None, &resolved_name)?;
+    if resources.is_empty() {
+        log_resource_lookup_miss(&resolved_name, "<system>", &classpath);
+    }
+    let enum_ref = allocate_resource_enumeration(heap, resources)?;
+    Ok(Some(Slot::Reference(Some(enum_ref))))
+}
+/// Static-field name on the synthetic `java/lang/ClassLoader` caching the single
+/// system `ClassLoader` instance returned by `getSystemClassLoader`.
+pub(crate) const SYSTEM_CLASS_LOADER_FIELD: &str = "$dukeSystemClassLoader";
+/// Native: static `ClassLoader.getSystemClassLoader()` — returns a single stable
+/// synthetic system `ClassLoader` instance, allocated lazily on first use and
+/// cached in a static field so every call yields the same object identity.
+pub(crate) fn native_class_loader_get_system_class_loader(
+    _args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+    ops: &mut dyn CallbackOps,
+) -> Result<Option<Slot>> {
+    if let Slot::Reference(Some(existing)) =
+        ops.read_static_field("java/lang/ClassLoader", SYSTEM_CLASS_LOADER_FIELD)?
+    {
+        return Ok(Some(Slot::Reference(Some(existing))));
+    }
+    let loader_ref = heap.allocate("java/lang/ClassLoader".to_string(), 0);
+    ops.write_static_field(
+        "java/lang/ClassLoader",
+        SYSTEM_CLASS_LOADER_FIELD,
+        Slot::Reference(Some(loader_ref)),
+    )?;
+    Ok(Some(Slot::Reference(Some(loader_ref))))
+}
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn native_class_loader_register_as_parallel_capable(
     _args: &[Slot],

--- a/crates/duke-interpreter/src/native/java_lang.rs
+++ b/crates/duke-interpreter/src/native/java_lang.rs
@@ -5124,3 +5124,54 @@ pub(crate) fn native_thread_local_remove(
     heap.get_mut(this_ref)?.fields[0] = Slot::Reference(None);
     Ok(None)
 }
+
+// ┌──────────────────────────────────────────────────────────────────────────┐
+// │ java/lang/ref reference objects (Spring Boot ladder / commons-logging     │
+// │ LogFactory.getFactory frontier)                                           │
+// │                                                                           │
+// │ NON-COLLECTING stub: the referent is held by an ordinary *strong* heap    │
+// │ field (slot 0 on java/lang/ref/Reference), so it is never reclaimed by GC │
+// │ — get() returns it until an explicit clear(). This deliberately omits     │
+// │ real weak-reachability semantics; it only needs to round-trip the         │
+// │ referent, which is all commons-logging's thisClassLoaderRef relies on.    │
+// └──────────────────────────────────────────────────────────────────────────┘
+
+/// `java/lang/ref/WeakReference.<init>(Ljava/lang/Object;)V` — store the referent
+/// (which may be null) in slot 0. Strong-ref-backed, non-collecting (see block
+/// header): the referent is retained until `clear()`.
+pub(crate) fn native_reference_init(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let referent = extract_slot_arg(args, 1);
+    heap.get_mut(this_ref)?.fields[0] = referent;
+    heap.remember_reference_write(this_ref, referent);
+    Ok(None)
+}
+
+/// `java/lang/ref/Reference.get()Ljava/lang/Object;` — return the stored referent
+/// (null after `clear()`). Non-collecting: never spontaneously returns null.
+pub(crate) fn native_reference_get(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    Ok(Some(heap.get(this_ref)?.fields[0]))
+}
+
+/// `java/lang/ref/Reference.clear()V` — drop the referent so `get()` returns null.
+pub(crate) fn native_reference_clear(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    heap.get_mut(this_ref)?.fields[0] = Slot::Reference(None);
+    Ok(None)
+}

--- a/crates/duke-interpreter/src/native/java_time.rs
+++ b/crates/duke-interpreter/src/native/java_time.rs
@@ -1518,3 +1518,48 @@ pub(crate) fn native_localdatetime_hash_code(
     hash = hash.wrapping_mul(31).wrapping_add(nanos);
     Ok(Some(Slot::Int(hash)))
 }
+/// Allocate a synthetic `java/time/ZoneId` holding `zone_id` in its `string_value`.
+fn allocate_zone_id(heap: &mut duke_gc::Heap, zone_id: &str) -> Result<u64> {
+    let r = heap.allocate("java/time/ZoneId".to_string(), 0);
+    heap.get_mut(r)?.string_value = Some(zone_id.to_string());
+    Ok(r)
+}
+/// Native: `ZoneId.systemDefault() -> ZoneId`.
+///
+/// Reports UTC. Duke's clocks (`Instant`, `LocalDate*`) are all epoch/UTC based, so a
+/// UTC system-default zone keeps timestamps self-consistent without modelling a real
+/// tzdb or `ZoneRules`.
+pub(crate) fn native_zoneid_system_default(
+    _args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    Ok(Some(Slot::Reference(Some(allocate_zone_id(heap, "UTC")?))))
+}
+/// Native: `ZoneId.of(String) -> ZoneId` — synthetic holder carrying the given id.
+pub(crate) fn native_zoneid_of(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let zone_id = extract_string_arg_value(args, 0, heap)?;
+    Ok(Some(Slot::Reference(Some(allocate_zone_id(heap, &zone_id)?))))
+}
+/// Native: `ZoneId.getId() -> String` (also serves `toString()`).
+pub(crate) fn native_zoneid_get_id(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let id = heap
+        .get(this_ref)?
+        .string_value
+        .clone()
+        .unwrap_or_else(|| "UTC".to_string());
+    let sr = heap.allocate_string(id);
+    Ok(Some(Slot::Reference(Some(sr))))
+}

--- a/crates/duke-interpreter/src/native/java_util.rs
+++ b/crates/duke-interpreter/src/native/java_util.rs
@@ -5087,3 +5087,103 @@ pub(crate) fn native_objects_check_from_index_size(
     }
     Ok(Some(Slot::Int(from_index)))
 }
+
+// ---- java.util.Locale (minimal-for-boot) ----
+//
+// Spring Boot / logback's `CachingDateFormatter` reaches `Locale.getDefault()` while
+// wiring up its timestamp layout during startup. Duke does not model CLDR / the full
+// locale + ResourceBundle machinery, so `Locale` is a thin synthetic holder carrying a
+// language tag and country code in its first two reference fields
+// (`fields[0]` = language `String`, `fields[1]` = country `String`).
+//
+// `getDefault()` returns a FIXED **en-US** locale rather than reading the host
+// environment. A fixed default keeps boot deterministic (identical formatting/behaviour
+// regardless of the machine's locale) and avoids pulling in the CLDR data build-out that
+// a faithful default-locale probe would require. en-US is the conventional JVM fallback
+// and the formatters Duke models are locale-insensitive, so the choice is inert beyond
+// boot.
+
+/// Allocate a synthetic `java/util/Locale` holding `language`/`country` strings.
+fn allocate_locale(heap: &mut duke_gc::Heap, language: &str, country: &str) -> Result<u64> {
+    let lang_ref = heap.allocate_string(language.to_string());
+    let country_ref = heap.allocate_string(country.to_string());
+    let r = heap.allocate("java/util/Locale".to_string(), 2);
+    let obj = heap.get_mut(r)?;
+    obj.fields[0] = Slot::Reference(Some(lang_ref));
+    obj.fields[1] = Slot::Reference(Some(country_ref));
+    Ok(r)
+}
+
+/// Native: `Locale.getDefault() -> Locale` — fixed en-US (see module note above).
+pub(crate) fn native_locale_get_default(
+    _args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    Ok(Some(Slot::Reference(Some(allocate_locale(heap, "en", "US")?))))
+}
+
+/// Native: `Locale.getDefault(Locale$Category) -> Locale` — ignores the category and
+/// returns the same fixed en-US default as the no-arg form.
+pub(crate) fn native_locale_get_default_category(
+    _args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    Ok(Some(Slot::Reference(Some(allocate_locale(heap, "en", "US")?))))
+}
+
+/// Native: `Locale.getLanguage() -> String` — the stored language tag (`fields[0]`).
+pub(crate) fn native_locale_get_language(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    match heap.get(this_ref)?.fields.first() {
+        Some(Slot::Reference(Some(r))) => Ok(Some(Slot::Reference(Some(*r)))),
+        _ => Ok(Some(Slot::Reference(Some(heap.allocate_string(String::new()))))),
+    }
+}
+
+/// Native: `Locale.getCountry() -> String` — the stored country code (`fields[1]`).
+pub(crate) fn native_locale_get_country(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    match heap.get(this_ref)?.fields.get(1) {
+        Some(Slot::Reference(Some(r))) => Ok(Some(Slot::Reference(Some(*r)))),
+        _ => Ok(Some(Slot::Reference(Some(heap.allocate_string(String::new()))))),
+    }
+}
+
+/// Native: `Locale.toString() -> String` — `language`, then `_country` when a country
+/// is present (matching `java.util.Locale.toString()`; ROOT renders as `""`).
+pub(crate) fn native_locale_to_string(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let language = match heap.get(this_ref)?.fields.first() {
+        Some(Slot::Reference(Some(r))) => heap.get(*r)?.string_value.clone().unwrap_or_default(),
+        _ => String::new(),
+    };
+    let country = match heap.get(this_ref)?.fields.get(1) {
+        Some(Slot::Reference(Some(r))) => heap.get(*r)?.string_value.clone().unwrap_or_default(),
+        _ => String::new(),
+    };
+    let text = if country.is_empty() {
+        language
+    } else {
+        format!("{language}_{country}")
+    };
+    Ok(Some(Slot::Reference(Some(heap.allocate_string(text)))))
+}

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -13082,6 +13082,57 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         native_zoneid_get_id,
     );
 
+    // ---- java.util.Locale (minimal-for-boot) ----
+    // logback's `CachingDateFormatter` calls `Locale.getDefault()` during startup.
+    // Duke does not model CLDR / ResourceBundle, so `Locale` is a thin synthetic holder
+    // for a language tag + country code (see the natives in native/java_util.rs).
+    // `getDefault()` reports a fixed en-US locale, keeping boot deterministic without a
+    // locale/CLDR data build-out.
+    let locale_ctx = ClassContext {
+        class_name: "java/util/Locale".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        // fields[0] = language String, fields[1] = country String
+        instance_field_count: 2,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    registry.register(locale_ctx);
+    registry.natives_mut().register(
+        "java/util/Locale",
+        "getDefault",
+        "()Ljava/util/Locale;",
+        native_locale_get_default,
+    );
+    registry.natives_mut().register(
+        "java/util/Locale",
+        "getDefault",
+        "(Ljava/util/Locale$Category;)Ljava/util/Locale;",
+        native_locale_get_default_category,
+    );
+    registry.natives_mut().register(
+        "java/util/Locale",
+        "getLanguage",
+        "()Ljava/lang/String;",
+        native_locale_get_language,
+    );
+    registry.natives_mut().register(
+        "java/util/Locale",
+        "getCountry",
+        "()Ljava/lang/String;",
+        native_locale_get_country,
+    );
+    registry.natives_mut().register(
+        "java/util/Locale",
+        "toString",
+        "()Ljava/lang/String;",
+        native_locale_to_string,
+    );
+
     // Phase 64 additions
     registry.natives_mut().register(
         "java/lang/String",

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -13455,6 +13455,69 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
             .register("java/lang/ThreadLocal", method, descriptor, handler);
     }
 
+    // ┌──────────────────────────────────────────────────────────────────────┐
+    // │ java/lang/ref reference objects (Spring Boot ladder / commons-logging │
+    // │ LogFactory.getFactory WeakReference.get frontier)                     │
+    // └──────────────────────────────────────────────────────────────────────┘
+    // Minimal NON-COLLECTING Reference/WeakReference: the referent lives in a
+    // single strong-ref slot (field 0 on Reference) so get() round-trips it until
+    // clear(); no GC weak semantics. commons-logging caches its own defining
+    // ClassLoader in a static WeakReference and only ever reads it back, which a
+    // strong slot models faithfully. See native_reference_* in native/java_lang.rs.
+    let reference_ctx = ClassContext {
+        class_name: "java/lang/ref/Reference".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "referent".to_string(),
+            descriptor: "Ljava/lang/Object;".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    registry.register(reference_ctx);
+    // get()/clear() live on the Reference base; WeakReference inherits them (the
+    // referent slot is inherited, so a WeakReference instance carries one field).
+    for (method, descriptor, handler) in [
+        (
+            "get",
+            "()Ljava/lang/Object;",
+            native_reference_get as NativeHandler,
+        ),
+        ("clear", "()V", native_reference_clear),
+    ] {
+        registry
+            .natives_mut()
+            .register("java/lang/ref/Reference", method, descriptor, handler);
+    }
+
+    let weak_reference_ctx = ClassContext {
+        class_name: "java/lang/ref/WeakReference".to_string(),
+        super_class: Some("java/lang/ref/Reference".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    registry.register(weak_reference_ctx);
+    // Only the single-arg WeakReference(referent) constructor is exercised by the
+    // ladder (commons-logging's thisClassLoaderRef static initialiser).
+    registry.natives_mut().register(
+        "java/lang/ref/WeakReference",
+        "<init>",
+        "(Ljava/lang/Object;)V",
+        native_reference_init,
+    );
+
     // java/lang/Class.isAssignableFrom — hierarchy-walking reflection predicate
     // (gson uses it while resolving type adapters).
     registry.natives_mut().register_callback(

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -13037,6 +13037,51 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         native_localdatetime_hash_code,
     );
 
+    // ---- java.time.ZoneId (minimal-for-boot) ----
+    // Spring Boot / logback's timestamp formatting reaches `ZoneId` during startup.
+    // Duke does not model a real tzdb, so `ZoneId` is a thin synthetic holder for a
+    // zone-id string. `systemDefault()` reports UTC: the interpreter's clocks are all
+    // epoch/UTC based (see `Instant`/`LocalDate*` natives above), so a UTC default
+    // zone keeps timestamps self-consistent without pulling in `ZoneRules`/tzdb.
+    let zone_id_ctx = ClassContext {
+        class_name: "java/time/ZoneId".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        // one field: the zone-id string (stored via string_value on the instance)
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    registry.register(zone_id_ctx);
+    registry.natives_mut().register(
+        "java/time/ZoneId",
+        "systemDefault",
+        "()Ljava/time/ZoneId;",
+        native_zoneid_system_default,
+    );
+    registry.natives_mut().register(
+        "java/time/ZoneId",
+        "of",
+        "(Ljava/lang/String;)Ljava/time/ZoneId;",
+        native_zoneid_of,
+    );
+    registry.natives_mut().register(
+        "java/time/ZoneId",
+        "getId",
+        "()Ljava/lang/String;",
+        native_zoneid_get_id,
+    );
+    registry.natives_mut().register(
+        "java/time/ZoneId",
+        "toString",
+        "()Ljava/lang/String;",
+        native_zoneid_get_id,
+    );
+
     // Phase 64 additions
     registry.natives_mut().register(
         "java/lang/String",

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -4247,8 +4247,14 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         super_class: Some("java/lang/Object".to_string()),
         constant_pool: Vec::new(),
         methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
+        // Static-only field caching the single system ClassLoader instance
+        // returned by `getSystemClassLoader` (see SYSTEM_CLASS_LOADER_FIELD).
+        fields: vec![FieldEntry {
+            name: SYSTEM_CLASS_LOADER_FIELD.to_string(),
+            descriptor: "Ljava/lang/ClassLoader;".to_string(),
+            is_static: true,
+        }],
+        static_fields: vec![Slot::Reference(None)],
         instance_field_count: 0,
         interfaces: Vec::new(),
         bootstrap_methods: Vec::new(),
@@ -4284,6 +4290,29 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         "getSystemResourceAsStream",
         "(Ljava/lang/String;)Ljava/io/InputStream;",
         native_class_loader_get_system_resource_as_stream,
+    );
+    // ┌──────────────────────────────────────────────────────────────────────┐
+    // │ System ClassLoader accessors (Spring Boot ladder / app frontier)      │
+    // └──────────────────────────────────────────────────────────────────────┘
+    registry.natives_mut().register_callback(
+        "java/lang/ClassLoader",
+        "getSystemResources",
+        "(Ljava/lang/String;)Ljava/util/Enumeration;",
+        native_class_loader_get_system_resources,
+    );
+    registry.natives_mut().register_callback(
+        "java/lang/ClassLoader",
+        "getSystemClassLoader",
+        "()Ljava/lang/ClassLoader;",
+        native_class_loader_get_system_class_loader,
+    );
+    // Base `ClassLoader.loadClass` delegates to the parent/default loader first and
+    // then the receiver's runtime paths — exactly `native_url_class_loader_load_class`.
+    registry.natives_mut().register_callback(
+        "java/lang/ClassLoader",
+        "loadClass",
+        "(Ljava/lang/String;)Ljava/lang/Class;",
+        native_url_class_loader_load_class,
     );
 
     let thread_ctx = ClassContext {

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -28271,6 +28271,73 @@ fn test_treeset_stream() {
     );
 }
 
+// ---- java.time.ZoneId (minimal-for-boot) ----
+
+#[test]
+fn test_zoneid_system_default_is_utc() {
+    let mut heap = duke_gc::Heap::new();
+    let mut sink: Vec<u8> = Vec::new();
+    let zone = native_zoneid_system_default(
+        &[],
+        &mut heap,
+        &mut sink,
+        &mut NativeControl::default(),
+    )
+    .expect("systemDefault should succeed")
+    .expect("systemDefault should return a ZoneId");
+    let Slot::Reference(Some(zone_ref)) = zone else {
+        panic!("expected ZoneId reference");
+    };
+    let id = native_zoneid_get_id(
+        &[Slot::Reference(Some(zone_ref))],
+        &mut heap,
+        &mut sink,
+        &mut NativeControl::default(),
+    )
+    .expect("getId should succeed")
+    .expect("getId should return a String");
+    let Slot::Reference(Some(id_ref)) = id else {
+        panic!("expected String reference");
+    };
+    assert_eq!(
+        heap.get(id_ref).unwrap().string_value.as_deref(),
+        Some("UTC")
+    );
+}
+
+#[test]
+fn test_zoneid_of_round_trips_id() {
+    let mut heap = duke_gc::Heap::new();
+    let mut sink: Vec<u8> = Vec::new();
+    let name_ref = heap.allocate_string("America/New_York".to_string());
+    let zone = native_zoneid_of(
+        &[Slot::Reference(Some(name_ref))],
+        &mut heap,
+        &mut sink,
+        &mut NativeControl::default(),
+    )
+    .expect("ZoneId.of should succeed")
+    .expect("ZoneId.of should return a ZoneId");
+    let Slot::Reference(Some(zone_ref)) = zone else {
+        panic!("expected ZoneId reference");
+    };
+    let id = native_zoneid_get_id(
+        &[Slot::Reference(Some(zone_ref))],
+        &mut heap,
+        &mut sink,
+        &mut NativeControl::default(),
+    )
+    .expect("getId should succeed")
+    .expect("getId should return a String");
+    let Slot::Reference(Some(id_ref)) = id else {
+        panic!("expected String reference");
+    };
+    assert_eq!(
+        heap.get(id_ref).unwrap().string_value.as_deref(),
+        Some("America/New_York")
+    );
+}
+
 // ---- Phase 62: java.time (LocalDate, Duration, Period, Instant) ----
 
 #[test]

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -22342,6 +22342,78 @@ fn native_class_for_name_with_loader_uses_binary_name() {
     );
 }
 
+/// Regression: a `Class.forName(name, false, cl)` availability probe for an absent
+/// class must surface a catchable `ClassNotFoundException`, even when computing the
+/// class identity key would itself raise `ClassNotFound`. The native previously
+/// computed the key eagerly (with `?`) alongside the load attempt, so a missing
+/// class made the key lookup fail first and propagate a fatal `ClassNotFound`
+/// instead of the mapped Java exception. Commons-logging's backend probing relies
+/// on the exception being catchable (e.g. the `SLF4JProvider`/`Log4jApiLogFactory`
+/// availability checks in `LogFactory.newStandardFactory`).
+#[test]
+fn native_class_for_name_missing_class_throws_even_when_key_lookup_fails() {
+    #[derive(Default)]
+    struct MissingKeyOps;
+
+    impl CallbackOps for MissingKeyOps {
+        fn invoke(
+            &mut self,
+            _heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            _args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            Ok(None)
+        }
+
+        fn ensure_loaded(&mut self, class: &str) -> Result<()> {
+            Err(Error::ClassNotFound {
+                name: class.to_string(),
+            })
+        }
+
+        // Mirrors the real registry: resolving the identity key for an unloaded
+        // class raises `ClassNotFound`. This must NOT escape as a fatal error.
+        fn class_key_for_loaded_class(&mut self, class: &str) -> Result<String> {
+            Err(Error::ClassNotFound {
+                name: class.to_string(),
+            })
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            unreachable!("inspect_class should not be used")
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let mut sink: Vec<u8> = Vec::new();
+    let binary_name_ref = heap.allocate_string("org.apache.logging.slf4j.SLF4JProvider".to_string());
+    let mut ops = MissingKeyOps;
+
+    let result = native_class_for_name_with_loader(
+        &[
+            Slot::Reference(Some(binary_name_ref)),
+            Slot::Int(0),
+            Slot::Reference(None),
+        ],
+        &mut heap,
+        &mut sink,
+        &mut NativeControl::default(),
+        &mut ops,
+    );
+
+    assert!(
+        matches!(
+            result,
+            Err(Error::JavaException { ref class_name })
+                if class_name == "java/lang/ClassNotFoundException"
+        ),
+        "missing class must throw catchable ClassNotFoundException, not a fatal error: {result:?}"
+    );
+}
+
 #[test]
 #[allow(clippy::too_many_lines)]
 fn native_class_for_name_with_loader_uses_loader_archive_not_global_default_code_source() {

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -1186,6 +1186,7 @@ fn invokevirtual_missing_loaded_method_returns_method_not_found() {
 /// interface directly — never the super chain — so `Object.getClass` was never
 /// found and dispatch raised `MethodNotFound`.
 #[test]
+#[allow(clippy::too_many_lines)]
 fn invokeinterface_getclass_resolves_inherited_object_native_via_super_chain() {
     use duke_classfile::CpIndex;
     use std::collections::HashMap;
@@ -1320,6 +1321,116 @@ fn invokeinterface_getclass_resolves_inherited_object_native_via_super_chain() {
         class_internal_name_from_ref(&heap, class_ref).unwrap(),
         "CfgImpl",
         "getClass() must report the receiver's concrete runtime class"
+    );
+}
+
+/// The minimal synthetic `java/lang/ref/WeakReference` round-trips its referent:
+/// `new WeakReference(x)` then `.get()` returns `x`. Mirrors commons-logging's
+/// `thisClassLoaderRef` (a static `WeakReference<ClassLoader>` it constructs once
+/// and only ever reads back). `get()` resolves on the `Reference` base via the
+/// receiver's super chain. This is a NON-COLLECTING strong-ref-backed stub.
+#[test]
+fn weak_reference_get_round_trips_referent() {
+    use duke_classfile::CpIndex;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    // CP: new/init/get for java/lang/ref/WeakReference.
+    let cp = make_cp(vec![
+        Some(CpEntry::Class {
+            name_index: CpIndex(2),
+        }),
+        Some(CpEntry::Utf8("java/lang/ref/WeakReference".to_string())),
+        Some(CpEntry::Methodref {
+            class_index: CpIndex(1),
+            name_and_type_index: CpIndex(4),
+        }),
+        Some(CpEntry::NameAndType {
+            name_index: CpIndex(5),
+            descriptor_index: CpIndex(6),
+        }),
+        Some(CpEntry::Utf8("<init>".to_string())),
+        Some(CpEntry::Utf8("(Ljava/lang/Object;)V".to_string())),
+        Some(CpEntry::Methodref {
+            class_index: CpIndex(1),
+            name_and_type_index: CpIndex(8),
+        }),
+        Some(CpEntry::NameAndType {
+            name_index: CpIndex(9),
+            descriptor_index: CpIndex(10),
+        }),
+        Some(CpEntry::Utf8("get".to_string())),
+        Some(CpEntry::Utf8("()Ljava/lang/Object;".to_string())),
+    ]);
+    let instructions: Arc<[(usize, Instruction)]> = vec![
+        (0, Instruction::New(CpIndex(1))),
+        (3, Instruction::Dup),
+        (4, Instruction::Aload0), // referent (local 0)
+        (5, Instruction::Invokespecial(CpIndex(3))),
+        (8, Instruction::Invokevirtual(CpIndex(7))),
+        (11, Instruction::Areturn),
+    ]
+    .into();
+    let method = MethodEntry {
+        name: "roundTrip".to_string(),
+        descriptor: "(Ljava/lang/Object;)Ljava/lang/Object;".to_string(),
+        is_public: true,
+        is_static: true,
+        is_native: false,
+        is_abstract: false,
+        instructions: Arc::clone(&instructions),
+        max_stack: 3,
+        max_locals: 1,
+        exception_table: Vec::new(),
+        pc_to_idx: Arc::new(HashMap::from([
+            (0, 0),
+            (3, 1),
+            (4, 2),
+            (5, 3),
+            (8, 4),
+            (11, 5),
+        ])),
+        line_number_table: Vec::new(),
+        source_file: None,
+    };
+    let caller_ctx = ClassContext {
+        class_name: "TestWeakRef".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        interfaces: Vec::new(),
+        constant_pool: cp,
+        methods: vec![method],
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Classfile,
+    };
+
+    let mut registry = ClassRegistry::new();
+    let mut heap = duke_gc::Heap::new();
+    bootstrap_stdlib(&mut registry, &mut heap);
+    registry.register(caller_ctx);
+    let loader = fixtures_loader();
+
+    let referent = heap.allocate("java/lang/Object".to_string(), 0);
+    let mut sink: Vec<u8> = Vec::new();
+    let result = execute_class(
+        &mut registry,
+        &loader,
+        &mut heap,
+        &mut sink,
+        "TestWeakRef",
+        "roundTrip",
+        "(Ljava/lang/Object;)Ljava/lang/Object;",
+        &[Slot::Reference(Some(referent))],
+    )
+    .expect("WeakReference new/init/get should execute")
+    .expect("WeakReference.get should return the referent");
+
+    assert_eq!(
+        result,
+        Slot::Reference(Some(referent)),
+        "WeakReference.get() must return the exact referent stored at construction"
     );
 }
 

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -22389,7 +22389,8 @@ fn native_class_for_name_missing_class_throws_even_when_key_lookup_fails() {
 
     let mut heap = duke_gc::Heap::new();
     let mut sink: Vec<u8> = Vec::new();
-    let binary_name_ref = heap.allocate_string("org.apache.logging.slf4j.SLF4JProvider".to_string());
+    let binary_name_ref =
+        heap.allocate_string("org.apache.logging.slf4j.SLF4JProvider".to_string());
     let mut ops = MissingKeyOps;
 
     let result = native_class_for_name_with_loader(
@@ -28277,14 +28278,10 @@ fn test_treeset_stream() {
 fn test_zoneid_system_default_is_utc() {
     let mut heap = duke_gc::Heap::new();
     let mut sink: Vec<u8> = Vec::new();
-    let zone = native_zoneid_system_default(
-        &[],
-        &mut heap,
-        &mut sink,
-        &mut NativeControl::default(),
-    )
-    .expect("systemDefault should succeed")
-    .expect("systemDefault should return a ZoneId");
+    let zone =
+        native_zoneid_system_default(&[], &mut heap, &mut sink, &mut NativeControl::default())
+            .expect("systemDefault should succeed")
+            .expect("systemDefault should return a ZoneId");
     let Slot::Reference(Some(zone_ref)) = zone else {
         panic!("expected ZoneId reference");
     };

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -28335,6 +28335,60 @@ fn test_zoneid_of_round_trips_id() {
     );
 }
 
+// ---- java.util.Locale (minimal-for-boot) ----
+
+#[test]
+fn test_locale_get_default_is_en_us() {
+    let mut heap = duke_gc::Heap::new();
+    let mut sink: Vec<u8> = Vec::new();
+    let locale =
+        native_locale_get_default(&[], &mut heap, &mut sink, &mut NativeControl::default())
+            .expect("getDefault should succeed")
+            .expect("getDefault should return a Locale");
+    let Slot::Reference(Some(locale_ref)) = locale else {
+        panic!("expected Locale reference");
+    };
+    // The documented fixed default: language "en", country "US".
+    let language = native_locale_get_language(
+        &[Slot::Reference(Some(locale_ref))],
+        &mut heap,
+        &mut sink,
+        &mut NativeControl::default(),
+    )
+    .expect("getLanguage should succeed")
+    .expect("getLanguage should return a String");
+    let country = native_locale_get_country(
+        &[Slot::Reference(Some(locale_ref))],
+        &mut heap,
+        &mut sink,
+        &mut NativeControl::default(),
+    )
+    .expect("getCountry should succeed")
+    .expect("getCountry should return a String");
+    let to_string = native_locale_to_string(
+        &[Slot::Reference(Some(locale_ref))],
+        &mut heap,
+        &mut sink,
+        &mut NativeControl::default(),
+    )
+    .expect("toString should succeed")
+    .expect("toString should return a String");
+    let (Slot::Reference(Some(lang_ref)), Slot::Reference(Some(country_ref)), Slot::Reference(Some(str_ref))) =
+        (language, country, to_string)
+    else {
+        panic!("expected String references");
+    };
+    assert_eq!(heap.get(lang_ref).unwrap().string_value.as_deref(), Some("en"));
+    assert_eq!(
+        heap.get(country_ref).unwrap().string_value.as_deref(),
+        Some("US")
+    );
+    assert_eq!(
+        heap.get(str_ref).unwrap().string_value.as_deref(),
+        Some("en_US")
+    );
+}
+
 // ---- Phase 62: java.time (LocalDate, Duration, Period, Instant) ----
 
 #[test]

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -28373,12 +28373,18 @@ fn test_locale_get_default_is_en_us() {
     )
     .expect("toString should succeed")
     .expect("toString should return a String");
-    let (Slot::Reference(Some(lang_ref)), Slot::Reference(Some(country_ref)), Slot::Reference(Some(str_ref))) =
-        (language, country, to_string)
+    let (
+        Slot::Reference(Some(lang_ref)),
+        Slot::Reference(Some(country_ref)),
+        Slot::Reference(Some(str_ref)),
+    ) = (language, country, to_string)
     else {
         panic!("expected String references");
     };
-    assert_eq!(heap.get(lang_ref).unwrap().string_value.as_deref(), Some("en"));
+    assert_eq!(
+        heap.get(lang_ref).unwrap().string_value.as_deref(),
+        Some("en")
+    );
     assert_eq!(
         heap.get(country_ref).unwrap().string_value.as_deref(),
         Some("US")

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -1177,6 +1177,152 @@ fn invokevirtual_missing_loaded_method_returns_method_not_found() {
     );
 }
 
+/// Regression: `getClass()` invoked through an *interface-typed* callsite must
+/// resolve the inherited `java/lang/Object.getClass` native by walking the
+/// receiver's super chain. Real Spring Boot bytecode calls
+/// `Configurator.getClass()` on a `DefaultJoranConfigurator` (which inherits
+/// `getClass` from `Object` via an intermediate base class). Before the fix the
+/// invokeinterface native fallback only probed the receiver class and the
+/// interface directly — never the super chain — so `Object.getClass` was never
+/// found and dispatch raised `MethodNotFound`.
+#[test]
+fn invokeinterface_getclass_resolves_inherited_object_native_via_super_chain() {
+    use duke_classfile::CpIndex;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    // Constant pool: an InterfaceMethodref for `Cfg.getClass()Ljava/lang/Class;`.
+    let cp = make_cp(vec![
+        Some(CpEntry::InterfaceMethodref {
+            class_index: CpIndex(2),
+            name_and_type_index: CpIndex(3),
+        }),
+        Some(CpEntry::Class {
+            name_index: CpIndex(4),
+        }),
+        Some(CpEntry::NameAndType {
+            name_index: CpIndex(5),
+            descriptor_index: CpIndex(6),
+        }),
+        Some(CpEntry::Utf8("Cfg".to_string())),
+        Some(CpEntry::Utf8("getClass".to_string())),
+        Some(CpEntry::Utf8("()Ljava/lang/Class;".to_string())),
+    ]);
+    let instructions: Arc<[(usize, Instruction)]> = vec![
+        (0, Instruction::Aload0),
+        (
+            1,
+            Instruction::Invokeinterface {
+                index: CpIndex(1),
+                count: 1,
+            },
+        ),
+        (6, Instruction::Areturn),
+    ]
+    .into();
+    let method = MethodEntry {
+        name: "callGetClass".to_string(),
+        descriptor: "(Ljava/lang/Object;)Ljava/lang/Object;".to_string(),
+        is_public: true,
+        is_static: true,
+        is_native: false,
+        is_abstract: false,
+        instructions: Arc::clone(&instructions),
+        max_stack: 1,
+        max_locals: 1,
+        exception_table: Vec::new(),
+        pc_to_idx: Arc::new(HashMap::from([(0, 0), (1, 1), (6, 2)])),
+        line_number_table: Vec::new(),
+        source_file: None,
+    };
+    let caller_ctx = ClassContext {
+        class_name: "TestCaller".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        interfaces: Vec::new(),
+        constant_pool: cp,
+        methods: vec![method],
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Classfile,
+    };
+
+    // Marker interface `Cfg` (declares no `getClass` of its own).
+    let cfg_iface = ClassContext {
+        class_name: "Cfg".to_string(),
+        super_class: None,
+        interfaces: Vec::new(),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    // Intermediate base class between the impl and Object — mirrors logback's
+    // `ContextAwareBase` so the native only resolves by walking past it.
+    let base_ctx = ClassContext {
+        class_name: "CfgBase".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        interfaces: Vec::new(),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    // Concrete receiver: `CfgImpl extends CfgBase implements Cfg`, no own methods.
+    let impl_ctx = ClassContext {
+        class_name: "CfgImpl".to_string(),
+        super_class: Some("CfgBase".to_string()),
+        interfaces: vec!["Cfg".to_string()],
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+
+    let mut registry = ClassRegistry::new();
+    let mut heap = duke_gc::Heap::new();
+    bootstrap_stdlib(&mut registry, &mut heap);
+    registry.register(caller_ctx);
+    registry.register(cfg_iface);
+    registry.register(base_ctx);
+    registry.register(impl_ctx);
+    let loader = fixtures_loader();
+
+    let impl_ref = heap.allocate("CfgImpl".to_string(), 0);
+    let mut sink: Vec<u8> = Vec::new();
+    let result = execute_class(
+        &mut registry,
+        &loader,
+        &mut heap,
+        &mut sink,
+        "TestCaller",
+        "callGetClass",
+        "(Ljava/lang/Object;)Ljava/lang/Object;",
+        &[Slot::Reference(Some(impl_ref))],
+    )
+    .expect("invokeinterface getClass should resolve the inherited Object native")
+    .expect("getClass should return a Class object");
+
+    let Slot::Reference(Some(class_ref)) = result else {
+        panic!("expected a Class reference from getClass, got {result:?}");
+    };
+    assert_eq!(
+        class_internal_name_from_ref(&heap, class_ref).unwrap(),
+        "CfgImpl",
+        "getClass() must report the receiver's concrete runtime class"
+    );
+}
+
 #[test]
 fn object_constructor_dispatches_via_invokespecial() {
     use duke_classfile::CpIndex;

--- a/docs/findings/2026-07-10-spring-boot-real-app.md
+++ b/docs/findings/2026-07-10-spring-boot-real-app.md
@@ -185,6 +185,35 @@ loader — precisely the pattern Spring's `LaunchedClassLoader` (and any nested-
 or custom-classloader app) creates. The two Spring Boot fixtures are the
 regression witnesses, but the fix is generic.
 
+## Update (this wave): two more rungs cleared
+
+**Ladder — `SLF4JProvider` `Class.forName` availability probe (CLEARED).**
+`crates/duke-interpreter/src/native/java_lang.rs`, `native_class_for_name_with_loader`.
+commons-logging `LogFactory.newStandardFactory` probes for logging backends via
+`isClassAvailable(name, cl)` → `Class.forName(name, false, cl)`, catching
+`ClassNotFoundException`. Duke's 3-arg `Class.forName` native computed the class
+identity key **eagerly** (with `?`) alongside the load attempt; for an absent
+class the key lookup itself raises `ClassNotFound`, propagating a **fatal** error
+before the not-found result could be mapped to a catchable
+`ClassNotFoundException`. Fix: compute the key lazily, only on a successful load.
+New ladder frontier: `class not found: org/apache/logging/log4j/MarkerManager`,
+reached while initializing `Log4jApiLogFactory` (its `<clinit>` calls
+`MarkerManager.getMarker`). A real JVM raises a **catchable `NoClassDefFoundError`**
+(a `LinkageError`) that commons-logging catches and falls through on; duke has no
+synthetic `NoClassDefFoundError`/`LinkageError` and surfaces class-resolution
+failures during bytecode execution as fatal errors. That is a distinct
+interpreter class-resolution / linkage-error rung (handoff).
+
+**App — minimal `java.time.ZoneId` for boot (CLEARED).**
+`crates/duke-interpreter/src/native/java_time.rs` + registration in
+`crates/duke-interpreter/src/stdlib.rs`. logback's timestamp formatting reaches
+`ZoneId` during Spring Boot startup. Registered a thin synthetic `ZoneId`:
+`systemDefault()` reports **UTC** (duke's `Instant`/`LocalDate*` clocks are all
+epoch/UTC based, so a UTC default keeps timestamps self-consistent **without**
+modelling `ZoneRules`/tzdb), plus `of(String)`, `getId()`, `toString()`. Clearing
+`ZoneId` did **not** cascade into a chronology/tzdb chain — the app frontier moved
+to `class not found: java/util/Locale` (a shallow, separate java.util rung, handoff).
+
 ## Lane ownership summary
 
 | Blocker | Owning lane | Status |
@@ -195,8 +224,10 @@ regression witnesses, but the fix is generic.
 | #1b `ClassLoader.loadClass` missing | synthetic-stdlib `java_lang` — `ClassLoader` (`stdlib.rs`) | **CLEARED (this branch)** |
 | #1c `Object.getClass()` interface-callsite dispatch | execution.rs interface dispatch (native fallback super-chain walk) | **CLEARED (this branch)** |
 | #1d `WeakReference.get()` underflow in commons-logging | native — `java.lang.ref` reference-object | **CLEARED (this branch)** |
-| #1e `class not found: java/time/ZoneId` | native / stdlib — `java_time` (`ZoneId`) | **HANDOFF — current app pin** |
-| #1f `class not found: org/apache/logging/slf4j/SLF4JProvider` | logging-backend / service-provider (classpath resolution) | **HANDOFF — current ladder pin** |
+| #1e `class not found: java/time/ZoneId` | native / stdlib — `java_time` (`ZoneId`) | **CLEARED (this branch)** |
+| #1e′ `class not found: java/util/Locale` | native / stdlib — `java_util` (`Locale`) | **HANDOFF — current app pin** |
+| #1f `class not found: org/apache/logging/slf4j/SLF4JProvider` | class-loader — `Class.forName` availability probe (`java_lang`) | **CLEARED (this branch)** |
+| #1f′ `class not found: org/apache/logging/log4j/MarkerManager` | interpreter — class-resolution / `NoClassDefFoundError` linkage during `<clinit>` (`execution.rs` + synthetic `LinkageError` in `stdlib.rs`) | **HANDOFF — current ladder pin** |
 | #2 `java/net/URL` layout coherence | native / stdlib object-layout — `java_net` (`URL`) | inferred |
 | #3 `spring.factories` / `AutoConfiguration.imports` resource enumeration | java_util + classloader/registry | inferred |
 | #4 reflective bean instantiation / annotations | reflect (`java_lang_reflect`) + `java_lang` (`Class`) | inferred |

--- a/docs/findings/2026-07-10-spring-boot-real-app.md
+++ b/docs/findings/2026-07-10-spring-boot-real-app.md
@@ -53,9 +53,34 @@ With the loader-lane fix in this branch (`5860f6b`, see below), `duke -jar` on
 3. Reaches Spring Boot's **classpath-scanning phase** — the point where the
    framework enumerates classpath resources to discover configuration.
 
-It then stops. **Update 2026-07-10 (after #1320):** the gson-natives work in
-#1320 advanced the **app** fixture past the `getSystemResources` rung; the two
-fixtures now diverge on the first blocker:
+It then stops. **Update 2026-07-11 (ClassLoader-lane rungs cleared):** three
+synthetic `java/lang/ClassLoader` natives are now implemented —
+`getSystemResources(String)` (mirrors `getResources` but resolves against the
+system/bootstrap loader), `getSystemClassLoader()` (returns a single stable
+synthetic system `ClassLoader` instance, cached in a static field), and base
+`loadClass(String)` (reuses `native_url_class_loader_load_class`, which delegates
+to the parent/default loader first). These advanced **both** fixtures several
+rungs. The frontier has now moved **out of the ClassLoader-native lane** on both:
+
+```
+# app  (duke-spring-boot-app-3.5.12.jar) — new frontier:
+duke: runtime error: method not found: ch/qos/logback/classic/util/DefaultJoranConfigurator.getClass()Ljava/lang/Class;
+
+# ladder (duke-spring-boot-ladder-3.5.12.jar) — new frontier:
+duke: runtime error: operand stack underflow
+```
+
+The **app** frontier is inherited `java/lang/Object.getClass()` virtual dispatch
+failing to resolve for a class loaded through the runtime `loadClass` path — an
+interpreter method-dispatch / class-identity issue (`execution.rs`), not a missing
+ClassLoader native. The **ladder** frontier is an `operand stack underflow` deep
+in real commons-logging `LogFactory.getFactory` at
+`java/lang/ref/WeakReference.get()Ljava/lang/Object;` (offset 188 → `checkcast` at
+191 underflows because `get()` returns no value) — a `java.lang.ref`
+reference-object native that is unimplemented. Both are handoffs to other lanes.
+
+Previous divergence (**Update 2026-07-10, after #1320**), retained for history —
+the two fixtures diverged after #1320 advanced the app past `getSystemResources`:
 
 ```
 # app  (duke-spring-boot-app-3.5.12.jar):
@@ -81,8 +106,11 @@ under the default synthetic-stdlib path).
 | # | Blocker (symptom) | Root cause | Status | Owning lane |
 | --- | --- | --- | --- | --- |
 | **0** | `class not found: java/lang/System` (app) / `java/lang/ClassLoader` (ladder) — died before any framework code, at a loader-suffixed key (`java/lang/System\0loader:113`). | `ensure_loaded_inner` recorded per-loader/per-code-source provenance onto **plain synthetic bootstrap singletons**, flipping `is_plain_bootstrap_class` false and desyncing it from `class_key_from_provenance`, which then computed a loader-suffixed key nothing was stored under. | **FIXED here** (`5860f6b`) | classloader/registry (**this lane**) |
-| **1** | `method not found: java/lang/ClassLoader.getSystemResources(Ljava/lang/String;)Ljava/util/Enumeration;` — boot reaches classpath scanning, no banner. | `getSystemResources` is a **missing synthetic method** on the synthetic `java/lang/ClassLoader` in `stdlib.rs`. The resource-enumeration API surface (`getResource(s)`, `getSystemResource(s)`, `getResourceAsStream`) is incomplete. | **CLEARED for app by #1320** (gson natives advanced the app past this rung). **Still OBSERVED for the ladder — current ladder pin.** | synthetic-stdlib / native — `java_lang` (`ClassLoader` resource API) |
-| **1a** | `method not found: java/lang/ClassLoader.getSystemClassLoader()Ljava/lang/ClassLoader;` — app fixture's new first blocker after #1320, still in the classpath-scanning / classloader-bootstrap path, no banner. | `getSystemClassLoader` is another **missing synthetic method** on the synthetic `java/lang/ClassLoader` in `stdlib.rs` — same `ClassLoader` surface as #1, next method the app reaches. | **OBSERVED — current app pin** | synthetic-stdlib / native — `java_lang` (`ClassLoader` static/system-loader API) |
+| **1** | `method not found: java/lang/ClassLoader.getSystemResources(Ljava/lang/String;)Ljava/util/Enumeration;` — boot reaches classpath scanning, no banner. | `getSystemResources` is a **missing synthetic method** on the synthetic `java/lang/ClassLoader` in `stdlib.rs`. The resource-enumeration API surface (`getResource(s)`, `getSystemResource(s)`, `getResourceAsStream`) is incomplete. | **CLEARED for app by #1320; CLEARED for ladder here** — `native_class_loader_get_system_resources` added (mirrors `getResources` with `None` loader). | synthetic-stdlib / native — `java_lang` (`ClassLoader` resource API) |
+| **1a** | `method not found: java/lang/ClassLoader.getSystemClassLoader()Ljava/lang/ClassLoader;` — app fixture's first blocker after #1320. | `getSystemClassLoader` missing on synthetic `java/lang/ClassLoader`. | **CLEARED here** — `native_class_loader_get_system_class_loader` returns one stable synthetic `ClassLoader` cached in a new static field. | synthetic-stdlib / native — `java_lang` (`ClassLoader` static/system-loader API) |
+| **1b** | `method not found: java/lang/ClassLoader.loadClass(Ljava/lang/String;)Ljava/lang/Class;` — app, after 1a cleared. | Base `ClassLoader.loadClass` missing on synthetic `java/lang/ClassLoader`. | **CLEARED here** — registered `native_url_class_loader_load_class` (parent-first delegation) for base `ClassLoader.loadClass`. | synthetic-stdlib / native — `java_lang` (`ClassLoader`) |
+| **1c** | `method not found: ch/qos/logback/classic/util/DefaultJoranConfigurator.getClass()Ljava/lang/Class;` — app, after 1b cleared. No banner yet. | Inherited `java/lang/Object.getClass()` virtual/interface dispatch fails to resolve for a class loaded through the runtime `loadClass` path — the hierarchy walk does not reach the `java/lang/Object` native (class-identity / method-dispatch). | **OBSERVED — current app pin. HANDOFF** to interpreter method-dispatch / class-identity lane (`execution.rs`). | execution.rs virtual/interface dispatch + class-key identity |
+| **1d** | `operand stack underflow` — ladder, after `getSystemResources` cleared. Deep in real commons-logging `LogFactory.getFactory`. | `java/lang/ref/WeakReference.get()Ljava/lang/Object;` returns no value (offset 188), so the following `checkcast` (191) underflows. Reference-object native unimplemented. | **OBSERVED — current ladder pin. HANDOFF** to `java.lang.ref` reference-object native lane. | native / stdlib — `java.lang.ref` (`Reference`/`WeakReference`) |
 | **2** | `--real-jdk` probe: getfield slot 10 out of bounds on a `java/net/URL` allocated with 1 slot where real `URL` bytecode expects 13 (`crates/duke-interpreter/src/execution.rs:1600`). | Synthetic-vs-real **object-layout coherence** boundary: `java/net/URL` is allocated synthetically (1 slot) but real `URL` bytecode indexes its full 13-field layout. | **INFERRED** (seen only under `--real-jdk`, past blocker #1) | native / stdlib object-layout — `java_net` (`URL`) |
 | **3** | Resource enumeration + `META-INF/spring.factories` and `META-INF/spring/…AutoConfiguration.imports` discovery returning empty/failing. | Spring's `SpringFactoriesLoader` / `ImportCandidates` walk **every** classpath entry via `ClassLoader.getResources`; requires working nested-jar resource enumeration (depends on #1). | **INFERRED** | java_util + classloader/registry (resource enumeration) |
 | **4** | Heavy `java.lang.reflect` use during auto-configuration: `Constructor.newInstance`, `Method.invoke`, annotation reads, `Class.forName` fan-out. | `SpringApplication.run` instantiates and wires beans almost entirely reflectively; annotation metadata is read via reflection/ASM. | **INFERRED** | reflect (`java_lang_reflect`) + `java_lang` (`Class`) |
@@ -138,8 +166,11 @@ regression witnesses, but the fix is generic.
 | Blocker | Owning lane | Status |
 | --- | --- | --- |
 | #0 provenance-poison on bootstrap singletons | classloader / registry (`registry.rs`) | **DONE (this branch)** |
-| #1 `ClassLoader.getSystemResources` missing | synthetic-stdlib `java_lang` — `ClassLoader` resource API (`stdlib.rs`) | **CLEARED for app by #1320; still NEXT for ladder** |
-| #1a `ClassLoader.getSystemClassLoader` missing | synthetic-stdlib `java_lang` — `ClassLoader` static/system-loader API (`stdlib.rs`) | **NEXT for app (current pin)** |
+| #1 `ClassLoader.getSystemResources` missing | synthetic-stdlib `java_lang` — `ClassLoader` resource API (`stdlib.rs`) | **CLEARED (app #1320, ladder this branch)** |
+| #1a `ClassLoader.getSystemClassLoader` missing | synthetic-stdlib `java_lang` — `ClassLoader` static/system-loader API (`stdlib.rs`) | **CLEARED (this branch)** |
+| #1b `ClassLoader.loadClass` missing | synthetic-stdlib `java_lang` — `ClassLoader` (`stdlib.rs`) | **CLEARED (this branch)** |
+| #1c `Object.getClass()` dispatch on loadClass-loaded class | execution.rs virtual/interface dispatch + class-identity | **HANDOFF — current app pin** |
+| #1d `WeakReference.get()` underflow in commons-logging | native — `java.lang.ref` reference-object | **HANDOFF — current ladder pin** |
 | #2 `java/net/URL` layout coherence | native / stdlib object-layout — `java_net` (`URL`) | inferred |
 | #3 `spring.factories` / `AutoConfiguration.imports` resource enumeration | java_util + classloader/registry | inferred |
 | #4 reflective bean instantiation / annotations | reflect (`java_lang_reflect`) + `java_lang` (`Class`) | inferred |
@@ -161,10 +192,12 @@ fixture:
   `spring_boot_app_surfaces_next_missing_capability_explicitly`,
   `spring_boot_ladder_surfaces_next_missing_capability_explicitly`. Each asserts
   the process still fails at **exactly** the current blocker. As of #1320 the
-  two fixtures diverge, so the pins assert per-fixture constants:
-  `APP_BLOCKER = "method not found: java/lang/ClassLoader.getSystemClassLoader()Ljava/lang/ClassLoader;"`
+  two fixtures diverge, so the pins assert per-fixture constants. As of this
+  branch (ClassLoader rungs cleared) they are:
+  `APP_BLOCKER = "method not found: ch/qos/logback/classic/util/DefaultJoranConfigurator.getClass()Ljava/lang/Class;"`
   and
-  `LADDER_BLOCKER = "method not found: java/lang/ClassLoader.getSystemResources(Ljava/lang/String;)Ljava/util/Enumeration;"`.
+  `LADDER_BLOCKER = "operand stack underflow"` (the `WeakReference.get()` underflow
+  in commons-logging `LogFactory.getFactory`).
   If boot advances (or regresses) past those strings, the pin **trips**, forcing a
   re-observe and an update to this doc.
 

--- a/docs/findings/2026-07-10-spring-boot-real-app.md
+++ b/docs/findings/2026-07-10-spring-boot-real-app.md
@@ -62,22 +62,44 @@ synthetic system `ClassLoader` instance, cached in a static field), and base
 to the parent/default loader first). These advanced **both** fixtures several
 rungs. The frontier has now moved **out of the ClassLoader-native lane** on both:
 
+**Update 2026-07-11 (interpreter-dispatch + `java.lang.ref` rungs cleared):** two
+more rungs fell. (a) The `Object.getClass()` interface-dispatch bug is fixed —
+the invokeinterface native fallback now walks the receiver's super chain (mirroring
+invokevirtual), so an inherited `java/lang/Object` native resolves for an
+interface-typed callsite. (b) A minimal non-collecting synthetic
+`java/lang/ref/WeakReference` (strong-ref-backed) now round-trips its referent,
+clearing the commons-logging `LogFactory.getFactory` underflow. New frontiers:
+
 ```
 # app  (duke-spring-boot-app-3.5.12.jar) — new frontier:
-duke: runtime error: method not found: ch/qos/logback/classic/util/DefaultJoranConfigurator.getClass()Ljava/lang/Class;
+duke: runtime error: class not found: java/time/ZoneId
 
 # ladder (duke-spring-boot-ladder-3.5.12.jar) — new frontier:
+duke: runtime error: class not found: org/apache/logging/slf4j/SLF4JProvider
+```
+
+The **app** frontier is now a missing synthetic `java/time/ZoneId` (stdlib
+date/time lane) reached deeper in logback configuration. The **ladder** frontier is
+a missing `org/apache/logging/slf4j/SLF4JProvider` — the log4j-to-slf4j binding
+provider class (logging-backend / service-provider lane). Both are handoffs to
+other lanes.
+
+For history, the prior (2026-07-11) frontiers were:
+
+```
+# app  — inherited Object.getClass() interface dispatch (FIXED this branch):
+duke: runtime error: method not found: ch/qos/logback/classic/util/DefaultJoranConfigurator.getClass()Ljava/lang/Class;
+
+# ladder — WeakReference.get() underflow (FIXED this branch):
 duke: runtime error: operand stack underflow
 ```
 
-The **app** frontier is inherited `java/lang/Object.getClass()` virtual dispatch
-failing to resolve for a class loaded through the runtime `loadClass` path — an
-interpreter method-dispatch / class-identity issue (`execution.rs`), not a missing
-ClassLoader native. The **ladder** frontier is an `operand stack underflow` deep
-in real commons-logging `LogFactory.getFactory` at
+The app rung was inherited `java/lang/Object.getClass()` dispatch failing to
+resolve through an interface-typed callsite. The ladder rung was an
+`operand stack underflow` deep in real commons-logging `LogFactory.getFactory` at
 `java/lang/ref/WeakReference.get()Ljava/lang/Object;` (offset 188 → `checkcast` at
-191 underflows because `get()` returns no value) — a `java.lang.ref`
-reference-object native that is unimplemented. Both are handoffs to other lanes.
+191 underflows because `get()` returned no value) — an unimplemented
+`java.lang.ref` reference-object native.
 
 Previous divergence (**Update 2026-07-10, after #1320**), retained for history —
 the two fixtures diverged after #1320 advanced the app past `getSystemResources`:
@@ -109,8 +131,10 @@ under the default synthetic-stdlib path).
 | **1** | `method not found: java/lang/ClassLoader.getSystemResources(Ljava/lang/String;)Ljava/util/Enumeration;` — boot reaches classpath scanning, no banner. | `getSystemResources` is a **missing synthetic method** on the synthetic `java/lang/ClassLoader` in `stdlib.rs`. The resource-enumeration API surface (`getResource(s)`, `getSystemResource(s)`, `getResourceAsStream`) is incomplete. | **CLEARED for app by #1320; CLEARED for ladder here** — `native_class_loader_get_system_resources` added (mirrors `getResources` with `None` loader). | synthetic-stdlib / native — `java_lang` (`ClassLoader` resource API) |
 | **1a** | `method not found: java/lang/ClassLoader.getSystemClassLoader()Ljava/lang/ClassLoader;` — app fixture's first blocker after #1320. | `getSystemClassLoader` missing on synthetic `java/lang/ClassLoader`. | **CLEARED here** — `native_class_loader_get_system_class_loader` returns one stable synthetic `ClassLoader` cached in a new static field. | synthetic-stdlib / native — `java_lang` (`ClassLoader` static/system-loader API) |
 | **1b** | `method not found: java/lang/ClassLoader.loadClass(Ljava/lang/String;)Ljava/lang/Class;` — app, after 1a cleared. | Base `ClassLoader.loadClass` missing on synthetic `java/lang/ClassLoader`. | **CLEARED here** — registered `native_url_class_loader_load_class` (parent-first delegation) for base `ClassLoader.loadClass`. | synthetic-stdlib / native — `java_lang` (`ClassLoader`) |
-| **1c** | `method not found: ch/qos/logback/classic/util/DefaultJoranConfigurator.getClass()Ljava/lang/Class;` — app, after 1b cleared. No banner yet. | Inherited `java/lang/Object.getClass()` virtual/interface dispatch fails to resolve for a class loaded through the runtime `loadClass` path — the hierarchy walk does not reach the `java/lang/Object` native (class-identity / method-dispatch). | **OBSERVED — current app pin. HANDOFF** to interpreter method-dispatch / class-identity lane (`execution.rs`). | execution.rs virtual/interface dispatch + class-key identity |
-| **1d** | `operand stack underflow` — ladder, after `getSystemResources` cleared. Deep in real commons-logging `LogFactory.getFactory`. | `java/lang/ref/WeakReference.get()Ljava/lang/Object;` returns no value (offset 188), so the following `checkcast` (191) underflows. Reference-object native unimplemented. | **OBSERVED — current ladder pin. HANDOFF** to `java.lang.ref` reference-object native lane. | native / stdlib — `java.lang.ref` (`Reference`/`WeakReference`) |
+| **1c** | `method not found: ch/qos/logback/classic/util/DefaultJoranConfigurator.getClass()Ljava/lang/Class;` — app, after 1b cleared. | Inherited `java/lang/Object.getClass()` invoked through an **interface-typed** callsite (`Configurator.getClass()`): the invokeinterface native fallback probed only the receiver class and the interface directly — never the receiver's super chain — so the `java/lang/Object.getClass` native was never found. | **CLEARED here** — `lookup_native_kind_in_super_chain` added; invokeinterface native fallback now walks the super chain like invokevirtual. | execution.rs interface dispatch (native fallback) |
+| **1d** | `operand stack underflow` — ladder, after `getSystemResources` cleared. Deep in real commons-logging `LogFactory.getFactory`. | `java/lang/ref/WeakReference.get()Ljava/lang/Object;` returned no value (offset 188), so the following `checkcast` (191) underflowed. Reference-object native unimplemented. | **CLEARED here** — minimal non-collecting synthetic `java/lang/ref/Reference`/`WeakReference` (strong-ref-backed `referent` slot; `<init>`/`get`/`clear`). | native / stdlib — `java.lang.ref` (`Reference`/`WeakReference`) |
+| **1e** | `class not found: java/time/ZoneId` — app, after 1c cleared. Deeper in logback configuration. | Synthetic `java.time` surface incomplete — `java/time/ZoneId` is not registered. | **OBSERVED — current app pin. HANDOFF** to stdlib date/time lane. | native / stdlib — `java_time` (`ZoneId`) |
+| **1f** | `class not found: org/apache/logging/slf4j/SLF4JProvider` — ladder, after 1d cleared. | The log4j-to-slf4j binding's `SLF4JProvider` is not resolvable — a logging-backend provider class discovered via the SLF4J `ServiceLoader`/provider mechanism is missing from the classpath resolution path. | **OBSERVED — current ladder pin. HANDOFF** to logging-backend / service-provider lane. | logging-backend / service-provider (classpath resolution) |
 | **2** | `--real-jdk` probe: getfield slot 10 out of bounds on a `java/net/URL` allocated with 1 slot where real `URL` bytecode expects 13 (`crates/duke-interpreter/src/execution.rs:1600`). | Synthetic-vs-real **object-layout coherence** boundary: `java/net/URL` is allocated synthetically (1 slot) but real `URL` bytecode indexes its full 13-field layout. | **INFERRED** (seen only under `--real-jdk`, past blocker #1) | native / stdlib object-layout — `java_net` (`URL`) |
 | **3** | Resource enumeration + `META-INF/spring.factories` and `META-INF/spring/…AutoConfiguration.imports` discovery returning empty/failing. | Spring's `SpringFactoriesLoader` / `ImportCandidates` walk **every** classpath entry via `ClassLoader.getResources`; requires working nested-jar resource enumeration (depends on #1). | **INFERRED** | java_util + classloader/registry (resource enumeration) |
 | **4** | Heavy `java.lang.reflect` use during auto-configuration: `Constructor.newInstance`, `Method.invoke`, annotation reads, `Class.forName` fan-out. | `SpringApplication.run` instantiates and wires beans almost entirely reflectively; annotation metadata is read via reflection/ASM. | **INFERRED** | reflect (`java_lang_reflect`) + `java_lang` (`Class`) |
@@ -169,8 +193,10 @@ regression witnesses, but the fix is generic.
 | #1 `ClassLoader.getSystemResources` missing | synthetic-stdlib `java_lang` — `ClassLoader` resource API (`stdlib.rs`) | **CLEARED (app #1320, ladder this branch)** |
 | #1a `ClassLoader.getSystemClassLoader` missing | synthetic-stdlib `java_lang` — `ClassLoader` static/system-loader API (`stdlib.rs`) | **CLEARED (this branch)** |
 | #1b `ClassLoader.loadClass` missing | synthetic-stdlib `java_lang` — `ClassLoader` (`stdlib.rs`) | **CLEARED (this branch)** |
-| #1c `Object.getClass()` dispatch on loadClass-loaded class | execution.rs virtual/interface dispatch + class-identity | **HANDOFF — current app pin** |
-| #1d `WeakReference.get()` underflow in commons-logging | native — `java.lang.ref` reference-object | **HANDOFF — current ladder pin** |
+| #1c `Object.getClass()` interface-callsite dispatch | execution.rs interface dispatch (native fallback super-chain walk) | **CLEARED (this branch)** |
+| #1d `WeakReference.get()` underflow in commons-logging | native — `java.lang.ref` reference-object | **CLEARED (this branch)** |
+| #1e `class not found: java/time/ZoneId` | native / stdlib — `java_time` (`ZoneId`) | **HANDOFF — current app pin** |
+| #1f `class not found: org/apache/logging/slf4j/SLF4JProvider` | logging-backend / service-provider (classpath resolution) | **HANDOFF — current ladder pin** |
 | #2 `java/net/URL` layout coherence | native / stdlib object-layout — `java_net` (`URL`) | inferred |
 | #3 `spring.factories` / `AutoConfiguration.imports` resource enumeration | java_util + classloader/registry | inferred |
 | #4 reflective bean instantiation / annotations | reflect (`java_lang_reflect`) + `java_lang` (`Class`) | inferred |
@@ -193,11 +219,10 @@ fixture:
   `spring_boot_ladder_surfaces_next_missing_capability_explicitly`. Each asserts
   the process still fails at **exactly** the current blocker. As of #1320 the
   two fixtures diverge, so the pins assert per-fixture constants. As of this
-  branch (ClassLoader rungs cleared) they are:
-  `APP_BLOCKER = "method not found: ch/qos/logback/classic/util/DefaultJoranConfigurator.getClass()Ljava/lang/Class;"`
+  branch (getClass interface-dispatch + `WeakReference` rungs cleared) they are:
+  `APP_BLOCKER = "class not found: java/time/ZoneId"`
   and
-  `LADDER_BLOCKER = "operand stack underflow"` (the `WeakReference.get()` underflow
-  in commons-logging `LogFactory.getFactory`).
+  `LADDER_BLOCKER = "class not found: org/apache/logging/slf4j/SLF4JProvider"`.
   If boot advances (or regresses) past those strings, the pin **trips**, forcing a
   re-observe and an update to this doc.
 

--- a/docs/findings/2026-07-10-spring-boot-real-app.md
+++ b/docs/findings/2026-07-10-spring-boot-real-app.md
@@ -62,27 +62,48 @@ synthetic system `ClassLoader` instance, cached in a static field), and base
 to the parent/default loader first). These advanced **both** fixtures several
 rungs. The frontier has now moved **out of the ClassLoader-native lane** on both:
 
-**Update 2026-07-11 (interpreter-dispatch + `java.lang.ref` rungs cleared):** two
-more rungs fell. (a) The `Object.getClass()` interface-dispatch bug is fixed —
-the invokeinterface native fallback now walks the receiver's super chain (mirroring
-invokevirtual), so an inherited `java/lang/Object` native resolves for an
-interface-typed callsite. (b) A minimal non-collecting synthetic
-`java/lang/ref/WeakReference` (strong-ref-backed) now round-trips its referent,
-clearing the commons-logging `LogFactory.getFactory` underflow. New frontiers:
+**Update 2026-07-11 (end of wave — 8 rungs cleared this wave):** this wave cleared
+**eight** distinct rungs across four lanes. In order:
+1. `ClassLoader.getSystemResources(String)` (ladder) — synthetic-stdlib `java_lang`.
+2. `ClassLoader.getSystemClassLoader()` (app) — synthetic-stdlib `java_lang`.
+3. `ClassLoader.loadClass(String)` (app) — synthetic-stdlib `java_lang`.
+4. Inherited `Object.getClass()` through an interface-typed callsite (app) —
+   execution.rs invokeinterface native fallback now walks the super chain.
+5. Minimal non-collecting synthetic `java/lang/ref/WeakReference` (ladder) —
+   clears the commons-logging `LogFactory.getFactory` underflow.
+6. 3-arg `Class.forName(name, false, cl)` availability probe made catchable via a
+   **lazy** identity-key computation (ladder) — native `java_lang`.
+7. Minimal-for-boot synthetic `java/time/ZoneId` (app) — native/stdlib `java_time`.
+8. Minimal-for-boot synthetic `java/util/Locale` (app) — native/stdlib `java_util`.
+
+After all eight, the two fixtures are parked at these **final end-of-wave
+frontiers**:
 
 ```
-# app  (duke-spring-boot-app-3.5.12.jar) — new frontier:
-duke: runtime error: class not found: java/time/ZoneId
+# app  (duke-spring-boot-app-3.5.12.jar) — final frontier:
+duke: runtime error: method not found: java/time/format/DateTimeFormatter.ofPattern(Ljava/lang/String;)Ljava/time/format/DateTimeFormatter;
 
-# ladder (duke-spring-boot-ladder-3.5.12.jar) — new frontier:
-duke: runtime error: class not found: org/apache/logging/slf4j/SLF4JProvider
+# ladder (duke-spring-boot-ladder-3.5.12.jar) — final frontier:
+duke: runtime error: class not found: org/apache/logging/log4j/MarkerManager
 ```
 
-The **app** frontier is now a missing synthetic `java/time/ZoneId` (stdlib
-date/time lane) reached deeper in logback configuration. The **ladder** frontier is
-a missing `org/apache/logging/slf4j/SLF4JProvider` — the log4j-to-slf4j binding
-provider class (logging-backend / service-provider lane). Both are handoffs to
-other lanes.
+The **app** frontier is now logback's `CachingDateFormatter` calling
+`DateTimeFormatter.ofPattern(String)` — the synthetic `DateTimeFormatter` carries
+only the ISO constant instances, not the `ofPattern` factory (java.time formatter
+lane; handoff to a future wave). The **ladder** frontier is a missing
+`org/apache/logging/log4j/MarkerManager` reached while initializing
+`Log4jApiLogFactory` (its `<clinit>` calls `MarkerManager.getMarker`): a real JVM
+raises a **catchable `NoClassDefFoundError`** (a `LinkageError`) that
+commons-logging catches and falls through on. Duke has no synthetic
+`NoClassDefFoundError`/`LinkageError` and surfaces class-resolution failures during
+bytecode execution as fatal errors — a distinct interpreter class-resolution /
+linkage-error rung **deferred to a future wave** (do not conflate with the missing
+class itself). Both are handoffs to other lanes.
+
+An intermediate frontier this wave (after the `WeakReference` rung, before the
+`Class.forName` probe fix) was `class not found: org/apache/logging/slf4j/SLF4JProvider`
+on the ladder; the lazy-key `Class.forName` fix turned that availability probe
+catchable and advanced the ladder to the `MarkerManager` frontier above.
 
 For history, the prior (2026-07-11) frontiers were:
 
@@ -133,8 +154,11 @@ under the default synthetic-stdlib path).
 | **1b** | `method not found: java/lang/ClassLoader.loadClass(Ljava/lang/String;)Ljava/lang/Class;` — app, after 1a cleared. | Base `ClassLoader.loadClass` missing on synthetic `java/lang/ClassLoader`. | **CLEARED here** — registered `native_url_class_loader_load_class` (parent-first delegation) for base `ClassLoader.loadClass`. | synthetic-stdlib / native — `java_lang` (`ClassLoader`) |
 | **1c** | `method not found: ch/qos/logback/classic/util/DefaultJoranConfigurator.getClass()Ljava/lang/Class;` — app, after 1b cleared. | Inherited `java/lang/Object.getClass()` invoked through an **interface-typed** callsite (`Configurator.getClass()`): the invokeinterface native fallback probed only the receiver class and the interface directly — never the receiver's super chain — so the `java/lang/Object.getClass` native was never found. | **CLEARED here** — `lookup_native_kind_in_super_chain` added; invokeinterface native fallback now walks the super chain like invokevirtual. | execution.rs interface dispatch (native fallback) |
 | **1d** | `operand stack underflow` — ladder, after `getSystemResources` cleared. Deep in real commons-logging `LogFactory.getFactory`. | `java/lang/ref/WeakReference.get()Ljava/lang/Object;` returned no value (offset 188), so the following `checkcast` (191) underflowed. Reference-object native unimplemented. | **CLEARED here** — minimal non-collecting synthetic `java/lang/ref/Reference`/`WeakReference` (strong-ref-backed `referent` slot; `<init>`/`get`/`clear`). | native / stdlib — `java.lang.ref` (`Reference`/`WeakReference`) |
-| **1e** | `class not found: java/time/ZoneId` — app, after 1c cleared. Deeper in logback configuration. | Synthetic `java.time` surface incomplete — `java/time/ZoneId` is not registered. | **OBSERVED — current app pin. HANDOFF** to stdlib date/time lane. | native / stdlib — `java_time` (`ZoneId`) |
-| **1f** | `class not found: org/apache/logging/slf4j/SLF4JProvider` — ladder, after 1d cleared. | The log4j-to-slf4j binding's `SLF4JProvider` is not resolvable — a logging-backend provider class discovered via the SLF4J `ServiceLoader`/provider mechanism is missing from the classpath resolution path. | **OBSERVED — current ladder pin. HANDOFF** to logging-backend / service-provider lane. | logging-backend / service-provider (classpath resolution) |
+| **1e** | `class not found: java/time/ZoneId` — app, after 1c cleared. Deeper in logback configuration. | Synthetic `java.time` surface incomplete — `java/time/ZoneId` is not registered. | **CLEARED here** — minimal synthetic `ZoneId` (UTC system default; `of`/`getId`/`toString`). | native / stdlib — `java_time` (`ZoneId`) |
+| **1e′** | `class not found: java/util/Locale` — app, after 1e cleared. logback timestamp formatting. | Synthetic `java.util` surface incomplete — `java/util/Locale` is not registered. | **CLEARED here** — minimal synthetic `Locale` (fixed en-US default; `getDefault`/`getLanguage`/`getCountry`/`toString`). | native / stdlib — `java_util` (`Locale`) |
+| **1e″** | `method not found: java/time/format/DateTimeFormatter.ofPattern(Ljava/lang/String;)Ljava/time/format/DateTimeFormatter;` — app, after 1e′ cleared. logback `CachingDateFormatter` builds a pattern formatter. | Synthetic `DateTimeFormatter` carries only the ISO constant instances, not the `ofPattern(String)` factory. | **OBSERVED — current app pin. HANDOFF** to java.time formatter lane (deferred to future wave). | native / stdlib — `java_time` (`DateTimeFormatter`) |
+| **1f** | `class not found: org/apache/logging/slf4j/SLF4JProvider` — ladder, after 1d cleared. | The log4j-to-slf4j binding's `SLF4JProvider` is not resolvable — a logging-backend provider class discovered via the SLF4J `ServiceLoader`/provider mechanism is missing from the classpath resolution path. | **CLEARED here** — lazy-key 3-arg `Class.forName` makes the availability probe catchable. | class-loader — `Class.forName` availability probe (`java_lang`) |
+| **1f′** | `class not found: org/apache/logging/log4j/MarkerManager` — ladder, after 1f cleared. `Log4jApiLogFactory.<clinit>` calls `MarkerManager.getMarker`. | A real JVM raises a catchable `NoClassDefFoundError` (`LinkageError`) here that commons-logging catches; duke has no synthetic `NoClassDefFoundError`/`LinkageError` and surfaces class-resolution failures during execution as fatal errors. | **OBSERVED — current ladder pin. HANDOFF** to interpreter class-resolution / linkage-error lane (deferred to future wave). | interpreter — class-resolution / `LinkageError` |
 | **2** | `--real-jdk` probe: getfield slot 10 out of bounds on a `java/net/URL` allocated with 1 slot where real `URL` bytecode expects 13 (`crates/duke-interpreter/src/execution.rs:1600`). | Synthetic-vs-real **object-layout coherence** boundary: `java/net/URL` is allocated synthetically (1 slot) but real `URL` bytecode indexes its full 13-field layout. | **INFERRED** (seen only under `--real-jdk`, past blocker #1) | native / stdlib object-layout — `java_net` (`URL`) |
 | **3** | Resource enumeration + `META-INF/spring.factories` and `META-INF/spring/…AutoConfiguration.imports` discovery returning empty/failing. | Spring's `SpringFactoriesLoader` / `ImportCandidates` walk **every** classpath entry via `ClassLoader.getResources`; requires working nested-jar resource enumeration (depends on #1). | **INFERRED** | java_util + classloader/registry (resource enumeration) |
 | **4** | Heavy `java.lang.reflect` use during auto-configuration: `Constructor.newInstance`, `Method.invoke`, annotation reads, `Class.forName` fan-out. | `SpringApplication.run` instantiates and wires beans almost entirely reflectively; annotation metadata is read via reflection/ASM. | **INFERRED** | reflect (`java_lang_reflect`) + `java_lang` (`Class`) |
@@ -212,7 +236,20 @@ interpreter class-resolution / linkage-error rung (handoff).
 epoch/UTC based, so a UTC default keeps timestamps self-consistent **without**
 modelling `ZoneRules`/tzdb), plus `of(String)`, `getId()`, `toString()`. Clearing
 `ZoneId` did **not** cascade into a chronology/tzdb chain — the app frontier moved
-to `class not found: java/util/Locale` (a shallow, separate java.util rung, handoff).
+to `class not found: java/util/Locale` (a shallow, separate java.util rung).
+
+**App — minimal `java.util.Locale` for boot (CLEARED).**
+`crates/duke-interpreter/src/native/java_util.rs` + registration in
+`crates/duke-interpreter/src/stdlib.rs`. logback's `CachingDateFormatter` calls
+`Locale.getDefault()` during Spring Boot startup. Registered a thin synthetic
+`Locale`: a holder carrying a language tag + country code, with `getDefault()`
+reporting a **fixed en-US** locale (a fixed default keeps boot deterministic
+**without** a CLDR/`ResourceBundle` build-out; the formatters duke models are
+locale-insensitive, so the choice is inert beyond boot), plus
+`getDefault(Locale$Category)`, `getLanguage()`, `getCountry()`, `toString()`.
+Clearing `Locale` did **not** cascade into a locale/CLDR chain — the app frontier
+moved to `method not found: java/time/format/DateTimeFormatter.ofPattern(String)`
+(a java.time formatter rung, handoff to a future wave).
 
 ## Lane ownership summary
 
@@ -225,9 +262,10 @@ to `class not found: java/util/Locale` (a shallow, separate java.util rung, hand
 | #1c `Object.getClass()` interface-callsite dispatch | execution.rs interface dispatch (native fallback super-chain walk) | **CLEARED (this branch)** |
 | #1d `WeakReference.get()` underflow in commons-logging | native — `java.lang.ref` reference-object | **CLEARED (this branch)** |
 | #1e `class not found: java/time/ZoneId` | native / stdlib — `java_time` (`ZoneId`) | **CLEARED (this branch)** |
-| #1e′ `class not found: java/util/Locale` | native / stdlib — `java_util` (`Locale`) | **HANDOFF — current app pin** |
+| #1e′ `class not found: java/util/Locale` | native / stdlib — `java_util` (`Locale`) | **CLEARED (this branch)** |
+| #1e″ `method not found: DateTimeFormatter.ofPattern(String)` | native / stdlib — `java_time` (`DateTimeFormatter` factory) | **HANDOFF — current app pin (deferred to future wave)** |
 | #1f `class not found: org/apache/logging/slf4j/SLF4JProvider` | class-loader — `Class.forName` availability probe (`java_lang`) | **CLEARED (this branch)** |
-| #1f′ `class not found: org/apache/logging/log4j/MarkerManager` | interpreter — class-resolution / `NoClassDefFoundError` linkage during `<clinit>` (`execution.rs` + synthetic `LinkageError` in `stdlib.rs`) | **HANDOFF — current ladder pin** |
+| #1f′ `class not found: org/apache/logging/log4j/MarkerManager` | interpreter — class-resolution / `NoClassDefFoundError` linkage during `<clinit>` (`execution.rs` + synthetic `LinkageError` in `stdlib.rs`) | **HANDOFF — current ladder pin (deferred to future wave)** |
 | #2 `java/net/URL` layout coherence | native / stdlib object-layout — `java_net` (`URL`) | inferred |
 | #3 `spring.factories` / `AutoConfiguration.imports` resource enumeration | java_util + classloader/registry | inferred |
 | #4 reflective bean instantiation / annotations | reflect (`java_lang_reflect`) + `java_lang` (`Class`) | inferred |
@@ -249,11 +287,11 @@ fixture:
   `spring_boot_app_surfaces_next_missing_capability_explicitly`,
   `spring_boot_ladder_surfaces_next_missing_capability_explicitly`. Each asserts
   the process still fails at **exactly** the current blocker. As of #1320 the
-  two fixtures diverge, so the pins assert per-fixture constants. As of this
-  branch (getClass interface-dispatch + `WeakReference` rungs cleared) they are:
-  `APP_BLOCKER = "class not found: java/time/ZoneId"`
+  two fixtures diverge, so the pins assert per-fixture constants. As of the end of
+  this wave (all eight rungs above cleared) they are:
+  `APP_BLOCKER = "method not found: java/time/format/DateTimeFormatter.ofPattern(Ljava/lang/String;)Ljava/time/format/DateTimeFormatter;"`
   and
-  `LADDER_BLOCKER = "class not found: org/apache/logging/slf4j/SLF4JProvider"`.
+  `LADDER_BLOCKER = "class not found: org/apache/logging/log4j/MarkerManager"`.
   If boot advances (or regresses) past those strings, the pin **trips**, forcing a
   re-observe and an update to this doc.
 
@@ -277,7 +315,8 @@ cargo run -p duke -- -jar tests/fixtures/oss-jars/spring-boot/duke-spring-boot-l
 verification below was run locally.**
 
 - `cargo build --workspace` — clean.
-- `cargo test --workspace --no-fail-fast` — **3039 passed / 0 failed / 6 ignored.**
+- `cargo test --workspace --no-fail-fast` — **3048 passed / 0 failed / 4 ignored**
+  (end of this wave; +1 new `test_locale_get_default_is_en_us` unit test).
 - `cargo fmt --check` — clean.
 - `cargo clippy --workspace` — zero warnings.
 

--- a/duke/tests/spring_boot_real_app.rs
+++ b/duke/tests/spring_boot_real_app.rs
@@ -51,16 +51,23 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 //   * APP now lands on `class not found: java/time/ZoneId` deep in logback's
 //     configuration path — a missing synthetic `java.time` class (stdlib
 //     date/time lane, not the interpreter method-dispatch lane).
-//   * LADDER cleared commons-logging `LogFactory.getFactory` once the minimal
-//     synthetic `java/lang/ref/WeakReference` landed (java.lang.ref
-//     reference-object native lane); it now lands on
-//     `class not found: org/apache/logging/slf4j/SLF4JProvider` — a missing
-//     log4j-to-slf4j binding provider class (logging-backend / service-provider
-//     lane, not the java.lang.ref lane).
+//   * LADDER cleared the commons-logging `LogFactory.newStandardFactory`
+//     `Class.forName("...SLF4JProvider", false, cl)` availability probe: the
+//     3-arg `Class.forName` native was eagerly computing the class key (which
+//     itself raises `ClassNotFound`) before the not-found result could be turned
+//     into a catchable `ClassNotFoundException`, so the probe crashed instead of
+//     returning "class absent". It now lands on
+//     `class not found: org/apache/logging/log4j/MarkerManager` — reached while
+//     initializing `Log4jApiLogFactory` (whose `<clinit>` calls
+//     `MarkerManager.getMarker`); a real JVM would raise a catchable
+//     `NoClassDefFoundError` (a `LinkageError`) that commons-logging catches and
+//     falls through on. Duke has no synthetic `NoClassDefFoundError`/`LinkageError`
+//     and surfaces class-resolution failures during bytecode execution as fatal
+//     errors (interpreter class-resolution / linkage-error lane).
 // If either boot advances past its pin, re-observe and update.
 // See docs/findings/2026-07-10-spring-boot-real-app.md.
 const APP_BLOCKER: &str = "class not found: java/time/ZoneId";
-const LADDER_BLOCKER: &str = "class not found: org/apache/logging/slf4j/SLF4JProvider";
+const LADDER_BLOCKER: &str = "class not found: org/apache/logging/log4j/MarkerManager";
 
 fn run_fixture(jar: &str) -> Output {
     let jar_path = spring_boot_fixture(jar);
@@ -137,10 +144,11 @@ fn spring_boot_app_surfaces_next_missing_capability_explicitly() {
 /// End-to-end CANARY for the commons-logging ladder fixture. Ignored until boot
 /// completes all rungs. Un-ignore when the happy path clears.
 #[test]
-#[ignore = "Blocked on missing class org/apache/logging/slf4j/SLF4JProvider (log4j-to-slf4j \
-            binding / service-provider lane; the java/lang/ref/WeakReference rung in \
-            commons-logging LogFactory.getFactory is now cleared); keep ignored until \
-            the ladder fixture completes. See docs/findings/2026-07-10-spring-boot-real-app.md"]
+#[ignore = "Blocked on missing class org/apache/logging/log4j/MarkerManager during \
+            Log4jApiLogFactory init (interpreter class-resolution / linkage-error lane; a real \
+            JVM raises a catchable NoClassDefFoundError here — the SLF4JProvider Class.forName \
+            probe rung is now cleared); keep ignored until the ladder fixture completes. \
+            See docs/findings/2026-07-10-spring-boot-real-app.md"]
 fn spring_boot_ladder_boots_end_to_end() {
     let output = run_fixture(LADDER_JAR);
     let combined = combined_output(&output);

--- a/duke/tests/spring_boot_real_app.rs
+++ b/duke/tests/spring_boot_real_app.rs
@@ -42,13 +42,22 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 // `java/lang/ClassLoader` method that lives in crates/duke-interpreter/src/stdlib.rs
 // (other lane), so both are pinned here rather than fixed.
 //
-// The two fixtures now diverge: #1320 pushed the APP past the previously-shared
-// `getSystemResources` rung onto `getSystemClassLoader`, while the LADDER still
-// lands on `getSystemResources`. If either boot advances past its pin, re-observe
-// and update. See docs/findings/2026-07-10-spring-boot-real-app.md.
+// The synthetic `ClassLoader` natives `getSystemResources`, `getSystemClassLoader`
+// and base `loadClass` are now implemented (ClassLoader lane), advancing BOTH
+// fixtures past the previous ClassLoader pins. The frontier has moved out of the
+// ClassLoader lane on both:
+//   * APP now lands on `getClass()` virtual dispatch failing to resolve the
+//     inherited `java/lang/Object` native for a class loaded through the runtime
+//     `loadClass` path (interpreter method-dispatch / class-identity lane, not the
+//     ClassLoader-native lane).
+//   * LADDER now runs deep into real commons-logging `LogFactory.getFactory` and
+//     hits an `operand stack underflow` when `java/lang/ref/WeakReference.get()`
+//     returns no value (java.lang.ref reference-object native lane).
+// If either boot advances past its pin, re-observe and update.
+// See docs/findings/2026-07-10-spring-boot-real-app.md.
 const APP_BLOCKER: &str =
-    "method not found: java/lang/ClassLoader.getSystemClassLoader()Ljava/lang/ClassLoader;";
-const LADDER_BLOCKER: &str = "method not found: java/lang/ClassLoader.getSystemResources(Ljava/lang/String;)Ljava/util/Enumeration;";
+    "method not found: ch/qos/logback/classic/util/DefaultJoranConfigurator.getClass()Ljava/lang/Class;";
+const LADDER_BLOCKER: &str = "operand stack underflow";
 
 fn run_fixture(jar: &str) -> Output {
     let jar_path = spring_boot_fixture(jar);
@@ -77,9 +86,10 @@ fn combined_output(output: &Output) -> String {
 /// End-to-end CANARY for the real Spring Boot app fixture. Ignored until boot
 /// reaches the started-application line. Un-ignore when the happy path clears.
 #[test]
-#[ignore = "Blocked on missing synthetic java/lang/ClassLoader.getSystemClassLoader \
-            (stdlib lane; #1320 cleared the earlier getSystemResources rung for the \
-            app); keep ignored until the Spring Boot app boot completes. \
+#[ignore = "Blocked on inherited java/lang/Object.getClass() virtual dispatch failing \
+            for a class loaded through the runtime loadClass path (interpreter \
+            method-dispatch lane; the ClassLoader getSystemClassLoader/loadClass rungs \
+            are now cleared); keep ignored until the Spring Boot app boot completes. \
             See docs/findings/2026-07-10-spring-boot-real-app.md"]
 fn spring_boot_app_boots_end_to_end() {
     let output = run_fixture(APP_JAR);
@@ -125,9 +135,11 @@ fn spring_boot_app_surfaces_next_missing_capability_explicitly() {
 /// End-to-end CANARY for the commons-logging ladder fixture. Ignored until boot
 /// completes all rungs. Un-ignore when the happy path clears.
 #[test]
-#[ignore = "Blocked on missing synthetic java/lang/ClassLoader.getSystemResources \
-            (stdlib lane); keep ignored until the ladder fixture completes. \
-            See docs/findings/2026-07-10-spring-boot-real-app.md"]
+#[ignore = "Blocked on operand stack underflow when java/lang/ref/WeakReference.get() \
+            returns no value deep in commons-logging LogFactory.getFactory \
+            (java.lang.ref reference-object native lane; the ClassLoader \
+            getSystemResources rung is now cleared); keep ignored until the ladder \
+            fixture completes. See docs/findings/2026-07-10-spring-boot-real-app.md"]
 fn spring_boot_ladder_boots_end_to_end() {
     let output = run_fixture(LADDER_JAR);
     let combined = combined_output(&output);

--- a/duke/tests/spring_boot_real_app.rs
+++ b/duke/tests/spring_boot_real_app.rs
@@ -48,9 +48,11 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 // lane then cleared the inherited `java/lang/Object.getClass()` virtual dispatch
 // for interface-typed callsites, advancing the app fixture again. Current
 // frontiers:
-//   * APP now lands on `class not found: java/time/ZoneId` deep in logback's
-//     configuration path — a missing synthetic `java.time` class (stdlib
-//     date/time lane, not the interpreter method-dispatch lane).
+//   * APP cleared the logback timestamp `java/time/ZoneId` rung: a minimal
+//     synthetic `ZoneId` (UTC system default; `of`/`getId`/`toString`) landed
+//     without pulling in `ZoneRules`/tzdb. It now lands on
+//     `class not found: java/util/Locale` — a missing synthetic `java.util`
+//     class (java.util lane, not the java.time date/time lane).
 //   * LADDER cleared the commons-logging `LogFactory.newStandardFactory`
 //     `Class.forName("...SLF4JProvider", false, cl)` availability probe: the
 //     3-arg `Class.forName` native was eagerly computing the class key (which
@@ -66,7 +68,7 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 //     errors (interpreter class-resolution / linkage-error lane).
 // If either boot advances past its pin, re-observe and update.
 // See docs/findings/2026-07-10-spring-boot-real-app.md.
-const APP_BLOCKER: &str = "class not found: java/time/ZoneId";
+const APP_BLOCKER: &str = "class not found: java/util/Locale";
 const LADDER_BLOCKER: &str = "class not found: org/apache/logging/log4j/MarkerManager";
 
 fn run_fixture(jar: &str) -> Output {
@@ -96,9 +98,9 @@ fn combined_output(output: &Output) -> String {
 /// End-to-end CANARY for the real Spring Boot app fixture. Ignored until boot
 /// reaches the started-application line. Un-ignore when the happy path clears.
 #[test]
-#[ignore = "Blocked on missing synthetic java/time/ZoneId (stdlib date/time lane; the \
-            inherited java/lang/Object.getClass() interface-dispatch rung is now \
-            cleared); keep ignored until the Spring Boot app boot completes. \
+#[ignore = "Blocked on missing synthetic java/util/Locale (java.util lane; the logback \
+            java/time/ZoneId date/time rung is now cleared); keep ignored until the \
+            Spring Boot app boot completes. \
             See docs/findings/2026-07-10-spring-boot-real-app.md"]
 fn spring_boot_app_boots_end_to_end() {
     let output = run_fixture(APP_JAR);

--- a/duke/tests/spring_boot_real_app.rs
+++ b/duke/tests/spring_boot_real_app.rs
@@ -51,13 +51,16 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 //   * APP now lands on `class not found: java/time/ZoneId` deep in logback's
 //     configuration path — a missing synthetic `java.time` class (stdlib
 //     date/time lane, not the interpreter method-dispatch lane).
-//   * LADDER now runs deep into real commons-logging `LogFactory.getFactory` and
-//     hits an `operand stack underflow` when `java/lang/ref/WeakReference.get()`
-//     returns no value (java.lang.ref reference-object native lane).
+//   * LADDER cleared commons-logging `LogFactory.getFactory` once the minimal
+//     synthetic `java/lang/ref/WeakReference` landed (java.lang.ref
+//     reference-object native lane); it now lands on
+//     `class not found: org/apache/logging/slf4j/SLF4JProvider` — a missing
+//     log4j-to-slf4j binding provider class (logging-backend / service-provider
+//     lane, not the java.lang.ref lane).
 // If either boot advances past its pin, re-observe and update.
 // See docs/findings/2026-07-10-spring-boot-real-app.md.
 const APP_BLOCKER: &str = "class not found: java/time/ZoneId";
-const LADDER_BLOCKER: &str = "operand stack underflow";
+const LADDER_BLOCKER: &str = "class not found: org/apache/logging/slf4j/SLF4JProvider";
 
 fn run_fixture(jar: &str) -> Output {
     let jar_path = spring_boot_fixture(jar);
@@ -134,11 +137,10 @@ fn spring_boot_app_surfaces_next_missing_capability_explicitly() {
 /// End-to-end CANARY for the commons-logging ladder fixture. Ignored until boot
 /// completes all rungs. Un-ignore when the happy path clears.
 #[test]
-#[ignore = "Blocked on operand stack underflow when java/lang/ref/WeakReference.get() \
-            returns no value deep in commons-logging LogFactory.getFactory \
-            (java.lang.ref reference-object native lane; the ClassLoader \
-            getSystemResources rung is now cleared); keep ignored until the ladder \
-            fixture completes. See docs/findings/2026-07-10-spring-boot-real-app.md"]
+#[ignore = "Blocked on missing class org/apache/logging/slf4j/SLF4JProvider (log4j-to-slf4j \
+            binding / service-provider lane; the java/lang/ref/WeakReference rung in \
+            commons-logging LogFactory.getFactory is now cleared); keep ignored until \
+            the ladder fixture completes. See docs/findings/2026-07-10-spring-boot-real-app.md"]
 fn spring_boot_ladder_boots_end_to_end() {
     let output = run_fixture(LADDER_JAR);
     let combined = combined_output(&output);

--- a/duke/tests/spring_boot_real_app.rs
+++ b/duke/tests/spring_boot_real_app.rs
@@ -44,18 +44,19 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 //
 // The synthetic `ClassLoader` natives `getSystemResources`, `getSystemClassLoader`
 // and base `loadClass` are now implemented (ClassLoader lane), advancing BOTH
-// fixtures past the previous ClassLoader pins. The frontier has moved out of the
-// ClassLoader lane on both:
-//   * APP now lands on `getClass()` virtual dispatch failing to resolve the
-//     inherited `java/lang/Object` native for a class loaded through the runtime
-//     `loadClass` path (interpreter method-dispatch / class-identity lane, not the
-//     ClassLoader-native lane).
+// fixtures past the previous ClassLoader pins. The interpreter method-dispatch
+// lane then cleared the inherited `java/lang/Object.getClass()` virtual dispatch
+// for interface-typed callsites, advancing the app fixture again. Current
+// frontiers:
+//   * APP now lands on `class not found: java/time/ZoneId` deep in logback's
+//     configuration path — a missing synthetic `java.time` class (stdlib
+//     date/time lane, not the interpreter method-dispatch lane).
 //   * LADDER now runs deep into real commons-logging `LogFactory.getFactory` and
 //     hits an `operand stack underflow` when `java/lang/ref/WeakReference.get()`
 //     returns no value (java.lang.ref reference-object native lane).
 // If either boot advances past its pin, re-observe and update.
 // See docs/findings/2026-07-10-spring-boot-real-app.md.
-const APP_BLOCKER: &str = "method not found: ch/qos/logback/classic/util/DefaultJoranConfigurator.getClass()Ljava/lang/Class;";
+const APP_BLOCKER: &str = "class not found: java/time/ZoneId";
 const LADDER_BLOCKER: &str = "operand stack underflow";
 
 fn run_fixture(jar: &str) -> Output {
@@ -85,10 +86,9 @@ fn combined_output(output: &Output) -> String {
 /// End-to-end CANARY for the real Spring Boot app fixture. Ignored until boot
 /// reaches the started-application line. Un-ignore when the happy path clears.
 #[test]
-#[ignore = "Blocked on inherited java/lang/Object.getClass() virtual dispatch failing \
-            for a class loaded through the runtime loadClass path (interpreter \
-            method-dispatch lane; the ClassLoader getSystemClassLoader/loadClass rungs \
-            are now cleared); keep ignored until the Spring Boot app boot completes. \
+#[ignore = "Blocked on missing synthetic java/time/ZoneId (stdlib date/time lane; the \
+            inherited java/lang/Object.getClass() interface-dispatch rung is now \
+            cleared); keep ignored until the Spring Boot app boot completes. \
             See docs/findings/2026-07-10-spring-boot-real-app.md"]
 fn spring_boot_app_boots_end_to_end() {
     let output = run_fixture(APP_JAR);

--- a/duke/tests/spring_boot_real_app.rs
+++ b/duke/tests/spring_boot_real_app.rs
@@ -55,8 +55,7 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 //     returns no value (java.lang.ref reference-object native lane).
 // If either boot advances past its pin, re-observe and update.
 // See docs/findings/2026-07-10-spring-boot-real-app.md.
-const APP_BLOCKER: &str =
-    "method not found: ch/qos/logback/classic/util/DefaultJoranConfigurator.getClass()Ljava/lang/Class;";
+const APP_BLOCKER: &str = "method not found: ch/qos/logback/classic/util/DefaultJoranConfigurator.getClass()Ljava/lang/Class;";
 const LADDER_BLOCKER: &str = "operand stack underflow";
 
 fn run_fixture(jar: &str) -> Output {

--- a/duke/tests/spring_boot_real_app.rs
+++ b/duke/tests/spring_boot_real_app.rs
@@ -48,11 +48,14 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 // lane then cleared the inherited `java/lang/Object.getClass()` virtual dispatch
 // for interface-typed callsites, advancing the app fixture again. Current
 // frontiers:
-//   * APP cleared the logback timestamp `java/time/ZoneId` rung: a minimal
-//     synthetic `ZoneId` (UTC system default; `of`/`getId`/`toString`) landed
-//     without pulling in `ZoneRules`/tzdb. It now lands on
-//     `class not found: java/util/Locale` — a missing synthetic `java.util`
-//     class (java.util lane, not the java.time date/time lane).
+//   * APP cleared the logback timestamp `java/util/Locale` rung: a minimal
+//     synthetic `Locale` (fixed en-US default; `getDefault`/`getLanguage`/
+//     `getCountry`/`toString`) landed without pulling in CLDR/`ResourceBundle`.
+//     It now lands on
+//     `method not found: java/time/format/DateTimeFormatter.ofPattern(String)` —
+//     logback's `CachingDateFormatter` builds a pattern-based formatter, and the
+//     synthetic `DateTimeFormatter` only carries the ISO constant instances, not
+//     the `ofPattern` factory (java.time formatter lane).
 //   * LADDER cleared the commons-logging `LogFactory.newStandardFactory`
 //     `Class.forName("...SLF4JProvider", false, cl)` availability probe: the
 //     3-arg `Class.forName` native was eagerly computing the class key (which
@@ -68,7 +71,7 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 //     errors (interpreter class-resolution / linkage-error lane).
 // If either boot advances past its pin, re-observe and update.
 // See docs/findings/2026-07-10-spring-boot-real-app.md.
-const APP_BLOCKER: &str = "class not found: java/util/Locale";
+const APP_BLOCKER: &str = "method not found: java/time/format/DateTimeFormatter.ofPattern(Ljava/lang/String;)Ljava/time/format/DateTimeFormatter;";
 const LADDER_BLOCKER: &str = "class not found: org/apache/logging/log4j/MarkerManager";
 
 fn run_fixture(jar: &str) -> Output {
@@ -98,9 +101,9 @@ fn combined_output(output: &Output) -> String {
 /// End-to-end CANARY for the real Spring Boot app fixture. Ignored until boot
 /// reaches the started-application line. Un-ignore when the happy path clears.
 #[test]
-#[ignore = "Blocked on missing synthetic java/util/Locale (java.util lane; the logback \
-            java/time/ZoneId date/time rung is now cleared); keep ignored until the \
-            Spring Boot app boot completes. \
+#[ignore = "Blocked on missing java/time/format/DateTimeFormatter.ofPattern(String) \
+            (java.time formatter lane; the logback java/util/Locale rung is now cleared); \
+            keep ignored until the Spring Boot app boot completes. \
             See docs/findings/2026-07-10-spring-boot-real-app.md"]
 fn spring_boot_app_boots_end_to_end() {
     let output = run_fixture(APP_JAR);


### PR DESCRIPTION
## Before / After

Booting the real Spring Boot 3.5.12 app fixture and the commons-logging "ladder" fixture both used to stop the moment Spring's `LaunchedClassLoader` began classpath scanning. This PR clears **eight** boot-ladder rungs so both fixtures advance well past classpath scanning into application/library initialization.

- **App fixture** — before: `method not found: java/lang/ClassLoader.getSystemClassLoader()`. After: reaches `method not found: java/time/format/DateTimeFormatter.ofPattern(...)` (deep in logback date-formatter init).
- **Ladder fixture** — before: `method not found: java/lang/ClassLoader.getSystemResources(...)`. After: reaches `class not found: org/apache/logging/log4j/MarkerManager` (a linkage-error-semantics gap, deferred — see below).

## Rungs cleared (8)

1. `ClassLoader.getSystemResources(Ljava/lang/String;)Ljava/util/Enumeration;` (ladder)
2. `ClassLoader.getSystemClassLoader()Ljava/lang/ClassLoader;` (app)
3. `ClassLoader.loadClass(Ljava/lang/String;)Ljava/lang/Class;` (app)
4. Inherited `Object.getClass()` not resolving on **interface-typed** callsites (app)
5. `java/lang/ref/WeakReference` unimplemented → operand-stack underflow (ladder)
6. 3-arg `Class.forName(name, false, cl)` on an absent class raised a **fatal** error instead of a catchable `ClassNotFoundException` (ladder)
7. `java/time/ZoneId` unregistered (app)
8. `java/util/Locale` unregistered (app)

## How

- **Synthetic `ClassLoader` natives** (`native/java_lang.rs`, registered in `stdlib.rs`): `getSystemResources` mirrors `getResources` with a `None` (system) loader; `getSystemClassLoader` lazily allocates one bare `ClassLoader` and caches its ref in a static field (`$dukeSystemClassLoader`) for stable identity; base `loadClass` reuses `native_url_class_loader_load_class` (parent-first delegation).
- **Interface-dispatch native fix** (`execution.rs`, `native/common.rs`): the `invokeinterface` native fallback probed only the receiver and interface classes directly, so a native inherited from `java/lang/Object` (e.g. `getClass()`) was never found for an interface-typed callsite. Added `lookup_native_kind_in_super_chain` and walk the receiver's super chain, mirroring `invokevirtual`. The opcode dispatch hot loop is untouched.
- **Minimal synthetic `java/lang/ref/Reference` + `WeakReference`** (`stdlib.rs`, `native/java_lang.rs`): single-arg constructor, `get()`, `clear()`. Non-collecting, strong-ref-backed (no GC weak semantics), documented in code.
- **`Class.forName` lazy key** (`native/java_lang.rs`): the 3-arg native computed the class-identity key eagerly (with `?`), so a missing class's key lookup raised a fatal error before the not-found result could be converted to a catchable `ClassNotFoundException`. The key is now computed only on a successful load, so an absent class always surfaces as a catchable `ClassNotFoundException` — exactly how commons-logging probes for logging backends.
- **Minimal `java/time/ZoneId`** (`native/java_time.rs`, `stdlib.rs`): `systemDefault()` returns UTC (documented — duke's `Instant`/`LocalDate*` clocks are epoch/UTC based, so a UTC default keeps timestamps self-consistent without modelling `ZoneRules`/tzdb), plus `of(String)`, `getId()`, `toString()`.
- **Minimal `java/util/Locale`** (`native/java_util.rs`, `stdlib.rs`): a thin holder (language/country) with `getDefault()` / `getDefault(Category)` returning a fixed **en-US** locale (documented — a fixed default keeps boot deterministic without a CLDR/ResourceBundle build-out; the formatters duke models are locale-insensitive), plus `getLanguage()`, `getCountry()`, `toString()`.
- Advanced the `APP_BLOCKER` / `LADDER_BLOCKER` frontier pins in `duke/tests/spring_boot_real_app.rs`; documented all 8 cleared rungs + remaining frontiers in `docs/findings/2026-07-10-spring-boot-real-app.md`.

## Remaining frontiers (out of scope — future waves)

- **App** → `method not found: java/time/format/DateTimeFormatter.ofPattern(...)` (java.time formatter lane).
- **Ladder** → `class not found: org/apache/logging/log4j/MarkerManager`. A **linkage-error-semantics** gap, not a missing class: a real JVM raises a catchable `NoClassDefFoundError` (a `LinkageError`) during `Log4jApiLogFactory.<clinit>`, which commons-logging catches and falls through past. Duke has no synthetic `LinkageError`/`NoClassDefFoundError` and surfaces execution-time class-resolution failures as fatal errors that bypass Java exception tables. Clearing it is a broad interpreter-core change (register `LinkageError`/`NoClassDefFoundError`; convert execution-time `ClassNotFound` into a catchable `NoClassDefFoundError` across opcode handlers) — deferred to a dedicated follow-up wave.

The two end-to-end boot canaries stay `#[ignore]`d since the frontiers moved to out-of-scope rungs; the non-ignored PIN tests assert the current frontiers.

## Verification (local; CI runners are unavailable in this environment)

- `cargo build`: clean
- `cargo test --workspace --no-fail-fast`: **3048 passed / 0 failed / 4 ignored** (baseline 3042 + 6 new regression tests)
- `cargo fmt --all --check`: clean
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -W clippy::pedantic -W clippy::nursery` on rustc 1.97: zero warnings