### PR TITLE
Invoke foundation: honest java.lang.invoke/SharedSecrets natives so real FileOutputStream.<clinit> completes

### DIFF
--- a/crates/duke-interpreter/src/native/jdk_internal.rs
+++ b/crates/duke-interpreter/src/native/jdk_internal.rs
@@ -264,3 +264,89 @@ pub(crate) fn native_reflection_get_class_access_flags(
         .map_or(SYNTHETIC_CLASS_ACCESS_FLAGS, |info| info.access_flags);
     Ok(Some(Slot::Int(i32::from(access_flags))))
 }
+
+// java.lang.invoke / SharedSecrets foundation
+// ---------------------------------------------------------------------------
+// Natives walking the real `FileOutputStream.<clinit>` chain under
+// `DUKE_REAL_JDK=1`: `SharedSecrets.getJavaIOFileDescriptorAccess()` finds
+// `FD_ACCESS == null`, which drives `MethodHandles.Lookup.ensureInitialized`
+// and the `java.lang.invoke` bootstrap. These honor the real contracts (force
+// real `<clinit>`, report real init state) rather than papering over the graph.
+
+/// Native: `jdk/internal/misc/Unsafe.ensureClassInitialized(Ljava/lang/Class;)V`.
+///
+/// Real `MethodHandles.Lookup.ensureInitialized(Class)` — reached from
+/// `FileOutputStream.<clinit>` via `SharedSecrets.getJavaIOFileDescriptorAccess`
+/// → the `java.lang.invoke` bootstrap — calls `UNSAFE.ensureClassInitialized`
+/// (JDK 21: `MethodHandles.Lookup.ensureInitialized` routes through
+/// `Unsafe.ensureClassInitialized`) to force the target's `<clinit>` to complete
+/// before a handle is bound against it. Duke honors that contract by driving the
+/// argument class through [`CallbackOps::ensure_class_initialized`], which runs
+/// `<clinit>` exactly once. `arg 0` is the (ignored) synthetic `Unsafe` receiver;
+/// `arg 1` is the target `Class`.
+pub(crate) fn native_unsafe_ensure_class_initialized(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    out: &mut dyn Write,
+    _control: &mut NativeControl,
+    ops: &mut dyn CallbackOps,
+) -> Result<Option<Slot>> {
+    let class_ref = extract_ref_arg(args, 1)?;
+    let class_name = class_internal_name_from_ref(heap, class_ref)?;
+    ops.ensure_class_initialized(heap, out, &class_name)?;
+    Ok(None)
+}
+
+/// Native: `initIDs()V` for `java/io/FileDescriptor` and `java/io/FileOutputStream`
+/// (and the other file-stream classes) — no-op.
+///
+/// This is the opening instruction of each of those classes' real `<clinit>`
+/// (reached once `Unsafe.ensureClassInitialized` forces initialization). In
+/// `HotSpot` `initIDs` only caches the `jfieldID`s (e.g. `fd`/`handle`/`append`) so
+/// later native code can poke those slots directly. Duke resolves fields
+/// positionally by name, so there is nothing to cache — an honest no-op. The rest
+/// of each `<clinit>` (installing the `JavaIOFileDescriptorAccess` via
+/// `SharedSecrets`, building `in`/`out`/`err`, seeding `FD_ACCESS`) runs as real
+/// bytecode.
+#[allow(clippy::unnecessary_wraps)] // signature must match `NativeHandler`
+pub(crate) fn native_io_init_ids_noop(
+    _args: &[Slot],
+    _heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    Ok(None)
+}
+
+/// Native: `java/io/FileDescriptor.getHandle(I)J`.
+///
+/// Called by the real `FileDescriptor(int)` constructor to seed the `handle`
+/// field. Handles are a Windows-only concept; the unix JDK native returns `-1`
+/// unconditionally (see `FileDescriptor_md.c`), so this mirrors that exactly.
+#[allow(clippy::unnecessary_wraps)] // signature must match `NativeHandler`
+pub(crate) fn native_file_descriptor_get_handle(
+    _args: &[Slot],
+    _heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    Ok(Some(Slot::Long(-1)))
+}
+
+/// Native: `java/io/FileDescriptor.getAppend(I)Z`.
+///
+/// Called by the real `FileDescriptor(int)` constructor to seed the `append`
+/// field. The unix JDK native returns `fcntl(fd, F_GETFL) & O_APPEND`. This path
+/// runs only for the standard descriptors `0`/`1`/`2` built in
+/// `FileDescriptor.<clinit>` — none of which is opened in append mode — so the
+/// honest answer is `false`. (`FileOutputStream`'s own append flag lives in a
+/// separate field set from its constructor, not from this descriptor query.)
+#[allow(clippy::unnecessary_wraps)] // signature must match `NativeHandler`
+pub(crate) fn native_file_descriptor_get_append(
+    _args: &[Slot],
+    _heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    Ok(Some(Slot::Int(0)))
+}

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -13853,6 +13853,45 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         "(Ljava/lang/Class;)I",
         native_reflection_get_class_access_flags,
     );
+
+    // ─── java.lang.invoke / SharedSecrets foundation ─────────────────────────
+    // Natives demanded by the real `FileOutputStream.<clinit>` chain under
+    // `DUKE_REAL_JDK=1`. The chain routes through `MethodHandles.Lookup`
+    // initialization, which forces `<clinit>` of the target class via
+    // `Unsafe.ensureClassInitialized`. `Unsafe` stays on `KEEP_SYNTHETIC`, so its
+    // methods are dispatched to this native (not shadowed bytecode); the native
+    // honors the real contract by driving the class through its real `<clinit>`.
+    // Handlers in `native/jdk_internal.rs`.
+    registry.natives_mut().register_callback(
+        "jdk/internal/misc/Unsafe",
+        "ensureClassInitialized",
+        "(Ljava/lang/Class;)V",
+        native_unsafe_ensure_class_initialized,
+    );
+    // `FileDescriptor.<clinit>` and `FileOutputStream.<clinit>` (forced by
+    // `ensureClassInitialized`) each open with the native `initIDs()V`. HotSpot uses
+    // it only to cache jfieldIDs; Duke resolves fields positionally, so it is a
+    // no-op. The rest of each `<clinit>` runs as real bytecode.
+    for class in ["java/io/FileDescriptor", "java/io/FileOutputStream"] {
+        registry
+            .natives_mut()
+            .register(class, "initIDs", "()V", native_io_init_ids_noop);
+    }
+    // The real `FileDescriptor(int)` constructor seeds `handle`/`append` from these
+    // natives. `getHandle` is -1 on unix (Windows-only concept); `getAppend` is
+    // false for the standard descriptors built in `<clinit>`.
+    registry.natives_mut().register(
+        "java/io/FileDescriptor",
+        "getHandle",
+        "(I)J",
+        native_file_descriptor_get_handle,
+    );
+    registry.natives_mut().register(
+        "java/io/FileDescriptor",
+        "getAppend",
+        "(I)Z",
+        native_file_descriptor_get_append,
+    );
 }
 
 // ─── Phase 88 natives ────────────────────────────────────────────────────────

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -32934,3 +32934,124 @@ fn native_class_get_module_returns_interned_unnamed_module() {
     .unwrap();
     assert_eq!(can_use, Slot::Int(1), "unnamed module canUse(..) == true");
 }
+
+// java.lang.invoke / SharedSecrets foundation natives
+// ---------------------------------------------------------------------------
+// These walk the real `FileOutputStream.<clinit>` chain under `DUKE_REAL_JDK=1`:
+// `Unsafe.ensureClassInitialized` forces `FileDescriptor.<clinit>`, whose real
+// bytecode calls `initIDs`/`getHandle`/`getAppend`. They are dormant while
+// `FileOutputStream` stays on `KEEP_SYNTHETIC`, so these direct-dispatch tests
+// pin their contracts against bit-rot.
+
+/// `Unsafe.ensureClassInitialized(Class)` must drive the argument class (arg 1,
+/// after the ignored `Unsafe` receiver) through `ensure_class_initialized`.
+#[test]
+fn native_unsafe_ensure_class_initialized_forces_arg_class() {
+    struct RecordingOps {
+        initialized: Vec<String>,
+    }
+
+    impl CallbackOps for RecordingOps {
+        fn invoke(
+            &mut self,
+            _heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            _args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            Ok(None)
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            unreachable!("ensureClassInitialized must not inspect")
+        }
+
+        fn ensure_class_initialized(
+            &mut self,
+            _heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            class: &str,
+        ) -> Result<()> {
+            self.initialized.push(class.to_string());
+            Ok(())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let mut sink: Vec<u8> = Vec::new();
+    let unsafe_ref = heap.allocate("jdk/internal/misc/Unsafe".to_string(), 0);
+    let class_ref = allocate_class_object(&mut heap, "java/io/FileDescriptor").unwrap();
+    let mut ops = RecordingOps {
+        initialized: Vec::new(),
+    };
+
+    let ret = native_unsafe_ensure_class_initialized(
+        &[
+            Slot::Reference(Some(unsafe_ref)),
+            Slot::Reference(Some(class_ref)),
+        ],
+        &mut heap,
+        &mut sink,
+        &mut NativeControl::default(),
+        &mut ops,
+    )
+    .unwrap();
+
+    assert_eq!(ret, None, "ensureClassInitialized returns void");
+    assert_eq!(
+        ops.initialized,
+        vec!["java/io/FileDescriptor".to_string()],
+        "the argument class must be forced through <clinit>"
+    );
+}
+
+/// `FileDescriptor`/`FileOutputStream` `initIDs()V` is an honest no-op under
+/// Duke's positional field model (nothing to cache).
+#[test]
+fn native_io_init_ids_is_noop() {
+    let mut heap = duke_gc::Heap::new();
+    let mut sink: Vec<u8> = Vec::new();
+    let ret =
+        native_io_init_ids_noop(&[], &mut heap, &mut sink, &mut NativeControl::default()).unwrap();
+    assert_eq!(ret, None, "initIDs returns void and caches nothing");
+}
+
+/// Unix `FileDescriptor.getHandle(int)` returns -1 unconditionally (handles are
+/// a Windows-only concept).
+#[test]
+fn native_file_descriptor_get_handle_is_minus_one_on_unix() {
+    let mut heap = duke_gc::Heap::new();
+    let mut sink: Vec<u8> = Vec::new();
+    let ret = native_file_descriptor_get_handle(
+        &[Slot::Int(0)],
+        &mut heap,
+        &mut sink,
+        &mut NativeControl::default(),
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(ret, Slot::Long(-1), "getHandle == -1 on unix");
+}
+
+/// `FileDescriptor.getAppend(int)` is false for the standard descriptors built
+/// in `<clinit>` (none opened in append mode).
+#[test]
+fn native_file_descriptor_get_append_is_false() {
+    let mut heap = duke_gc::Heap::new();
+    let mut sink: Vec<u8> = Vec::new();
+    let ret = native_file_descriptor_get_append(
+        &[Slot::Int(1)],
+        &mut heap,
+        &mut sink,
+        &mut NativeControl::default(),
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(ret, Slot::Int(0), "getAppend == false");
+}

--- a/docs/findings/2026-07-11-system-io-real-layout-blockers.md
+++ b/docs/findings/2026-07-11-system-io-real-layout-blockers.md
@@ -256,6 +256,82 @@ for CI stability.
 
 ---
 
+## 8. Edge-1 update (2026-07-12) — `java.lang.invoke` / `SharedSecrets` foundation
+
+Stage (a)/(b) down-payment: walking the FIRST edge of the file chain until the
+real `java/io/FileOutputStream.<clinit>` runs to completion under
+`DUKE_REAL_JDK=1`. Probed empirically with a throwaway removal of
+`FileOutputStream` from `KEEP_SYNTHETIC` under `DUKE_LAYOUT_CHECK=fail`, driving a
+fixture that constructs a `FileOutputStream`. **The probe was reverted** — the
+allowlist is unchanged (still 10 members). The half-migration would regress
+because full FOS *construction* is not yet wired (see the next-blocker wall
+below); only `<clinit>` completes.
+
+### Chain progress — before vs. after
+
+**Before this wave** (post-#1330, `getClassAccessFlags` already landed): dropping
+`FileOutputStream` died at `Unsafe.ensureClassInitialized` — `method not found`.
+
+**After this wave:** real `FileOutputStream.<clinit>` runs to completion
+(`FileOutputStream::<clinit>@9 return` observed under `DUKE_TRACE_EXEC=1`). The
+full cleared chain is:
+
+1. `FileOutputStream.<clinit>@0` → `SharedSecrets.getJavaIOFileDescriptorAccess()`
+   (FD_ACCESS null) → `MethodHandles.Lookup.ensureInitialized(FileDescriptor)`
+   (real invoke bytecode: `VerifyAccess.isClassAccessible`, `checkSecurityManager`)
+   → `Unsafe.ensureClassInitialized(FileDescriptor.class)`. **[native added]**
+2. That forces real `FileDescriptor.<clinit>`, which opens with native
+   `initIDs()V` **[native added, no-op]**, installs the `JavaIOFileDescriptorAccess`
+   via `SharedSecrets.setJavaIOFileDescriptorAccess` (real bytecode), and builds
+   `in`/`out`/`err` via `FileDescriptor(int)` — whose body calls native
+   `getHandle(I)J` **[native added, −1 on unix]** and `getAppend(I)Z`
+   **[native added, false]**.
+3. Control returns; `SharedSecrets.getJavaIOFileDescriptorAccess()` now returns
+   non-null FD_ACCESS.
+4. `FileOutputStream.<clinit>@3` stores FD_ACCESS, `@6` runs native
+   `FileOutputStream.initIDs()V` **[native added, no-op]**, `@9 return`. **DONE.**
+
+### Natives added (all honest, dormant while FOS stays synthetic)
+
+Registration in `stdlib.rs` (`bootstrap_stdlib` tail, grouped block
+`// java.lang.invoke / SharedSecrets foundation`); handlers in
+`native/jdk_internal.rs`:
+
+| Native | Descriptor | Behavior |
+|--------|-----------|----------|
+| `jdk/internal/misc/Unsafe.ensureClassInitialized` | `(Ljava/lang/Class;)V` | drives arg-1 `Class` through `CallbackOps::ensure_class_initialized` (real `<clinit>`) |
+| `java/io/FileDescriptor.initIDs` | `()V` | no-op (nothing to cache under positional fields) |
+| `java/io/FileOutputStream.initIDs` | `()V` | no-op (same) |
+| `java/io/FileDescriptor.getHandle` | `(I)J` | `-1` (Windows-only concept; matches unix native) |
+| `java/io/FileDescriptor.getAppend` | `(I)Z` | `false` (std descriptors built in `<clinit>` are non-append) |
+
+4 direct-dispatch unit tests pin these contracts (`tests.rs`), since the natives
+are dormant in the default (FOS-synthetic) config.
+
+### VERBATIM next blocker (the next wall — a NEW, deeper chain)
+
+Past `<clinit>`, FOS *construction* (`new FileOutputStream(path)`) allocates a
+`File`, whose `File.<clinit>` reaches `UnixFileSystem.<clinit>@0 invokestatic`:
+
+```
+duke: trace java/io/UnixFileSystem::<clinit>@0 invokestatic stack=0
+duke: runtime error: fell off end of bytecode without a return instruction
+```
+
+`UnixFileSystem.<clinit>` is `0: invokestatic initIDs:()V; 3: return` — i.e. the
+native `java/io/UnixFileSystem.initIDs()V`. This is **Stage (b) file-stream
+territory**, not the invoke foundation: it drags in the whole `File` /
+`FileSystem` / `UnixFileSystem` layer plus the leaf file natives
+(`open0`/`writeBytes`/`readBytes`/`read0`/`close0`), which still model `fd` as an
+`int` incompatible with the real `FileDescriptor` reference field. That is a
+separate wave and was intentionally NOT walked here.
+
+**Allowlist delta: none.** `KEEP_SYNTHETIC` remains 10 members. Tests
+3059 → 3063 (+4). fmt/clippy clean, HelloWorld exit 0 flag-on and flag-off,
+real-JDK gate tests green.
+
+---
+
 ## Summary
 
 Phase 1 is an investigation plus a scaffolding down-payment. The single most
@@ -263,4 +339,7 @@ load-bearing takeaway is §3: **bytecode wins over registered natives for shadow
 classes**, so no allowlist member can be migrated with a native-shim shortcut —
 the real object graph must be genuinely well-formed. The staged plan in §5
 sequences the remaining waves behind one shared `java.lang.invoke` /
-`Reflection.getClassAccessFlags` prerequisite.
+`Reflection.getClassAccessFlags` prerequisite. §8 lands the first slice of that
+prerequisite: real `FileOutputStream.<clinit>` now completes under
+`DUKE_REAL_JDK=1`; the next wall is the `UnixFileSystem`/leaf-file-native layer
+(Stage b), which the allowlist still correctly guards.


### PR DESCRIPTION
**Before:** With `DUKE_REAL_JDK=1`, forcing the real `java/io/FileOutputStream` static initializer crashed almost immediately — the `java.lang.invoke`/SharedSecrets bootstrap it depends on had no backing natives, so the class-init chain died at unregistered methods (`Unsafe.ensureClassInitialized`, `FileDescriptor` field-ID/handle natives).

**After:** Real `java/io/FileOutputStream.<clinit>` now runs to completion under `DUKE_REAL_JDK=1` (verified: `java/io/FileOutputStream::<clinit>@9 return`). This is the first edge of the System/IO real-layout dependency DAG from #1331 — the reflection / java.lang.invoke foundation — building on `Reflection.getClassAccessFlags` from #1330.

## How (implementation)

Added five honest natives (no fake object-graph shortcuts) in `crates/duke-interpreter/src/native/jdk_internal.rs`, registered in an append-only grouped block at the `bootstrap_stdlib` tail in `crates/duke-interpreter/src/stdlib.rs`:

- `Unsafe.ensureClassInitialized(Class)` — drives the class through real `<clinit>` via `CallbackOps::ensure_class_initialized` (Unsafe kept on KEEP_SYNTHETIC so the native dispatches rather than shadowed bytecode).
- `FileDescriptor.initIDs()` / `FileOutputStream.initIDs()` — honest no-ops (HotSpot uses them only to cache jfieldIDs; Duke resolves fields positionally).
- `FileDescriptor.getHandle(int)` → `-1` (handles are Windows-only in the unix native), `FileDescriptor.getAppend(int)` → `false` (std descriptors 0/1/2 are non-append).

Cleared chain: `FileOutputStream.<clinit>` → `SharedSecrets.getJavaIOFileDescriptorAccess` (FD_ACCESS null) → real invoke bytecode → `Unsafe.ensureClassInitialized(FileDescriptor)` → real `FileDescriptor.<clinit>` (installs FD_ACCESS, builds in/out/err) → `<clinit>@9 return`.

## Scope guardrails

This is foundation work, NOT the FileStream migration. `KEEP_SYNTHETIC` is unchanged (still 10 members) — the FileOutputStream drop was only a throwaway probe and was fully reverted; shipping it would be the #1331 "half-migration trap" since full construction isn't wired yet. New natives are dormant in the default synthetic config; 4 direct-dispatch unit tests pin their contracts.

## Next wall (pinned, deliberately not walked)

FOS *construction* (past `<clinit>`) reaches `java/io/UnixFileSystem.<clinit>` → `fell off end of bytecode` — Stage (b) file-stream territory (File/FileSystem/UnixFileSystem layer + leaf file natives modeling `fd` as int). Left for the file-stream migration wave. Documented in §8 of `docs/findings/2026-07-11-system-io-real-layout-blockers.md`.

## Gates

- `cargo test --workspace` 3063 passed / 0 failed / 4 ignored (baseline 3059 + 4 new tests, no regressions)
- `cargo fmt --all --check` clean
- CI clippy (1.97.0, `-D warnings`, pedantic+nursery) clean
- HelloWorld green with and without `DUKE_REAL_JDK=1`
- `real_jdk_shadow` / `layout_coherence` / `module_model` all pass

Commits: `b79ebd4`, `0ca6712`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mhr9HmDpvZ4t5neL2qeCd3)_