### PR TITLE
Synthetic DateTimeFormatter (ofPattern/withZone/withLocale/format) for Spring Boot boot

### DIFF
--- a/crates/duke-interpreter/src/native/java_time.rs
+++ b/crates/duke-interpreter/src/native/java_time.rs
@@ -1563,3 +1563,431 @@ pub(crate) fn native_zoneid_get_id(
     let sr = heap.allocate_string(id);
     Ok(Some(Slot::Reference(Some(sr))))
 }
+
+// ---------------------------------------------------------------------------
+// java.time.format.DateTimeFormatter (minimal-for-boot)
+//
+// logback's `ch.qos.logback.core.util.CachingDateFormatter` builds a
+// pattern-based formatter via `DateTimeFormatter.ofPattern(String)`, binds it to
+// a zone/locale (`withZone`/`withLocale`), then formats an `Instant` through
+// `format(TemporalAccessor)`. Duke models the formatter as a thin synthetic
+// holder whose `string_value` carries the pattern string (or, for the ISO
+// constant instances registered in stdlib, the constant's name). A small pure
+// pattern engine (`format_with_pattern`) renders broken-down UTC wall-clock
+// fields into text. This deliberately does not model a real
+// `DateTimeFormatterBuilder`/CLDR: it is minimal-for-boot.
+// ---------------------------------------------------------------------------
+
+/// Broken-down UTC wall-clock fields fed to [`format_with_pattern`].
+///
+/// Duke is UTC-only (see the `ZoneId` natives), so these are always the UTC
+/// wall-clock components of the underlying temporal.
+struct BrokenDownTime {
+    year: i64,
+    month: u32,
+    day: u32,
+    hour: u32,
+    minute: u32,
+    second: u32,
+    nano: u32,
+}
+
+/// en-US short month names, indexed by `month - 1`.
+const SHORT_MONTH_NAMES: [&str; 12] = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+/// en-US full month names, indexed by `month - 1`.
+const LONG_MONTH_NAMES: [&str; 12] = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+];
+
+/// Map an ISO-constant formatter name to an equivalent pattern string.
+///
+/// The three static `DateTimeFormatter` constants registered in stdlib store
+/// their name (not a pattern) in `string_value`. This is a deliberate
+/// simplification: duke renders each via a fixed equivalent pattern rather than
+/// the full ISO-8601 formatting rules. Any other value is treated as a literal
+/// pattern and returned unchanged.
+fn iso_constant_to_pattern(name: &str) -> String {
+    match name {
+        "ISO_INSTANT" => "yyyy-MM-dd'T'HH:mm:ss.SSSXXX".to_string(),
+        "ISO_LOCAL_DATE" => "yyyy-MM-dd".to_string(),
+        "ISO_LOCAL_DATE_TIME" => "yyyy-MM-dd'T'HH:mm:ss".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Append the decimal `digits` to `out`, zero-padded on the left to at least
+/// `width` characters.
+fn push_left_zero_padded(out: &mut String, digits: &str, width: usize) {
+    for _ in digits.len()..width {
+        out.push('0');
+    }
+    out.push_str(digits);
+}
+
+/// Append `value` to `out`, zero-padded on the left to at least `width` digits.
+fn push_zero_padded(out: &mut String, value: u32, width: usize) {
+    push_left_zero_padded(out, &value.to_string(), width);
+}
+
+/// Render one run of `count` identical pattern letters into `out`.
+///
+/// Supports the subset documented on [`format_with_pattern`]. Any unrecognized
+/// letter is emitted verbatim (`count` copies), never panicking.
+fn append_pattern_field(out: &mut String, letter: char, count: usize, dt: &BrokenDownTime) {
+    match letter {
+        // year: zero-padded to at least `count` digits.
+        'y' | 'u' => push_left_zero_padded(out, &dt.year.to_string(), count),
+        'M' | 'L' => match count {
+            3 => out.push_str(month_name(&SHORT_MONTH_NAMES, dt.month)),
+            n if n >= 4 => out.push_str(month_name(&LONG_MONTH_NAMES, dt.month)),
+            _ => push_zero_padded(out, dt.month, count),
+        },
+        'd' => push_zero_padded(out, dt.day, count),
+        // hour-of-day 0..=23.
+        'H' => push_zero_padded(out, dt.hour, count),
+        // clock-hour 1..=12.
+        'h' => {
+            let clock = if dt.hour.is_multiple_of(12) {
+                12
+            } else {
+                dt.hour % 12
+            };
+            push_zero_padded(out, clock, count);
+        }
+        'm' => push_zero_padded(out, dt.minute, count),
+        's' => push_zero_padded(out, dt.second, count),
+        // fraction-of-second: value = nano / 10^(9 - count), zero-padded to count.
+        'S' => {
+            let digits = count.min(9);
+            let exp = u32::try_from(9 - digits).unwrap_or(0);
+            let frac = dt.nano / 10u32.pow(exp);
+            push_zero_padded(out, frac, digits);
+            for _ in digits..count {
+                out.push('0');
+            }
+        }
+        // AM/PM marker (en-US).
+        'a' => out.push_str(if dt.hour < 12 { "AM" } else { "PM" }),
+        // zone-offset: duke is UTC-only, so the offset is always zero, which the
+        // java.time X-family renders as `Z`.
+        'X' => out.push('Z'),
+        // zone name: always UTC in duke.
+        'z' | 'v' | 'V' => out.push_str("UTC"),
+        // Unrecognized letter: emit the raw letters literally.
+        _ => {
+            for _ in 0..count {
+                out.push(letter);
+            }
+        }
+    }
+}
+
+/// Look up an en-US month name, falling back to an empty string for out-of-range
+/// month numbers (defensive; callers pass `1..=12`).
+fn month_name(names: &[&'static str; 12], month: u32) -> &'static str {
+    usize::try_from(month)
+        .ok()
+        .and_then(|m| m.checked_sub(1))
+        .and_then(|idx| names.get(idx).copied())
+        .unwrap_or("")
+}
+
+/// Pure pattern-formatting engine for the `DateTimeFormatter` subset duke supports.
+///
+/// Supported pattern letters (Java `DateTimeFormatter` semantics, en-US, UTC):
+/// * `y`/`u` — year, zero-padded to the letter count.
+/// * `M`/`L` — month: `M`/`MM` numeric (padded); `MMM` short name; `MMMM`+ full name.
+/// * `d`/`dd` — day-of-month (padded).
+/// * `H`/`HH` — hour-of-day 0..=23 (padded); `h`/`hh` — clock-hour 1..=12 (padded).
+/// * `m`/`mm` — minute; `s`/`ss` — second.
+/// * `S`… — fraction-of-second; for count `n`, `nano / 10^(9-n)` padded to `n` (`SSS` = millis).
+/// * `a` — AM/PM (en-US).
+/// * `X`/`XX`/`XXX` — zone-offset; always `Z` under duke's zero (UTC) offset.
+/// * `z`/`zzzz` — zone name → `UTC`.
+/// * `'…'` — literal text; `''` → a literal `'`.
+/// * Any non-letter character is a literal.
+///
+/// Unrecognized letters are emitted verbatim rather than raising an error.
+fn format_with_pattern(pattern: &str, dt: &BrokenDownTime) -> String {
+    let chars: Vec<char> = pattern.chars().collect();
+    let mut out = String::new();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        if c == '\'' {
+            i += 1;
+            // `''` outside a quoted run is a literal single quote.
+            if i < chars.len() && chars[i] == '\'' {
+                out.push('\'');
+                i += 1;
+                continue;
+            }
+            // Quoted literal: consume to the closing quote, `''` inside → `'`.
+            while i < chars.len() {
+                if chars[i] == '\'' {
+                    if i + 1 < chars.len() && chars[i + 1] == '\'' {
+                        out.push('\'');
+                        i += 2;
+                        continue;
+                    }
+                    i += 1;
+                    break;
+                }
+                out.push(chars[i]);
+                i += 1;
+            }
+            continue;
+        }
+        if c.is_ascii_alphabetic() {
+            let mut count = 1;
+            while i + count < chars.len() && chars[i + count] == c {
+                count += 1;
+            }
+            append_pattern_field(&mut out, c, count, dt);
+            i += count;
+            continue;
+        }
+        out.push(c);
+        i += 1;
+    }
+    out
+}
+
+/// Build [`BrokenDownTime`] from the temporal object referenced by `temporal_ref`.
+///
+/// Recognizes duke's synthetic `Instant`, `LocalDateTime`, and `LocalDate`.
+fn broken_down_time_from_ref(heap: &duke_gc::Heap, temporal_ref: u64) -> Result<BrokenDownTime> {
+    let class_name = heap.get(temporal_ref)?.class_name.clone();
+    match class_name.as_str() {
+        "java/time/Instant" => {
+            let (seconds, nanos) = instant_parts_from_ref(heap, temporal_ref)?;
+            let (year, month, day, hour, minute, second) =
+                epoch_seconds_to_datetime_parts(seconds);
+            Ok(BrokenDownTime {
+                year: i64::from(year),
+                month,
+                day,
+                hour: u32::try_from(hour).unwrap_or(0),
+                minute: u32::try_from(minute).unwrap_or(0),
+                second: u32::try_from(second).unwrap_or(0),
+                nano: u32::try_from(nanos).unwrap_or(0),
+            })
+        }
+        "java/time/LocalDateTime" => {
+            let (epoch_day, hour, minute, second, nano) =
+                localdatetime_components_from_ref(heap, temporal_ref)?;
+            let (year, month, day) = epoch_days_to_ymd(epoch_day);
+            Ok(BrokenDownTime {
+                year: i64::from(year),
+                month,
+                day,
+                hour: u32::try_from(hour).unwrap_or(0),
+                minute: u32::try_from(minute).unwrap_or(0),
+                second: u32::try_from(second).unwrap_or(0),
+                nano: u32::try_from(nano).unwrap_or(0),
+            })
+        }
+        "java/time/LocalDate" => {
+            let epoch_day = match heap.get(temporal_ref)?.fields.first() {
+                Some(Slot::Int(v)) => *v,
+                _ => 0,
+            };
+            let (year, month, day) = epoch_days_to_ymd(epoch_day);
+            Ok(BrokenDownTime {
+                year: i64::from(year),
+                month,
+                day,
+                hour: 0,
+                minute: 0,
+                second: 0,
+                nano: 0,
+            })
+        }
+        _ => Err(class_cast_error()),
+    }
+}
+
+/// Native: `DateTimeFormatter.ofPattern(String) -> DateTimeFormatter` (static).
+///
+/// Allocates a fresh synthetic formatter carrying the pattern string in its
+/// `string_value`.
+pub(crate) fn native_datetimeformatter_of_pattern(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let pattern = extract_string_arg_value(args, 0, heap)?;
+    let r = heap.allocate("java/time/format/DateTimeFormatter".to_string(), 0);
+    heap.get_mut(r)?.string_value = Some(pattern);
+    Ok(Some(Slot::Reference(Some(r))))
+}
+
+/// Native: `DateTimeFormatter.withZone(ZoneId) -> DateTimeFormatter` (instance).
+///
+/// Returns `this` unchanged. This is honest because duke is UTC-only (see the
+/// `ZoneId` natives): a zone-bound formatter and an unbound one produce identical
+/// output under UTC, so there is nothing to bind.
+pub(crate) fn native_datetimeformatter_with_zone(
+    args: &[Slot],
+    _heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let _zone = extract_ref_arg(args, 1)?;
+    Ok(Some(Slot::Reference(Some(this_ref))))
+}
+
+/// Native: `DateTimeFormatter.withLocale(Locale) -> DateTimeFormatter` (instance).
+///
+/// Returns `this` unchanged. This is honest because duke's `Locale` is a fixed
+/// en-US default (see the `Locale` natives), the same locale this formatter
+/// already renders with, so there is nothing to change.
+pub(crate) fn native_datetimeformatter_with_locale(
+    args: &[Slot],
+    _heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let _locale = extract_ref_arg(args, 1)?;
+    Ok(Some(Slot::Reference(Some(this_ref))))
+}
+
+/// Native: `DateTimeFormatter.format(TemporalAccessor) -> String` (instance).
+///
+/// Reads the formatter's pattern (or ISO-constant name) from `this.string_value`,
+/// extracts the temporal's broken-down UTC fields, and renders them via
+/// [`format_with_pattern`].
+pub(crate) fn native_datetimeformatter_format(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let temporal_ref = extract_ref_arg(args, 1)?;
+    let pattern_source = heap.get(this_ref)?.string_value.clone().unwrap_or_default();
+    let pattern = iso_constant_to_pattern(&pattern_source);
+    let dt = broken_down_time_from_ref(heap, temporal_ref)?;
+    let text = format_with_pattern(&pattern, &dt);
+    let sr = heap.allocate_string(text);
+    Ok(Some(Slot::Reference(Some(sr))))
+}
+
+#[cfg(test)]
+mod datetimeformatter_pattern_tests {
+    use super::*;
+
+    fn epoch_zero() -> BrokenDownTime {
+        BrokenDownTime {
+            year: 1970,
+            month: 1,
+            day: 1,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            nano: 0,
+        }
+    }
+
+    #[test]
+    fn formats_epoch_zero_date_time_millis() {
+        let dt = epoch_zero();
+        assert_eq!(
+            format_with_pattern("yyyy-MM-dd HH:mm:ss.SSS", &dt),
+            "1970-01-01 00:00:00.000"
+        );
+    }
+
+    #[test]
+    fn formats_iso_instant_equivalent_pattern() {
+        let dt = epoch_zero();
+        assert_eq!(
+            format_with_pattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", &dt),
+            "1970-01-01T00:00:00.000Z"
+        );
+    }
+
+    #[test]
+    fn formats_clock_hour_ampm_and_multi_digit_fraction() {
+        // 2026-07-11 14:05:09.123456789 UTC
+        let dt = BrokenDownTime {
+            year: 2026,
+            month: 7,
+            day: 11,
+            hour: 14,
+            minute: 5,
+            second: 9,
+            nano: 123_456_789,
+        };
+        // clock-hour 14 -> 02, PM marker, milliseconds fraction.
+        assert_eq!(
+            format_with_pattern("yyyy-MM-dd hh:mm:ss a SSS", &dt),
+            "2026-07-11 02:05:09 PM 123"
+        );
+        // six-digit (microsecond) fraction.
+        assert_eq!(format_with_pattern("SSSSSS", &dt), "123456");
+    }
+
+    #[test]
+    fn formats_month_names_and_quoted_literals() {
+        let dt = BrokenDownTime {
+            year: 2026,
+            month: 7,
+            day: 11,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            nano: 0,
+        };
+        assert_eq!(format_with_pattern("MMM", &dt), "Jul");
+        assert_eq!(format_with_pattern("MMMM", &dt), "July");
+        // 'at' -> quoted literal text (the letters are NOT interpreted).
+        assert_eq!(format_with_pattern("d 'at' HH", &dt), "11 at 00");
+        // '' -> a literal single quote; embedded '' inside a quoted run -> '.
+        assert_eq!(format_with_pattern("''", &dt), "'");
+        assert_eq!(format_with_pattern("'o''clock'", &dt), "o'clock");
+    }
+
+    #[test]
+    fn midnight_clock_hour_is_twelve() {
+        let dt = epoch_zero();
+        assert_eq!(format_with_pattern("hh a", &dt), "12 AM");
+    }
+
+    #[test]
+    fn unrecognized_letters_are_emitted_verbatim() {
+        let dt = epoch_zero();
+        assert_eq!(format_with_pattern("QQ", &dt), "QQ");
+    }
+
+    #[test]
+    fn iso_constant_names_map_to_patterns() {
+        assert_eq!(iso_constant_to_pattern("ISO_LOCAL_DATE"), "yyyy-MM-dd");
+        assert_eq!(
+            iso_constant_to_pattern("ISO_LOCAL_DATE_TIME"),
+            "yyyy-MM-dd'T'HH:mm:ss"
+        );
+        assert_eq!(
+            iso_constant_to_pattern("ISO_INSTANT"),
+            "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+        );
+        // A real pattern passes through unchanged.
+        assert_eq!(iso_constant_to_pattern("yyyy"), "yyyy");
+    }
+}

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -12416,6 +12416,36 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
     };
     registry.register(date_time_formatter_ctx);
 
+    // Minimal-for-boot DateTimeFormatter natives. logback's `CachingDateFormatter`
+    // builds a pattern formatter (`ofPattern`), binds it to a zone/locale
+    // (`withZone`/`withLocale` — no-ops under duke's UTC-only, fixed en-US model),
+    // then formats an `Instant` via `format(TemporalAccessor)`. See the pattern
+    // engine and simplifications documented in native/java_time.rs.
+    registry.natives_mut().register(
+        "java/time/format/DateTimeFormatter",
+        "ofPattern",
+        "(Ljava/lang/String;)Ljava/time/format/DateTimeFormatter;",
+        native_datetimeformatter_of_pattern,
+    );
+    registry.natives_mut().register(
+        "java/time/format/DateTimeFormatter",
+        "withZone",
+        "(Ljava/time/ZoneId;)Ljava/time/format/DateTimeFormatter;",
+        native_datetimeformatter_with_zone,
+    );
+    registry.natives_mut().register(
+        "java/time/format/DateTimeFormatter",
+        "withLocale",
+        "(Ljava/util/Locale;)Ljava/time/format/DateTimeFormatter;",
+        native_datetimeformatter_with_locale,
+    );
+    registry.natives_mut().register(
+        "java/time/format/DateTimeFormatter",
+        "format",
+        "(Ljava/time/temporal/TemporalAccessor;)Ljava/lang/String;",
+        native_datetimeformatter_format,
+    );
+
     let localdate_ctx = ClassContext {
         class_name: "java/time/LocalDate".to_string(),
         super_class: Some("java/lang/Object".to_string()),

--- a/docs/findings/2026-07-10-spring-boot-real-app.md
+++ b/docs/findings/2026-07-10-spring-boot-real-app.md
@@ -263,7 +263,8 @@ moved to `method not found: java/time/format/DateTimeFormatter.ofPattern(String)
 | #1d `WeakReference.get()` underflow in commons-logging | native — `java.lang.ref` reference-object | **CLEARED (this branch)** |
 | #1e `class not found: java/time/ZoneId` | native / stdlib — `java_time` (`ZoneId`) | **CLEARED (this branch)** |
 | #1e′ `class not found: java/util/Locale` | native / stdlib — `java_util` (`Locale`) | **CLEARED (this branch)** |
-| #1e″ `method not found: DateTimeFormatter.ofPattern(String)` | native / stdlib — `java_time` (`DateTimeFormatter` factory) | **HANDOFF — current app pin (deferred to future wave)** |
+| #1e″ `method not found: DateTimeFormatter.ofPattern(String)` | native / stdlib — `java_time` (`DateTimeFormatter` factory) | **CLEARED (this branch)** |
+| #1e‴ `operand stack underflow` in logback `COWArrayList.addIfAbsent` | java.util.concurrent (`CopyOnWriteArrayList`) + interpreter lenient method-dispatch | **HANDOFF — current app pin (deferred to future wave)** |
 | #1f `class not found: org/apache/logging/slf4j/SLF4JProvider` | class-loader — `Class.forName` availability probe (`java_lang`) | **CLEARED (this branch)** |
 | #1f′ `class not found: org/apache/logging/log4j/MarkerManager` | interpreter — class-resolution / `NoClassDefFoundError` linkage during `<clinit>` (`execution.rs` + synthetic `LinkageError` in `stdlib.rs`) | **HANDOFF — current ladder pin (deferred to future wave)** |
 | #2 `java/net/URL` layout coherence | native / stdlib object-layout — `java_net` (`URL`) | inferred |
@@ -332,3 +333,75 @@ cargo clippy --workspace --all-targets
 cargo test -p duke --test spring_boot_real_app              # 2 passed / 2 ignored
 cargo test -p duke --test spring_boot_real_app -- --ignored # canaries (expected fail today)
 ```
+
+## Update (this wave): `DateTimeFormatter` cleared; app advances to a concurrent-collection underflow
+
+**App — minimal `java.time.format.DateTimeFormatter` for boot (CLEARED).**
+`crates/duke-interpreter/src/native/java_time.rs` + registration in
+`crates/duke-interpreter/src/stdlib.rs`. logback's
+`ch.qos.logback.core.util.CachingDateFormatter` builds a pattern-based formatter
+during Spring Boot startup: `ofPattern(String)` in its ctor, then `withZone(ZoneId)`
+and `withLocale(Locale)`, then per-format `Instant.ofEpochMilli(long)` +
+`format(TemporalAccessor)`. The synthetic `DateTimeFormatter` previously carried
+only the ISO constant instances (no factory), so `ofPattern` was `method not found`.
+
+Implemented four natives on `java/time/format/DateTimeFormatter`:
+
+- `ofPattern(String)` (static) — allocates a fresh synthetic formatter carrying the
+  pattern string in its `string_value`.
+- `withZone(ZoneId)` (instance) — returns `this` unchanged. **Honest** because duke
+  is UTC-only (wave-5 `ZoneId`=UTC decision): a zone-bound and an unbound formatter
+  produce identical output under UTC.
+- `withLocale(Locale)` (instance) — returns `this` unchanged. **Honest** because
+  duke's `Locale` is a fixed en-US default; there is nothing to re-bind.
+- `format(TemporalAccessor)` (instance) — reads the formatter's pattern (or ISO
+  constant name) from `string_value`, extracts the temporal's broken-down **UTC**
+  fields (`Instant` via epoch-seconds/nanos, `LocalDateTime`, `LocalDate`), and
+  renders them via a small pure pattern engine.
+
+**Pattern engine** (`format_with_pattern`, unit-tested). Supported subset (en-US,
+UTC): `y`/`u` (year, zero-padded to count); `M`/`L` (`M`/`MM` numeric, `MMM` short
+name, `MMMM`+ full name); `d` (day); `H` (hour 0–23), `h` (clock-hour 1–12);
+`m`/`s` (minute/second); `S…` (fraction-of-second, `nano / 10^(9-n)` padded to `n`,
+so `SSS` = millis); `a` (AM/PM); `X`/`XX`/`XXX` (zone-offset → always `Z` under
+duke's zero UTC offset); `z`/`zzzz` (zone name → `UTC`); single-quoted literals
+(`'T'` → `T`, `''` → `'`); any non-letter char is a literal. Unrecognized letters
+are emitted verbatim, never panicking.
+
+**Simplifications (documented in code):** UTC-only offsets (`X`→`Z`), fixed en-US
+month names / AM-PM, and the three ISO constant instances mapped to fixed
+equivalent patterns — `ISO_LOCAL_DATE` → `yyyy-MM-dd`, `ISO_LOCAL_DATE_TIME` →
+`yyyy-MM-dd'T'HH:mm:ss`, `ISO_INSTANT` → `yyyy-MM-dd'T'HH:mm:ss.SSSXXX` — rather
+than the full ISO-8601 formatting rules.
+
+**Unit tests** (`#[cfg(test)] mod datetimeformatter_pattern_tests` in
+`native/java_time.rs`): epoch-0 → `"yyyy-MM-dd HH:mm:ss.SSS"` = `"1970-01-01
+00:00:00.000"`; epoch-0 → `"yyyy-MM-dd'T'HH:mm:ss.SSSXXX"` = `"1970-01-01
+T00:00:00.000Z"`; a non-zero 2026-07-11 14:05:09.123456789 covering `hh`/`a`
+clock-hour + AM/PM and a multi-digit (`SSSSSS`) fraction; month names (`MMM`/`MMMM`);
+quoted literals and `''`; midnight clock-hour = `12 AM`; unrecognized `QQ` verbatim;
+and the ISO-constant → pattern mapping.
+
+**Rung cleared:** `#1e″` — `method not found:
+java/time/format/DateTimeFormatter.ofPattern(...)`.
+
+**New app frontier (HANDOFF).** With the formatter working, boot advances and now
+lands on `duke: runtime error: operand stack underflow` — the app's only output.
+Traced (`DUKE_TRACE_EXEC=1`) to logback's
+`ch/qos/logback/core/util/COWArrayList.addIfAbsent`: at offset 5 it calls
+`java/util/concurrent/CopyOnWriteArrayList.addIfAbsent(Ljava/lang/Object;)Z` and at
+offset 8 `pop`s the boolean. Duke has **no** synthetic `CopyOnWriteArrayList`; it
+resolves the class leniently (the `new`/`invokespecial <init>()V` are silently
+absorbed, and the `addIfAbsent` `invokevirtual` returns **void** instead of pushing
+a boolean), so the following `pop` underflows the operand stack. Note this surfaces
+as a generic interpreter runtime error, **not** a clean `method not found` — the
+lenient dispatch swallows the missing method.
+
+**Ownership assessment: owned-elsewhere (not java.time).** The gap is a synthetic
+`java/util/concurrent/CopyOnWriteArrayList` (`addIfAbsent`/`add`/`remove` returning
+their `boolean` results) and/or a stricter method-dispatch that raises
+`method not found` rather than silently returning void for an unregistered method.
+That is the **java.util.concurrent / interpreter lenient-dispatch lane**, outside
+the java.time family, so it is pinned rather than fixed here.
+`APP_BLOCKER` is now `"duke: runtime error: operand stack underflow"`.
+`LADDER_BLOCKER` is unchanged (`"class not found: org/apache/logging/log4j/MarkerManager"`).

--- a/duke/tests/spring_boot_real_app.rs
+++ b/duke/tests/spring_boot_real_app.rs
@@ -48,14 +48,21 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 // lane then cleared the inherited `java/lang/Object.getClass()` virtual dispatch
 // for interface-typed callsites, advancing the app fixture again. Current
 // frontiers:
-//   * APP cleared the logback timestamp `java/util/Locale` rung: a minimal
-//     synthetic `Locale` (fixed en-US default; `getDefault`/`getLanguage`/
-//     `getCountry`/`toString`) landed without pulling in CLDR/`ResourceBundle`.
-//     It now lands on
-//     `method not found: java/time/format/DateTimeFormatter.ofPattern(String)` —
-//     logback's `CachingDateFormatter` builds a pattern-based formatter, and the
-//     synthetic `DateTimeFormatter` only carries the ISO constant instances, not
-//     the `ofPattern` factory (java.time formatter lane).
+//   * APP cleared the logback timestamp `java/time/format/DateTimeFormatter`
+//     rung: a minimal synthetic `DateTimeFormatter` now implements
+//     `ofPattern`/`withZone`/`withLocale`/`format(TemporalAccessor)` with a small
+//     pattern engine (UTC-only, fixed en-US; see native/java_time.rs). logback's
+//     `CachingDateFormatter` now constructs and drives its formatter without a
+//     `method not found`. It now lands on `duke: runtime error: operand stack
+//     underflow`, raised inside logback's `COWArrayList.addIfAbsent`: that method
+//     calls `java/util/concurrent/CopyOnWriteArrayList.addIfAbsent(Object)Z` and
+//     `pop`s the boolean result, but duke resolves the unregistered
+//     `CopyOnWriteArrayList` leniently (no-op `<init>`, and the `addIfAbsent`
+//     invokevirtual returns void instead of a boolean), so the following `pop`
+//     underflows the operand stack. The real gap is a synthetic
+//     `java/util/concurrent/CopyOnWriteArrayList` (or a strict method-dispatch
+//     that raises `method not found` instead of silently returning void)
+//     (java.util.concurrent / interpreter lenient-dispatch lane).
 //   * LADDER cleared the commons-logging `LogFactory.newStandardFactory`
 //     `Class.forName("...SLF4JProvider", false, cl)` availability probe: the
 //     3-arg `Class.forName` native was eagerly computing the class key (which
@@ -71,7 +78,7 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 //     errors (interpreter class-resolution / linkage-error lane).
 // If either boot advances past its pin, re-observe and update.
 // See docs/findings/2026-07-10-spring-boot-real-app.md.
-const APP_BLOCKER: &str = "method not found: java/time/format/DateTimeFormatter.ofPattern(Ljava/lang/String;)Ljava/time/format/DateTimeFormatter;";
+const APP_BLOCKER: &str = "duke: runtime error: operand stack underflow";
 const LADDER_BLOCKER: &str = "class not found: org/apache/logging/log4j/MarkerManager";
 
 fn run_fixture(jar: &str) -> Output {
@@ -101,9 +108,11 @@ fn combined_output(output: &Output) -> String {
 /// End-to-end CANARY for the real Spring Boot app fixture. Ignored until boot
 /// reaches the started-application line. Un-ignore when the happy path clears.
 #[test]
-#[ignore = "Blocked on missing java/time/format/DateTimeFormatter.ofPattern(String) \
-            (java.time formatter lane; the logback java/util/Locale rung is now cleared); \
-            keep ignored until the Spring Boot app boot completes. \
+#[ignore = "Blocked on a runtime 'operand stack underflow' raised inside logback's \
+            COWArrayList.addIfAbsent — duke resolves java/util/concurrent/CopyOnWriteArrayList \
+            leniently so its addIfAbsent(Object)Z returns void and the following pop underflows \
+            (java.util.concurrent / interpreter lenient-dispatch lane; the DateTimeFormatter \
+            ofPattern rung is now cleared); keep ignored until the Spring Boot app boot completes. \
             See docs/findings/2026-07-10-spring-boot-real-app.md"]
 fn spring_boot_app_boots_end_to_end() {
     let output = run_fixture(APP_JAR);


### PR DESCRIPTION
## Before / After

**Before:** Booting the real Spring Boot 3.5.12 app fixture (`duke -jar duke-spring-boot-app-3.5.12.jar`) died with `method not found: java/time/format/DateTimeFormatter.ofPattern(Ljava/lang/String;)Ljava/time/format/DateTimeFormatter;`. logback's `CachingDateFormatter` builds a pattern-based timestamp formatter during startup, and duke's synthetic `DateTimeFormatter` carried only the ISO constant instances — no `ofPattern` factory, no `format`.

**After:** logback's timestamp formatter constructs and runs. `CachingDateFormatter` calls `ofPattern(...)`, then `withZone(...)`/`withLocale(...)`, then formats an `Instant` via `format(TemporalAccessor)` — all resolve, and boot advances past this rung.

## How

Four minimal-for-boot natives on `java/time/format/DateTimeFormatter` (in `native/java_time.rs`, registered append-only in `stdlib.rs`):

- **`ofPattern(String)`** (static) — allocates a fresh synthetic formatter carrying the pattern string in its `string_value`.
- **`withZone(ZoneId)` / `withLocale(Locale)`** (instance) — return `this` unchanged. Honest because duke is UTC-only (a zone-bound and unbound formatter render identically under UTC) and its `Locale` is a fixed en-US default, so there is nothing to re-bind.
- **`format(TemporalAccessor)`** (instance) — reads the formatter's pattern (or ISO-constant name) and extracts broken-down UTC fields from `Instant` / `LocalDateTime` / `LocalDate`, then renders them via a pure pattern engine.

The pattern engine `format_with_pattern` (unit-tested directly) supports `y`/`u`, `M`/`L` (numeric + en-US short/full month names), `d`, `H`, `h`, `m`, `s`, `S` (fraction-of-second), `a` (AM/PM), `X` (→ `Z` under duke's zero UTC offset), `z`/`v`/`V` (→ `UTC`), single-quoted literals (`'T'` → `T`, `''` → `'`), and literal non-letters; unrecognized letters are emitted verbatim rather than panicking.

**Simplifications (documented in code):** UTC-only offsets, fixed en-US month/AM-PM names, and the three ISO constant instances mapped to fixed equivalent patterns (`ISO_LOCAL_DATE` → `yyyy-MM-dd`, `ISO_LOCAL_DATE_TIME` → `yyyy-MM-dd'T'HH:mm:ss`, `ISO_INSTANT` → `yyyy-MM-dd'T'HH:mm:ss.SSSXXX`) rather than the full ISO-8601 rules.

## Rung cleared + new frontier

- **Cleared:** `method not found: DateTimeFormatter.ofPattern(String)` (app fixture).
- **New app frontier (pinned, owned elsewhere):** `duke: runtime error: operand stack underflow`, traced to logback's `COWArrayList.addIfAbsent` calling `java/util/concurrent/CopyOnWriteArrayList.addIfAbsent(Object)Z`. Duke resolves the unregistered `CopyOnWriteArrayList` leniently, so its `addIfAbsent` `invokevirtual` returns void and the following `pop` underflows. The real gap is a synthetic `CopyOnWriteArrayList` (and/or stricter method dispatch) — the **java.util.concurrent / interpreter lenient-dispatch lane**, outside the java.time family — so it is pinned, not fixed here. `APP_BLOCKER` is updated to the new verbatim frontier; `LADDER_BLOCKER` is unchanged.

## Verification (local)

- `cargo build --workspace` — clean.
- `cargo test --workspace` — **3066 passed / 0 failed / 4 ignored** (+7 new pattern-engine unit tests). oss_jar_smoke canaries (slf4j/gson/commons_lang3) and `spring_boot_jar` HelloWorld still pass.
- `cargo fmt --check` — clean.
- `RUSTFLAGS="-D warnings" cargo +1.97.0 clippy --workspace --all-targets -- -W clippy::pedantic -W clippy::nursery` — zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJfDBZYCCRo4T5e7r8oFJm

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJfDBZYCCRo4T5e7r8oFJm)_