### PR TITLE
Resolve inherited static methods on invokestatic (super-chain walk)

### DIFF
--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -639,7 +639,7 @@ pub fn run_execution(
                 };
                 let class_was_loaded =
                     registry.ensure_loaded_from(&callee_class, Some(&**current_class), loader)?;
-                let callee_class_key =
+                let mut callee_class_key =
                     registry.class_key_from_source(&callee_class, Some(&**current_class));
                 if class_was_loaded {
                     route_class_init_result!(ensure_initialized(
@@ -685,10 +685,29 @@ pub fn run_execution(
                         .filter(|(owning_class, _)| owning_class == &callee_class_key)
                         .map(|(_, idx)| idx)
                 } else {
-                    let ctx = registry.get(&callee_class_key)?;
-                    ctx.methods
-                        .iter()
-                        .position(|m| m.name == callee_name && m.descriptor == callee_desc)
+                    // JVMS §5.4.3.3: a static method may be declared on a superclass
+                    // and invoked via a Methodref symbolically bound to a subclass
+                    // (e.g. commons-logging LogFactoryImpl.objectId, declared on the
+                    // abstract superclass LogFactory). invokestatic has no receiver, so
+                    // no virtual dispatch — a plain upward walk for a concrete matching
+                    // name+descriptor is correct. Rebind callee_class_key to the class
+                    // where the body was found so the invoked frame resolves its own
+                    // constant pool / method idx / ctx correctly.
+                    match resolve_method_in_hierarchy_lookup(
+                        registry,
+                        loader,
+                        &callee_class_key,
+                        &callee_name,
+                        &callee_desc,
+                    ) {
+                        MethodHierarchyLookup::Bytecode(found_class, idx) => {
+                            callee_class_key = found_class;
+                            Some(idx)
+                        }
+                        MethodHierarchyLookup::NativeOverride | MethodHierarchyLookup::Missing => {
+                            None
+                        }
+                    }
                 };
                 match callee_idx {
                     Some(callee_idx) => {

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -1895,6 +1895,142 @@ fn registered_callback_native_overrides_loaded_bytecode_static_method() {
     assert_eq!(result, Some(Slot::Int(42)));
 }
 
+/// Regression: an `invokestatic` whose `Methodref` is symbolically bound to a
+/// subclass must resolve a `public static` method declared on a *superclass*
+/// (JVMS §5.4.3.3). Mirror of the real commons-logging bug where
+/// `LogFactoryImpl.objectId(...)` is invoked via a Methodref bound to the
+/// subclass `LogFactoryImpl`, but the body is declared on the abstract
+/// superclass `LogFactory`. Before the fix the invokestatic slow-path resolver
+/// flat-scanned only the referenced class, found nothing, and raised
+/// `MethodNotFound`. The resolver now walks the super chain and rebinds the
+/// callee class to where the body was found.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn invokestatic_resolves_inherited_static_method() {
+    use duke_classfile::CpIndex;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    // Caller: `Invokestatic` on `SubStaticImpl.inheritedStatic()I`. The
+    // Methodref is bound to the *subclass*, which declares no such method.
+    let caller_cp = make_cp(vec![
+        Some(CpEntry::Methodref {
+            class_index: CpIndex(2),
+            name_and_type_index: CpIndex(3),
+        }),
+        Some(CpEntry::Class {
+            name_index: CpIndex(4),
+        }),
+        Some(CpEntry::NameAndType {
+            name_index: CpIndex(5),
+            descriptor_index: CpIndex(6),
+        }),
+        Some(CpEntry::Utf8("SubStaticImpl".to_string())),
+        Some(CpEntry::Utf8("inheritedStatic".to_string())),
+        Some(CpEntry::Utf8("()I".to_string())),
+    ]);
+    let caller_instructions: Arc<[(usize, Instruction)]> = vec![
+        (0, Instruction::Invokestatic(CpIndex(1))),
+        (3, Instruction::Ireturn),
+    ]
+    .into();
+    let caller_method = MethodEntry {
+        name: "callInherited".to_string(),
+        descriptor: "()I".to_string(),
+        is_public: true,
+        is_static: true,
+        is_native: false,
+        is_abstract: false,
+        instructions: Arc::clone(&caller_instructions),
+        max_stack: 1,
+        max_locals: 0,
+        exception_table: Vec::new(),
+        pc_to_idx: Arc::new(HashMap::from([(0, 0), (3, 1)])),
+        line_number_table: Vec::new(),
+        source_file: None,
+    };
+    let caller_ctx = ClassContext {
+        class_name: "InheritedStaticCaller".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        interfaces: Vec::new(),
+        constant_pool: caller_cp,
+        methods: vec![caller_method],
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Classfile,
+    };
+
+    // Superclass declares the `public static` body (returns 7).
+    let super_instructions: Arc<[(usize, Instruction)]> =
+        vec![(0, Instruction::Bipush(7)), (2, Instruction::Ireturn)].into();
+    let super_method = MethodEntry {
+        name: "inheritedStatic".to_string(),
+        descriptor: "()I".to_string(),
+        is_public: true,
+        is_static: true,
+        is_native: false,
+        is_abstract: false,
+        instructions: Arc::clone(&super_instructions),
+        max_stack: 1,
+        max_locals: 0,
+        exception_table: Vec::new(),
+        pc_to_idx: Arc::new(HashMap::from([(0, 0), (2, 1)])),
+        line_number_table: Vec::new(),
+        source_file: None,
+    };
+    let super_ctx = ClassContext {
+        class_name: "SuperStaticBase".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        interfaces: Vec::new(),
+        constant_pool: Vec::new(),
+        methods: vec![super_method],
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Classfile,
+    };
+
+    // Subclass declares NO `inheritedStatic` of its own — it inherits the static.
+    let sub_ctx = ClassContext {
+        class_name: "SubStaticImpl".to_string(),
+        super_class: Some("SuperStaticBase".to_string()),
+        interfaces: Vec::new(),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Classfile,
+    };
+
+    let mut registry = ClassRegistry::new();
+    let mut heap = duke_gc::Heap::new();
+    bootstrap_stdlib(&mut registry, &mut heap);
+    registry.register(caller_ctx);
+    registry.register(super_ctx);
+    registry.register(sub_ctx);
+    let loader = make_simple_loader();
+    let mut sink: Vec<u8> = Vec::new();
+
+    let result = execute_class(
+        &mut registry,
+        &loader,
+        &mut heap,
+        &mut sink,
+        "InheritedStaticCaller",
+        "callInherited",
+        "()I",
+        &[],
+    )
+    .expect("invokestatic should resolve the inherited static via the super chain");
+
+    assert_eq!(result, Some(Slot::Int(7)));
+}
+
 // ---- Unit tests: parse_arg_count ----
 
 #[test]

--- a/duke/tests/spring_boot_real_app.rs
+++ b/duke/tests/spring_boot_real_app.rs
@@ -106,16 +106,21 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 //     — computeIfAbsent/computeIfPresent/compute/merge/forEach/replaceAll plus
 //     putIfAbsent/getOrDefault/replace/containsValue/putAll — is registered on
 //     `java/util/Hashtable`, reusing the HashMap natives). That rung is CLEARED.
-//     The ladder now lands on `method not found:
-//     org/apache/commons/logging/impl/LogFactoryImpl.objectId(...)` — the next
-//     real blocker in commons-logging's LogFactoryImpl bootstrap (collections
-//     lane cleared; this is a different missing-method rung).
+//     The ladder previously landed on `method not found:
+//     org/apache/commons/logging/impl/LogFactoryImpl.objectId(...)`. That rung is
+//     now CLEARED: `objectId` is a `public static` method declared on the abstract
+//     superclass `LogFactory` and invoked via a Methodref bound to the subclass
+//     `LogFactoryImpl`. The invokestatic slow-path resolver now walks the super
+//     chain (JVMS §5.4.3.3) instead of flat-scanning the subclass, so the
+//     inherited static body resolves. The frontier advanced
+//     (objectId → java/io/Serializable): the ladder now lands on
+//     `class not found: java/io/Serializable`, the next real blocker.
 // If either boot advances past its pin, re-observe and update.
 // See docs/findings/2026-07-10-spring-boot-real-app.md.
 // Root cause (visible only via instrumentation of the reflection wrap):
 // `NoClassDefFoundError: java/util/EnumSet`, then `ExceptionInInitializerError`.
 const APP_BLOCKER: &str = "java exception: java/lang/reflect/InvocationTargetException";
-const LADDER_BLOCKER: &str = "method not found: org/apache/commons/logging/impl/LogFactoryImpl.objectId(Ljava/lang/Object;)Ljava/lang/String;";
+const LADDER_BLOCKER: &str = "class not found: java/io/Serializable";
 
 fn run_fixture(jar: &str) -> Output {
     let jar_path = spring_boot_fixture(jar);
@@ -199,14 +204,14 @@ fn spring_boot_app_surfaces_next_missing_capability_explicitly() {
 /// End-to-end CANARY for the commons-logging ladder fixture. Ignored until boot
 /// completes all rungs. Un-ignore when the happy path clears.
 #[test]
-#[ignore = "Blocked on missing \
-            org/apache/commons/logging/impl/LogFactoryImpl.objectId(Object)String in the \
-            LogFactoryImpl bootstrap (a NoSuchMethodError-territory blocker). The \
-            Hashtable.computeIfAbsent rung is now cleared: java/util/Hashtable registers the \
-            full Map-default native family (computeIfAbsent/computeIfPresent/compute/merge/\
-            forEach/replaceAll plus putIfAbsent/getOrDefault/replace/containsValue/putAll), so \
-            the LogFactoryImpl fallback advances past it; keep ignored until the ladder fixture \
-            completes. See docs/findings/2026-07-10-spring-boot-real-app.md"]
+#[ignore = "Blocked on 'class not found: java/io/Serializable' in the commons-logging \
+            bootstrap (a class-linkage blocker). The LogFactoryImpl.objectId rung is now \
+            cleared: objectId is a public static declared on the abstract superclass \
+            LogFactory and invoked via a Methodref bound to the subclass LogFactoryImpl; the \
+            invokestatic slow-path resolver now walks the super chain (JVMS §5.4.3.3) so the \
+            inherited static body resolves (frontier advanced objectId → java/io/Serializable); \
+            keep ignored until the ladder fixture completes. \
+            See docs/findings/2026-07-10-spring-boot-real-app.md"]
 fn spring_boot_ladder_boots_end_to_end() {
     let output = run_fixture(LADDER_JAR);
     let combined = combined_output(&output);


### PR DESCRIPTION
> **Fast-merge requested** — surgical correctness fix; the `Arc<str>` refactor lane owns `execution.rs` this wave and has been notified of the overlap, so merging early keeps the rebase trivial.

## Before

Calling a `public static` method that a class inherits from a superclass — invoked via a Methodref symbolically bound to the subclass — failed with `runtime error: method not found: <Subclass>.<method>`, even though the method is present one level up. This blocked the commons-logging ladder at `org/apache/commons/logging/impl/LogFactoryImpl.objectId(...)` (declared on the abstract superclass `LogFactory`).

## After

`invokestatic` now walks the superclass chain to resolve inherited static methods, matching JVMS §5.4.3.3. The commons-logging ladder advances past `objectId` to its next frontier (`class not found: java/io/Serializable`).

## How

In `crates/duke-interpreter/src/execution.rs`, the `invokestatic` slow-path resolver previously did a flat single-class scan of the callee class's method table. It now reuses the existing `resolve_method_in_hierarchy_lookup` helper (already used by invokevirtual/invokespecial) and rebinds the callee class to the class where the concrete body was found, so the invoked frame resolves its own constant pool and method index. `invokestatic` has no receiver, so a plain upward walk for a concrete matching name+descriptor is correct (no virtual dispatch). This is the static-dispatch analogue of the super-chain gap PR #1329 closed for virtual/native paths.

## Tests

- Adds regression test `invokestatic_resolves_inherited_static_method` (superclass declares a static, subclass invokes it via a subclass-bound Methodref) — fails on trunk, passes with the fix.
- Re-pins the commons-logging ladder blocker (`objectId` → `java/io/Serializable`).
- Full workspace: 3096 passed / 0 failed / 4 ignored; fmt, clippy (1.97.0, pedantic+nursery, `-D warnings`), and HelloWorld (class + jar modes) all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_011jcMqddLn2cYdbeSqv744o)_