### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/crates/duke-classfile/tests/havoc_classfile_proptest.rs
+++ b/crates/duke-classfile/tests/havoc_classfile_proptest.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use proptest::prelude::*;
 
 proptest! {

--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -1494,7 +1494,7 @@ impl Heap {
 
     /// Lisp-2 sliding mark-compact of the old generation.
     ///
-    /// 1. **Mark** live old objects reachable from `roots` (reuses [`mark_old`]).
+    /// 1. **Mark** live old objects reachable from `roots` (reuses `mark_old`).
     /// 2. **Forward** — assign each live object a new, densely-packed old index
     ///    in ascending (stable, sliding) order; record old→new in an
     ///    `old_forward` map (only for objects that actually move).
@@ -1510,8 +1510,6 @@ impl Heap {
     ///
     /// `identity_hash` and `atomic_payload` ride along with each moved object,
     /// preserving the [`HeapObject`] invariant across relocation.
-    ///
-    /// [`mark_old`]: Self::mark_old
     pub fn compact_old(&mut self, roots: &[Slot]) {
         // Snapshot executor shared state up front: their task queues hold bare
         // OLD refs the mutator never sees, so we both (a) treat them as extra

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -777,7 +777,7 @@ impl ClassRegistry {
     }
 
     /// Enable "real JDK shadow" mode: synthetic stdlib classes that are not on the
-    /// [`KEEP_SYNTHETIC`] allowlist and whose real classfile is resolvable via `loader`
+    /// `KEEP_SYNTHETIC` allowlist and whose real classfile is resolvable via `loader`
     /// will be skipped by [`Self::register`], letting a later `ensure_loaded` load the
     /// real JDK bytecode. Must be called *before* `bootstrap_stdlib` runs to take effect.
     pub fn enable_real_jdk_shadow(&mut self, loader: Arc<dyn ClassLoader + Send + Sync>) {

--- a/crates/duke-interpreter/tests/havoc_slice_panics.rs
+++ b/crates/duke-interpreter/tests/havoc_slice_panics.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use duke_gc::Heap;
 use duke_runtime::Slot;
 

--- a/duke/tests/havoc_jdwp_oom.rs
+++ b/duke/tests/havoc_jdwp_oom.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![allow(clippy::unreadable_literal)]
 #![allow(clippy::needless_borrows_for_generic_args)]
 #![allow(clippy::uninlined_format_args)]

--- a/pr_details.txt
+++ b/pr_details.txt
@@ -1,6 +1,0 @@
-Title: 🛡️ Sentry: [test coverage improvement]
-Body:
-🎯 Target: `duke_loader::ZipReader::read_entry_info`, `duke_loader::parse_central_directory`, and `duke_telemetry::ser_helpers`.
-💣 Risk: Edge cases where zip central directories have truncated entries or mismatched local header offsets, and missing telemetry map empty paths could panic or fail implicitly if refactored.
-🧪 Strategy: Added specific inline tests inside `crates/duke-loader/src/zip.rs` to reach missing branches of Zip Format errors (e.g. truncated `filename_len`, exceeded `uncompressed_size`). Added tests in `crates/duke-telemetry/src/helpers.rs` for empty map serialization. Added an empty check for `print_report`.
-🔭 Verification: `cargo test -p duke-loader` and `cargo test -p duke-telemetry`


### PR DESCRIPTION
📖 Chapter: Resolving `cargo doc` warnings
🔦 Insight: Integration test files trigger `missing_docs` warnings if the lint is globally enabled. Public library functions triggering `rustdoc::private_intra_doc_links` were also fixed by downgrading the intra-doc links to standard code spans (backticks).
🧪 Example: Added `#![allow(missing_docs)]` to `havoc_slice_panics.rs`, `havoc_classfile_proptest.rs`, and `havoc_jdwp_oom.rs`. Changed `[`mark_old`]` to `` `mark_old` `` in `duke-gc/src/lib.rs` and `[`KEEP_SYNTHETIC`]` to `` `KEEP_SYNTHETIC` `` in `crates/duke-interpreter/src/registry.rs`.
🖼️ Preview: All `cargo doc` and `cargo check` warnings are now resolved!

---
*PR created automatically by Jules for task [14527250482860562111](https://jules.google.com/task/14527250482860562111) started by @madmax983*