### PR TITLE
🗺️ Atlas: Encapsulate telemetry helper module

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -7,3 +7,6 @@
 **[Encapsulate `duke_classfile` Facade]**
 **Tangle:** The `duke_classfile` API exported an intermediate `types` module (`pub mod types`) merely to re-export its inner types, and `duke-telemetry` exposed internal serialization helpers via `pub mod ser_helpers`. This creates confusing, leaky abstractions and redundant paths.
 **Blueprint:** Encapsulated both modules. In `duke_classfile`, replaced `pub mod types` with direct `pub use` statements at the crate root, eliminating the `types` namespace from the public API entirely. In `duke_telemetry`, reduced `ser_helpers` visibility to `pub(crate)`.
+**Encapsulate Telemetry Helpers**
+**Tangle:** The `duke-telemetry` API exposed internal serialization helpers via `pub mod ser_helpers`, creating a leaky abstraction.
+**Blueprint:** Reduced `ser_helpers` visibility to `pub(crate)` to encapsulate the module.

--- a/crates/duke-telemetry/src/helpers.rs
+++ b/crates/duke-telemetry/src/helpers.rs
@@ -1,6 +1,6 @@
 //! Serde serialization helpers for telemetry data structures.
 #[cfg(feature = "telemetry")]
-pub mod ser_helpers {
+pub(crate) mod ser_helpers {
     use std::collections::HashMap;
 
     use serde::{Serialize, ser::SerializeMap};


### PR DESCRIPTION
🕸️ Tangle: The duke-telemetry API exposed internal serialization helpers via pub mod ser_helpers, creating a leaky abstraction.
📐 Blueprint: Reduced ser_helpers visibility to pub(crate) to encapsulate the module.
🧱 Stability: Enforced encapsulation boundaries.
🔬 Verification: Builds and tests run successfully.

---
*PR created automatically by Jules for task [18007870222931374807](https://jules.google.com/task/18007870222931374807) started by @madmax983*