### PR TITLE
StringBuilder.append(Object) + 13 shallow Spring Boot APP rungs

### DIFF
--- a/crates/duke-interpreter/src/native/java_lang.rs
+++ b/crates/duke-interpreter/src/native/java_lang.rs
@@ -4291,6 +4291,29 @@ pub(crate) fn native_sb_append_char(
     }
     Ok(Some(Slot::Reference(Some(this_ref))))
 }
+/// Native: `StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;`
+/// Appends `String.valueOf(obj)` — i.e. `obj.toString()`, or the literal
+/// `"null"` when the argument is null. Mirrors `native_string_value_of_object`
+/// by rendering the heap object via `heap_object_to_string` (the same
+/// toString-dispatch precedent used by `String.valueOf(Object)` and
+/// `PrintStream.println(Object)`).
+pub(crate) fn native_sb_append_object(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let append_str = match args.get(1) {
+        Some(Slot::Reference(Some(r))) => heap_object_to_string(heap.get(*r)?, *r),
+        _ => "null".to_string(),
+    };
+    let obj = heap.get_mut(this_ref)?;
+    if let Some(ref mut buf) = obj.string_value {
+        buf.push_str(&append_str);
+    }
+    Ok(Some(Slot::Reference(Some(this_ref))))
+}
 /// Native: `StringBuilder.toString()Ljava/lang/String;`
 pub(crate) fn native_sb_tostring(
     args: &[Slot],
@@ -4731,6 +4754,90 @@ pub(crate) fn native_string_index_of_char(
                     .as_deref()
                     .map(|s| s[..byte_pos].chars().count())
             })
+        });
+    let result = idx.and_then(|i| i32::try_from(i).ok()).unwrap_or(-1);
+    Ok(Some(Slot::Int(result)))
+}
+/// Native: `String.indexOf(int, int)I` — first occurrence of char (as Unicode
+/// code point) at or after `fromIndex`. A negative `fromIndex` is treated as 0;
+/// indices are counted in chars, matching `native_string_index_of_char`.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+pub(crate) fn native_string_index_of_char_from(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let ch = char::from_u32(extract_int_arg(args, 1)? as u32).unwrap_or('\0');
+    let from = extract_int_arg(args, 2).unwrap_or(0).max(0) as usize;
+    let idx = heap
+        .get(this_ref)?
+        .string_value
+        .as_deref()
+        .and_then(|s| {
+            s.chars()
+                .enumerate()
+                .skip(from)
+                .find(|(_, c)| *c == ch)
+                .map(|(i, _)| i)
+        });
+    let result = idx.and_then(|i| i32::try_from(i).ok()).unwrap_or(-1);
+    Ok(Some(Slot::Int(result)))
+}
+/// Native: `String.lastIndexOf(int)I` — last occurrence of char (as Unicode code
+/// point); indices are counted in chars, matching `native_string_index_of_char`.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+pub(crate) fn native_string_last_index_of_char(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let ch = char::from_u32(extract_int_arg(args, 1)? as u32).unwrap_or('\0');
+    let idx = heap
+        .get(this_ref)?
+        .string_value
+        .as_deref()
+        .and_then(|s| {
+            s.chars()
+                .enumerate()
+                .filter(|(_, c)| *c == ch)
+                .map(|(i, _)| i)
+                .last()
+        });
+    let result = idx.and_then(|i| i32::try_from(i).ok()).unwrap_or(-1);
+    Ok(Some(Slot::Int(result)))
+}
+/// Native: `String.lastIndexOf(int, int)I` — last occurrence of char (as Unicode
+/// code point) at or before `fromIndex`. A negative `fromIndex` yields -1; indices
+/// are counted in chars, matching `native_string_index_of_char`.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+pub(crate) fn native_string_last_index_of_char_from(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let this_ref = extract_ref_arg(args, 0)?;
+    let ch = char::from_u32(extract_int_arg(args, 1)? as u32).unwrap_or('\0');
+    let from = extract_int_arg(args, 2)?;
+    if from < 0 {
+        return Ok(Some(Slot::Int(-1)));
+    }
+    let from = from as usize;
+    let idx = heap
+        .get(this_ref)?
+        .string_value
+        .as_deref()
+        .and_then(|s| {
+            s.chars()
+                .enumerate()
+                .take(from + 1)
+                .filter(|(_, c)| *c == ch)
+                .map(|(i, _)| i)
+                .last()
         });
     let result = idx.and_then(|i| i32::try_from(i).ok()).unwrap_or(-1);
     Ok(Some(Slot::Int(result)))
@@ -5289,6 +5396,20 @@ pub(crate) fn native_reference_clear(
     let this_ref = extract_ref_arg(args, 0)?;
     heap.get_mut(this_ref)?.fields[0] = Slot::Reference(None);
     Ok(None)
+}
+
+/// `java/lang/ref/ReferenceQueue.poll()Ljava/lang/ref/Reference;` — always returns
+/// null. Duke's Reference model is non-collecting (see the block header above), so
+/// no reference is ever enqueued; a map that drains its queue simply observes it
+/// empty, which matches the "nothing has been GC'd" world Duke presents.
+pub(crate) fn native_reference_queue_poll(
+    args: &[Slot],
+    _heap: &mut duke_gc::Heap,
+    _out: &mut dyn Write,
+    _control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    let _ = extract_ref_arg(args, 0)?;
+    Ok(Some(Slot::Reference(None)))
 }
 
 // ─── java.lang.Module — minimal unnamed-module model ─────────────────────────

--- a/crates/duke-interpreter/src/native/java_util.rs
+++ b/crates/duke-interpreter/src/native/java_util.rs
@@ -4249,6 +4249,58 @@ pub(crate) fn native_properties_to_string(
     let string_ref = heap.allocate_string(rendered);
     Ok(Some(Slot::Reference(Some(string_ref))))
 }
+/// Native: `Collections.newSetFromMap(Map)Set` — returns a set backed by the
+/// given map. `Map.newSetFromMap`'s contract requires the supplied map to be
+/// empty, so the backing storage starts empty; Duke returns a fresh field-backed
+/// `HashSet`, which preserves insertion order and supports the full Set surface.
+/// This is the same simplification Duke already applies for `WeakHashMap`
+/// (backing type is not observable through the returned view in normal usage).
+pub(crate) fn native_collections_new_set_from_map(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    out: &mut dyn Write,
+    control: &mut NativeControl,
+) -> Result<Option<Slot>> {
+    // The map argument is required (NPE on null) but, per the empty-map
+    // precondition, its contents do not seed the returned set.
+    let _map_ref = extract_ref_arg(args, 0)?;
+    let set_ref = heap.allocate("java/util/HashSet".to_string(), 1);
+    native_hashset_init(&[Slot::Reference(Some(set_ref))], heap, out, control)?;
+    Ok(Some(Slot::Reference(Some(set_ref))))
+}
+/// Native: `Collections.addAll(Collection, Object[])Z` — adds every array element
+/// to the target collection by invoking its `add(Object)` (so it works for any
+/// Collection impl). Returns 1 if the collection changed.
+pub(crate) fn native_collections_add_all(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    output: &mut dyn Write,
+    _control: &mut NativeControl,
+    ops: &mut dyn CallbackOps,
+) -> Result<Option<Slot>> {
+    let collection_ref = extract_ref_arg(args, 0)?;
+    let collection_class = heap.get(collection_ref)?.class_name.clone();
+    let elements: Vec<Slot> = match extract_slot_arg(args, 1) {
+        Slot::Reference(Some(array_ref)) => heap.get(array_ref)?.fields.clone(),
+        Slot::Reference(None) => return Err(Error::NullPointerException),
+        _ => Vec::new(),
+    };
+    let mut modified = false;
+    for element in elements {
+        let added = ops.invoke(
+            heap,
+            output,
+            &collection_class,
+            "add",
+            "(Ljava/lang/Object;)Z",
+            vec![Slot::Reference(Some(collection_ref)), element],
+        )?;
+        if matches!(added, Some(Slot::Int(1))) {
+            modified = true;
+        }
+    }
+    Ok(Some(Slot::Int(i32::from(modified))))
+}
 pub(crate) fn native_set_of(
     args: &[Slot],
     heap: &mut duke_gc::Heap,
@@ -4343,6 +4395,62 @@ pub(crate) fn native_hashset_init_from_collection(
         )?;
     }
     Ok(None)
+}
+/// Native: `HashSet.addAll(Collection)Z` — adds every element of the source
+/// collection, skipping duplicates. Returns 1 if the set changed. Elements are
+/// pulled via the source's `toArray()` (mirroring `native_hashset_init_from_collection`),
+/// so any Collection works; each element is routed through `native_hashset_add`
+/// for dedup.
+pub(crate) fn native_hashset_add_all(
+    args: &[Slot],
+    heap: &mut duke_gc::Heap,
+    output: &mut dyn Write,
+    control: &mut NativeControl,
+    ops: &mut dyn CallbackOps,
+) -> Result<Option<Slot>> {
+    let mut this_ref = extract_ref_arg(args, 0)?;
+    let collection_ref = extract_ref_arg(args, 1)?;
+
+    let collection_class = heap.get(collection_ref)?.class_name.clone();
+    let elements: Vec<Slot> = if collection_class == "java/util/HashSet" {
+        heap.get(collection_ref)?
+            .fields
+            .iter()
+            .skip(1)
+            .copied()
+            .collect()
+    } else {
+        let array_slot = ops.invoke(
+            heap,
+            output,
+            &collection_class,
+            "toArray",
+            "()[Ljava/lang/Object;",
+            vec![Slot::Reference(Some(collection_ref))],
+        )?;
+        let Some(Slot::Reference(Some(array_ref))) = array_slot else {
+            return Err(Error::TypeMismatch {
+                expected: "Reference",
+                got: "other",
+            });
+        };
+        patch_forwarded_ref_if_needed(heap, &mut this_ref);
+        heap.get(array_ref)?.fields.clone()
+    };
+
+    let mut modified = false;
+    for element in elements {
+        let added = native_hashset_add(
+            &[Slot::Reference(Some(this_ref)), element],
+            heap,
+            output,
+            control,
+        )?;
+        if matches!(added, Some(Slot::Int(1))) {
+            modified = true;
+        }
+    }
+    Ok(Some(Slot::Int(i32::from(modified))))
 }
 /// Native: `HashSet.add(Object)Z` — adds element if not already present.
 /// Returns 1 if added, 0 if element was already in the set.

--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -6170,6 +6170,24 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
     );
     registry.natives_mut().register(
         "java/lang/String",
+        "indexOf",
+        "(II)I",
+        native_string_index_of_char_from,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "lastIndexOf",
+        "(I)I",
+        native_string_last_index_of_char,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
+        "lastIndexOf",
+        "(II)I",
+        native_string_last_index_of_char_from,
+    );
+    registry.natives_mut().register(
+        "java/lang/String",
         "lastIndexOf",
         "(Ljava/lang/String;)I",
         native_string_last_index_of,
@@ -6293,6 +6311,13 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         "append",
         "(C)Ljava/lang/StringBuilder;",
         native_sb_append_char,
+    );
+    // StringBuilder.append(Object)
+    registry.natives_mut().register(
+        "java/lang/StringBuilder",
+        "append",
+        "(Ljava/lang/Object;)Ljava/lang/StringBuilder;",
+        native_sb_append_object,
     );
     // StringBuilder.toString()
     registry.natives_mut().register(
@@ -7018,6 +7043,28 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         native_arrays_as_list,
     );
 
+    // java/util/AbstractMap — abstract Map ancestor. Real map classes loaded from
+    // a jar chain their `<init>` to `AbstractMap.<init>()V` (a protected no-op),
+    // so a synthetic class with an Object-style no-op constructor lets that
+    // super() call resolve. Concrete AbstractMap helper methods are not provided;
+    // subclasses that Duke runs override the surface they use.
+    let abstract_map_ctx = ClassContext {
+        class_name: "java/util/AbstractMap".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: vec!["java/util/Map".to_string()],
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    registry.register(abstract_map_ctx);
+    registry
+        .natives_mut()
+        .register("java/util/AbstractMap", "<init>", "()V", native_object_init);
+
     // java/util/HashMap — hash map backed by flat key/value pair list in fields
     // fields[0] = Int(size), fields[1]=key0, fields[2]=val0, fields[3]=key1, ...
     let hashmap_ctx = ClassContext {
@@ -7043,6 +7090,13 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
     registry
         .natives_mut()
         .register("java/util/HashMap", "<init>", "()V", native_hashmap_init);
+    // Initial-capacity / capacity+loadFactor constructors ignore their hints.
+    registry
+        .natives_mut()
+        .register("java/util/HashMap", "<init>", "(I)V", native_hashmap_init);
+    registry
+        .natives_mut()
+        .register("java/util/HashMap", "<init>", "(IF)V", native_hashmap_init);
     registry.natives_mut().register(
         "java/util/HashMap",
         "put",
@@ -7247,6 +7301,274 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
     );
     registry.natives_mut().register_callback(
         "java/util/Hashtable",
+        "replaceAll",
+        "(Ljava/util/function/BiFunction;)V",
+        native_hashmap_replace_all,
+    );
+
+    // java/util/WeakHashMap — weak-keyed map. Duke does not model GC-driven key
+    // eviction, so this deliberately reuses the HashMap layout and natives, the
+    // same way java/util/Hashtable does. Behaviour is that of a plain HashMap,
+    // which is correct for the bootstraps that allocate a WeakHashMap as a cache.
+    let weak_hashmap_ctx = ClassContext {
+        class_name: "java/util/WeakHashMap".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "size".to_string(),
+            descriptor: "I".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: vec![
+            "java/util/Map".to_string(),
+            "java/util/Collection".to_string(),
+        ],
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    registry.register(weak_hashmap_ctx);
+    for (method, descriptor, handler) in [
+        ("<init>", "()V", native_hashmap_init as NativeHandler),
+        (
+            "put",
+            "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+            native_hashmap_put as NativeHandler,
+        ),
+        (
+            "get",
+            "(Ljava/lang/Object;)Ljava/lang/Object;",
+            native_hashmap_get as NativeHandler,
+        ),
+        (
+            "containsKey",
+            "(Ljava/lang/Object;)Z",
+            native_hashmap_contains_key as NativeHandler,
+        ),
+        ("size", "()I", native_hashmap_size as NativeHandler),
+        (
+            "remove",
+            "(Ljava/lang/Object;)Ljava/lang/Object;",
+            native_hashmap_remove as NativeHandler,
+        ),
+        ("isEmpty", "()Z", native_hashmap_is_empty as NativeHandler),
+        (
+            "keySet",
+            "()Ljava/util/Set;",
+            native_hashmap_key_set as NativeHandler,
+        ),
+        (
+            "values",
+            "()Ljava/util/Collection;",
+            native_hashmap_values as NativeHandler,
+        ),
+        (
+            "entrySet",
+            "()Ljava/util/Set;",
+            native_hashmap_entry_set as NativeHandler,
+        ),
+        ("clear", "()V", native_hashmap_clear as NativeHandler),
+        (
+            "putIfAbsent",
+            "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+            native_hashmap_put_if_absent as NativeHandler,
+        ),
+        (
+            "getOrDefault",
+            "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+            native_hashmap_get_or_default as NativeHandler,
+        ),
+        (
+            "replace",
+            "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+            native_hashmap_replace as NativeHandler,
+        ),
+        (
+            "containsValue",
+            "(Ljava/lang/Object;)Z",
+            native_hashmap_contains_value as NativeHandler,
+        ),
+        (
+            "putAll",
+            "(Ljava/util/Map;)V",
+            native_hashmap_put_all as NativeHandler,
+        ),
+    ] {
+        registry
+            .natives_mut()
+            .register("java/util/WeakHashMap", method, descriptor, handler);
+    }
+    // Map-default callback natives (invoke Java lambdas) — must use register_callback.
+    registry.natives_mut().register_callback(
+        "java/util/WeakHashMap",
+        "computeIfAbsent",
+        "(Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;",
+        native_hashmap_compute_if_absent,
+    );
+    registry.natives_mut().register_callback(
+        "java/util/WeakHashMap",
+        "computeIfPresent",
+        "(Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;",
+        native_hashmap_compute_if_present,
+    );
+    registry.natives_mut().register_callback(
+        "java/util/WeakHashMap",
+        "compute",
+        "(Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;",
+        native_hashmap_compute,
+    );
+    registry.natives_mut().register_callback(
+        "java/util/WeakHashMap",
+        "merge",
+        "(Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;",
+        native_hashmap_merge,
+    );
+    registry.natives_mut().register_callback(
+        "java/util/WeakHashMap",
+        "forEach",
+        "(Ljava/util/function/BiConsumer;)V",
+        native_hashmap_for_each,
+    );
+    registry.natives_mut().register_callback(
+        "java/util/WeakHashMap",
+        "replaceAll",
+        "(Ljava/util/function/BiFunction;)V",
+        native_hashmap_replace_all,
+    );
+
+    // java/util/IdentityHashMap — reference-equality map. Duke's shared map key
+    // comparison (`slots_equal`) already compares general object keys by identity
+    // (only String/Class/UUID/boxed keys fall back to value equality, which
+    // IdentityHashMap is not used with in these bootstraps), so IdentityHashMap
+    // reuses the HashMap layout and natives, like Hashtable/WeakHashMap do. The
+    // `(I)V` initial-capacity constructor ignores the capacity hint.
+    let identity_hashmap_ctx = ClassContext {
+        class_name: "java/util/IdentityHashMap".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "size".to_string(),
+            descriptor: "I".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: vec![
+            "java/util/Map".to_string(),
+            "java/util/Collection".to_string(),
+        ],
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    registry.register(identity_hashmap_ctx);
+    for (method, descriptor, handler) in [
+        ("<init>", "()V", native_hashmap_init as NativeHandler),
+        // Initial-capacity constructor; the capacity hint is ignored.
+        ("<init>", "(I)V", native_hashmap_init as NativeHandler),
+        (
+            "put",
+            "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+            native_hashmap_put as NativeHandler,
+        ),
+        (
+            "get",
+            "(Ljava/lang/Object;)Ljava/lang/Object;",
+            native_hashmap_get as NativeHandler,
+        ),
+        (
+            "containsKey",
+            "(Ljava/lang/Object;)Z",
+            native_hashmap_contains_key as NativeHandler,
+        ),
+        ("size", "()I", native_hashmap_size as NativeHandler),
+        (
+            "remove",
+            "(Ljava/lang/Object;)Ljava/lang/Object;",
+            native_hashmap_remove as NativeHandler,
+        ),
+        ("isEmpty", "()Z", native_hashmap_is_empty as NativeHandler),
+        (
+            "keySet",
+            "()Ljava/util/Set;",
+            native_hashmap_key_set as NativeHandler,
+        ),
+        (
+            "values",
+            "()Ljava/util/Collection;",
+            native_hashmap_values as NativeHandler,
+        ),
+        (
+            "entrySet",
+            "()Ljava/util/Set;",
+            native_hashmap_entry_set as NativeHandler,
+        ),
+        ("clear", "()V", native_hashmap_clear as NativeHandler),
+        (
+            "putIfAbsent",
+            "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+            native_hashmap_put_if_absent as NativeHandler,
+        ),
+        (
+            "getOrDefault",
+            "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+            native_hashmap_get_or_default as NativeHandler,
+        ),
+        (
+            "replace",
+            "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+            native_hashmap_replace as NativeHandler,
+        ),
+        (
+            "containsValue",
+            "(Ljava/lang/Object;)Z",
+            native_hashmap_contains_value as NativeHandler,
+        ),
+        (
+            "putAll",
+            "(Ljava/util/Map;)V",
+            native_hashmap_put_all as NativeHandler,
+        ),
+    ] {
+        registry
+            .natives_mut()
+            .register("java/util/IdentityHashMap", method, descriptor, handler);
+    }
+    // Map-default callback natives (invoke Java lambdas) — must use register_callback.
+    registry.natives_mut().register_callback(
+        "java/util/IdentityHashMap",
+        "computeIfAbsent",
+        "(Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;",
+        native_hashmap_compute_if_absent,
+    );
+    registry.natives_mut().register_callback(
+        "java/util/IdentityHashMap",
+        "computeIfPresent",
+        "(Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;",
+        native_hashmap_compute_if_present,
+    );
+    registry.natives_mut().register_callback(
+        "java/util/IdentityHashMap",
+        "compute",
+        "(Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;",
+        native_hashmap_compute,
+    );
+    registry.natives_mut().register_callback(
+        "java/util/IdentityHashMap",
+        "merge",
+        "(Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;",
+        native_hashmap_merge,
+    );
+    registry.natives_mut().register_callback(
+        "java/util/IdentityHashMap",
+        "forEach",
+        "(Ljava/util/function/BiConsumer;)V",
+        native_hashmap_for_each,
+    );
+    registry.natives_mut().register_callback(
+        "java/util/IdentityHashMap",
         "replaceAll",
         "(Ljava/util/function/BiFunction;)V",
         native_hashmap_replace_all,
@@ -7604,6 +7926,13 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
     registry
         .natives_mut()
         .register("java/util/HashSet", "<init>", "()V", native_hashset_init);
+    // Initial-capacity / capacity+loadFactor constructors ignore their hints.
+    registry
+        .natives_mut()
+        .register("java/util/HashSet", "<init>", "(I)V", native_hashset_init);
+    registry
+        .natives_mut()
+        .register("java/util/HashSet", "<init>", "(IF)V", native_hashset_init);
     registry.natives_mut().register_callback(
         "java/util/HashSet",
         "<init>",
@@ -7615,6 +7944,12 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         "add",
         "(Ljava/lang/Object;)Z",
         native_hashset_add,
+    );
+    registry.natives_mut().register_callback(
+        "java/util/HashSet",
+        "addAll",
+        "(Ljava/util/Collection;)Z",
+        native_hashset_add_all,
     );
     registry.natives_mut().register(
         "java/util/HashSet",
@@ -7697,6 +8032,119 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         "next",
         "()Ljava/lang/Object;",
         native_hashset_iter_next,
+    );
+
+    // java/util/LinkedHashSet — insertion-ordered Set. In real Java it extends
+    // HashSet; Duke's HashSet natives already store elements in insertion order
+    // in the object's fields (fields[0] = size, fields[1..] = elements), so
+    // LinkedHashSet reuses the exact same native family. The shared
+    // duke/util/HashSetIterator walks any set ref's fields, so iteration
+    // preserves insertion order automatically.
+    let linked_hashset_ctx = ClassContext {
+        class_name: "java/util/LinkedHashSet".to_string(),
+        super_class: Some("java/util/HashSet".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: vec![FieldEntry {
+            name: "size".to_string(),
+            descriptor: "I".to_string(),
+            is_static: false,
+        }],
+        static_fields: Vec::new(),
+        instance_field_count: 1,
+        interfaces: vec![
+            "java/util/Set".to_string(),
+            "java/util/Collection".to_string(),
+            "java/lang/Iterable".to_string(),
+        ],
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    registry.register(linked_hashset_ctx);
+    registry.natives_mut().register(
+        "java/util/LinkedHashSet",
+        "<init>",
+        "()V",
+        native_hashset_init,
+    );
+    // Initial-capacity / capacity+loadFactor constructors ignore their hints.
+    registry.natives_mut().register(
+        "java/util/LinkedHashSet",
+        "<init>",
+        "(I)V",
+        native_hashset_init,
+    );
+    registry.natives_mut().register(
+        "java/util/LinkedHashSet",
+        "<init>",
+        "(IF)V",
+        native_hashset_init,
+    );
+    registry.natives_mut().register_callback(
+        "java/util/LinkedHashSet",
+        "<init>",
+        "(Ljava/util/Collection;)V",
+        native_hashset_init_from_collection,
+    );
+    registry.natives_mut().register(
+        "java/util/LinkedHashSet",
+        "add",
+        "(Ljava/lang/Object;)Z",
+        native_hashset_add,
+    );
+    registry.natives_mut().register_callback(
+        "java/util/LinkedHashSet",
+        "addAll",
+        "(Ljava/util/Collection;)Z",
+        native_hashset_add_all,
+    );
+    registry.natives_mut().register(
+        "java/util/LinkedHashSet",
+        "contains",
+        "(Ljava/lang/Object;)Z",
+        native_hashset_contains,
+    );
+    registry.natives_mut().register(
+        "java/util/LinkedHashSet",
+        "remove",
+        "(Ljava/lang/Object;)Z",
+        native_hashset_remove,
+    );
+    registry.natives_mut().register(
+        "java/util/LinkedHashSet",
+        "size",
+        "()I",
+        native_hashset_size,
+    );
+    registry.natives_mut().register(
+        "java/util/LinkedHashSet",
+        "isEmpty",
+        "()Z",
+        native_hashset_is_empty,
+    );
+    registry.natives_mut().register(
+        "java/util/LinkedHashSet",
+        "iterator",
+        "()Ljava/util/Iterator;",
+        native_hashset_iterator,
+    );
+    registry.natives_mut().register(
+        "java/util/LinkedHashSet",
+        "toArray",
+        "()[Ljava/lang/Object;",
+        native_collection_to_array,
+    );
+    registry.natives_mut().register(
+        "java/util/LinkedHashSet",
+        "toArray",
+        "([Ljava/lang/Object;)[Ljava/lang/Object;",
+        native_collection_to_array_with_seed_array,
+    );
+    registry.natives_mut().register(
+        "java/util/LinkedHashSet",
+        "stream",
+        "()Ljava/util/stream/Stream;",
+        native_hashset_stream,
     );
 
     // java/util/Collections — static utility class
@@ -8228,6 +8676,20 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         native_collections_swap,
     );
 
+    // Collections.newSetFromMap(map) — set backed by the (empty) map
+    registry.natives_mut().register(
+        "java/util/Collections",
+        "newSetFromMap",
+        "(Ljava/util/Map;)Ljava/util/Set;",
+        native_collections_new_set_from_map,
+    );
+    // Collections.addAll(Collection, T...) — bulk add of array elements
+    registry.natives_mut().register_callback(
+        "java/util/Collections",
+        "addAll",
+        "(Ljava/util/Collection;[Ljava/lang/Object;)Z",
+        native_collections_add_all,
+    );
     // Collections.unmodifiableMap(map) — wraps in UnmodifiableMap
     registry.natives_mut().register(
         "java/util/Collections",
@@ -14017,6 +14479,45 @@ pub fn bootstrap_stdlib(registry: &mut ClassRegistry, heap: &mut duke_gc::Heap) 
         "<init>",
         "(Ljava/lang/Object;)V",
         native_reference_init,
+    );
+    // WeakReference(referent, queue): the queue is accepted and ignored — Duke's
+    // non-collecting model never enqueues, so only the referent slot is stored.
+    registry.natives_mut().register(
+        "java/lang/ref/WeakReference",
+        "<init>",
+        "(Ljava/lang/Object;Ljava/lang/ref/ReferenceQueue;)V",
+        native_reference_init,
+    );
+
+    // java/lang/ref/ReferenceQueue — non-collecting stub. Nothing is ever enqueued
+    // (Duke never clears a Reference implicitly), so the constructor is a no-op and
+    // poll() always returns null. Real WeakHashMap-style classes loaded from a jar
+    // allocate a queue and drain it; observing it empty is the correct behaviour
+    // in a world where no referent has been reclaimed.
+    let reference_queue_ctx = ClassContext {
+        class_name: "java/lang/ref/ReferenceQueue".to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        interfaces: Vec::new(),
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Synthetic,
+    };
+    registry.register(reference_queue_ctx);
+    registry.natives_mut().register(
+        "java/lang/ref/ReferenceQueue",
+        "<init>",
+        "()V",
+        native_object_init,
+    );
+    registry.natives_mut().register(
+        "java/lang/ref/ReferenceQueue",
+        "poll",
+        "()Ljava/lang/ref/Reference;",
+        native_reference_queue_poll,
     );
 
     // java/lang/Class.isAssignableFrom — hierarchy-walking reflection predicate

--- a/docs/findings/2026-07-10-spring-boot-real-app.md
+++ b/docs/findings/2026-07-10-spring-boot-real-app.md
@@ -483,3 +483,92 @@ That is the **java.util.concurrent / interpreter lenient-dispatch lane**, outsid
 the java.time family, so it is pinned rather than fixed here.
 `APP_BLOCKER` is now `"duke: runtime error: operand stack underflow"`.
 `LADDER_BLOCKER` is unchanged (`"class not found: org/apache/logging/log4j/MarkerManager"`).
+
+---
+
+## Session 2026-07-13 — `StringBuilder.append(Object)` + a run of shallow java.lang/java.util APP rungs
+
+**Mission:** implement `java/lang/StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;`, then climb as many shallow APP rungs as possible.
+
+**toString-dispatch mechanism (the crux of `append(Object)`).** Real
+`StringBuilder.append(Object o)` == `append(String.valueOf(o))` == `"null"` when
+`o == null`, else `o.toString()`. Calling a Java `toString()` from native code
+would need interpreter re-entry — but Duke has an existing precedent that does
+**not** re-enter: the free function `heap_object_to_string(&HeapObject, u64)` in
+`native/common.rs`. It renders String / boxed primitives (Integer/Long/Double/
+Float/Boolean/Character) / Class / UUID directly from the heap object, falling
+back to `class@hex`. `String.valueOf(Object)` (`native_string_value_of_object`)
+and `PrintStream.println(Object)`/`print(Object)` all use it. The new
+`native_sb_append_object` **mirrors `native_string_value_of_object` exactly**:
+null → append literal `"null"`; otherwise append `heap_object_to_string(...)`;
+return `this`. No forbidden file was edited (all `native/*.rs` are `include!`d
+into one module, so the helper is directly callable from `java_lang.rs`).
+
+**Rungs cleared this session (each a small native mirroring existing ones):**
+- `java/lang/StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;`
+  — `native_sb_append_object` (toString dispatch via `heap_object_to_string`).
+- `java/lang/String.indexOf(II)I` — `native_string_index_of_char_from`.
+- `java/lang/String.lastIndexOf(I)I` — `native_string_last_index_of_char`.
+- `java/lang/String.lastIndexOf(II)I` — `native_string_last_index_of_char_from`.
+  (All char-index natives mirror `native_string_index_of_char`; indices counted
+  in chars, consistent with the existing char `indexOf`.)
+- `java/util/LinkedHashSet` — synthetic class reusing the entire `HashSet` native
+  family + the shared `duke/util/HashSetIterator`. Duke's HashSet already stores
+  elements in insertion order (a flat field list), so insertion-ordered iteration
+  is automatic. `<init>()V/(I)V/(IF)V`, add/addAll/contains/remove/size/isEmpty/
+  iterator/toArray/stream all registered.
+- `java/util/WeakHashMap` — synthetic class reusing the full `HashMap` native
+  family (incl. the Map-default callback family), exactly like `Hashtable` does.
+  Duke does not model GC-driven key eviction, so it behaves as a plain HashMap —
+  the same documented simplification pattern.
+- `java/util/IdentityHashMap` — synthetic class reusing the `HashMap` native
+  family, incl. the `<init>(I)V` capacity ctor. This is *faithful*, not just a
+  simplification: Duke's shared map key comparison (`slots_equal`) already
+  compares general object keys by **identity** (`ra == rb`), only falling back to
+  value equality for String/Class/UUID/boxed keys, which IdentityHashMap is not
+  used with in these bootstraps.
+- `java/util/AbstractMap` — synthetic class with a no-op `<init>()V`
+  (`native_object_init`). A real map class loaded from the jar chains its `<init>`
+  to `AbstractMap.<init>()V`; the synthetic super lets that `super()` resolve.
+- `java/util/HashMap.<init>(I)V` and `(IF)V`, `java/util/HashSet.<init>(I)V` and
+  `(IF)V`, `java/util/LinkedHashSet.<init>(I)V` and `(IF)V` — capacity/loadFactor
+  hints ignored, all mapped to the existing no-arg init native.
+- `java/util/HashSet.addAll(Ljava/util/Collection;)Z` — `native_hashset_add_all`
+  (pulls elements via the source's `toArray()`, mirroring
+  `native_hashset_init_from_collection`; routes each through `native_hashset_add`
+  for dedup; returns whether the set changed). Also registered on LinkedHashSet.
+- `java/util/Collections.addAll(Ljava/util/Collection;[Ljava/lang/Object;)Z` —
+  `native_collections_add_all` (invokes `add(Object)` on the target collection
+  for each array element, so any Collection impl works).
+- `java/util/Collections.newSetFromMap(Ljava/util/Map;)Ljava/util/Set;` —
+  `native_collections_new_set_from_map`. `newSetFromMap`'s contract requires the
+  supplied map to be empty, so the returned set starts empty; Duke returns a
+  fresh field-backed `HashSet` (same non-observable-backing-type simplification
+  as WeakHashMap).
+- `java/lang/ref/ReferenceQueue` — non-collecting stub: no-op `<init>()V`,
+  `poll()` always returns null (Duke never enqueues, matching its existing
+  non-collecting Reference model). Plus the two-arg
+  `WeakReference(referent, ReferenceQueue)` constructor (queue accepted +
+  ignored, referent stored via `native_reference_init`).
+
+**New APP frontier (HANDOFF — a real subsystem, pinned not fixed).** After the
+rungs above, the app boots far enough to fail *inside a reflectively-invoked
+method*. `native_reflect_method_invoke` catches the target's `JavaException` and
+re-throws it as `InvocationTargetException`, **discarding the cause's class name**,
+so the only visible output is the generic
+`duke: runtime error: java exception: java/lang/reflect/InvocationTargetException`.
+Temporarily instrumenting that catch arm (peeking the uncaught-exception ref's
+detail message via `take_uncaught_java_exception_ref`) revealed the underlying
+cause: `NoClassDefFoundError: java/util/EnumSet`. Registering an empty synthetic
+`java/util/EnumSet` only uncovers a deeper `ExceptionInInitializerError` from an
+enum/config static initializer that uses EnumSet's Class-typed factories
+(`noneOf`/`allOf`/`range`/`of`, which need enum-constant reflection and
+ordinal-based bit-set storage). That is a genuine subsystem — enum reflection +
+EnumSet ordinal semantics — not a one-function mirror, so the app is pinned here.
+All instrumentation was reverted; `reflect.rs` is byte-for-byte unchanged.
+
+`APP_BLOCKER` is now `"java exception: java/lang/reflect/InvocationTargetException"`
+(root cause `NoClassDefFoundError: java/util/EnumSet`, then
+`ExceptionInInitializerError`, both documented in the test).
+`LADDER_BLOCKER` is unchanged
+(`"method not found: org/apache/commons/logging/impl/LogFactoryImpl.objectId(Ljava/lang/Object;)Ljava/lang/String;"`).

--- a/duke/tests/spring_boot_real_app.rs
+++ b/duke/tests/spring_boot_real_app.rs
@@ -59,12 +59,35 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 //     then surfaced — and this lane cleared — several previously-swallowed rungs:
 //     `java/lang/Record.<init>` (now registered), a synthetic
 //     `java/util/concurrent/LinkedBlockingQueue` (FIFO queue with drainTo/clear),
-//     and `java/lang/InheritableThreadLocal` (ThreadLocal subclass). The app now
-//     lands on `method not found: java/lang/StringBuilder.append(Ljava/lang/
-//     Object;)Ljava/lang/StringBuilder;` — the StringBuilder `append(Object)`
-//     overload (which must String.valueOf/`toString` its argument) is not yet a
-//     native. That is a java.lang lane blocker (a new toString-dispatching native
-//     in native/java_lang.rs), out of the j.u.c./java_util/dispatch scope here.
+//     and `java/lang/InheritableThreadLocal` (ThreadLocal subclass). The
+//     `StringBuilder.append(Object)` rung is now CLEARED: a new
+//     `native_sb_append_object` appends `String.valueOf(arg)` by rendering the
+//     argument through `heap_object_to_string` — the same toString-dispatch
+//     precedent `String.valueOf(Object)` and `PrintStream.println(Object)` use.
+//     The app then climbed a run of shallow java.lang/java.util rungs, all
+//     CLEARED this session: `String.indexOf(II)I`, `String.lastIndexOf(I)I` and
+//     `String.lastIndexOf(II)I` (char-index natives); synthetic
+//     `java/util/LinkedHashSet`, `java/util/WeakHashMap` and
+//     `java/util/IdentityHashMap` (reuse the HashSet / HashMap native families —
+//     Duke's map key comparison is already identity-based for general objects, so
+//     IdentityHashMap is faithful); a synthetic `java/util/AbstractMap` with a
+//     no-op `<init>` (jar-loaded map subclasses chain super() to it); the
+//     initial-capacity `<init>(I)V`/`(IF)V` constructors on HashMap/HashSet/
+//     LinkedHashSet (capacity hint ignored); `HashSet.addAll(Collection)`,
+//     `Collections.addAll(Collection, Object[])` and
+//     `Collections.newSetFromMap(Map)` (returns a fresh field-backed HashSet,
+//     matching the empty-map contract); and a non-collecting
+//     `java/lang/ref/ReferenceQueue` (no-op `<init>`, `poll()` always null) plus
+//     the two-arg `WeakReference(referent, queue)` constructor. The app now boots
+//     far enough to fail inside a *reflectively-invoked* method, so the visible
+//     first blocker is an uncaught `java/lang/reflect/InvocationTargetException`
+//     (reflection wraps the target throwable and discards its class). Instrumenting
+//     the wrap shows the underlying cause is `NoClassDefFoundError:
+//     java/util/EnumSet`; registering EnumSet only uncovers a deeper
+//     `ExceptionInInitializerError` from an enum/config static initializer that
+//     uses EnumSet's Class-typed factories (`noneOf`/`allOf`/`range`, which need
+//     enum-constant reflection and ordinal bit-set storage). That is a real
+//     subsystem, not a shallow method mirror, so the app is pinned here.
 //   * LADDER cleared the commons-logging `LogFactory.newStandardFactory`
 //     `Class.forName("...SLF4JProvider", false, cl)` availability probe: the
 //     3-arg `Class.forName` native was eagerly computing the class key (which
@@ -89,8 +112,9 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 //     lane cleared; this is a different missing-method rung).
 // If either boot advances past its pin, re-observe and update.
 // See docs/findings/2026-07-10-spring-boot-real-app.md.
-const APP_BLOCKER: &str =
-    "method not found: java/lang/StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;";
+// Root cause (visible only via instrumentation of the reflection wrap):
+// `NoClassDefFoundError: java/util/EnumSet`, then `ExceptionInInitializerError`.
+const APP_BLOCKER: &str = "java exception: java/lang/reflect/InvocationTargetException";
 const LADDER_BLOCKER: &str = "method not found: org/apache/commons/logging/impl/LogFactoryImpl.objectId(Ljava/lang/Object;)Ljava/lang/String;";
 
 fn run_fixture(jar: &str) -> Output {
@@ -120,14 +144,17 @@ fn combined_output(output: &Output) -> String {
 /// End-to-end CANARY for the real Spring Boot app fixture. Ignored until boot
 /// reaches the started-application line. Un-ignore when the happy path clears.
 #[test]
-#[ignore = "Blocked on 'method not found: java/lang/StringBuilder.append(Ljava/lang/Object;)\
-            Ljava/lang/StringBuilder;' — the StringBuilder append(Object) overload is not yet a \
-            native (a java.lang lane blocker: it must String.valueOf/toString its argument). \
-            The logback COWArrayList.addIfAbsent operand-stack-underflow rung is now cleared by \
-            honest method dispatch (catchable NoSuchMethodError) plus a synthetic \
-            CopyOnWriteArrayList/LinkedBlockingQueue/InheritableThreadLocal/Record; keep ignored \
-            until the Spring Boot app boot completes. \
-            See docs/findings/2026-07-10-spring-boot-real-app.md"]
+#[ignore = "Blocked on an uncaught java/lang/reflect/InvocationTargetException whose underlying \
+            cause (visible only via instrumentation of the reflection wrap) is \
+            NoClassDefFoundError: java/util/EnumSet, which in turn uncovers an \
+            ExceptionInInitializerError from an enum/config static initializer using EnumSet's \
+            Class-typed factories (noneOf/allOf/range) — a real enum-reflection/ordinal-bitset \
+            subsystem, not a shallow method mirror. The StringBuilder append(Object) rung plus a \
+            run of shallow java.lang/java.util rungs (String.indexOf(II)/lastIndexOf(I)/(II); \
+            synthetic LinkedHashSet/WeakHashMap/IdentityHashMap/AbstractMap; capacity ctors on \
+            HashMap/HashSet; HashSet.addAll; Collections.addAll/newSetFromMap; non-collecting \
+            ReferenceQueue) are now cleared; keep ignored until the Spring Boot app boot \
+            completes. See docs/findings/2026-07-10-spring-boot-real-app.md"]
 fn spring_boot_app_boots_end_to_end() {
     let output = run_fixture(APP_JAR);
     let combined = combined_output(&output);


### PR DESCRIPTION
## Before / After

**Before:** running the Spring Boot real-app fixture died immediately with `method not found: java/lang/StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;` — the JVM had every primitive `append` overload but not the `Object` one, so any `append(someObject)` in library code (logback, Spring init) hit a wall.

**After:** `append(Object)` works (rendering `String.valueOf(obj)`, with `null` → `"null"`), and 13 shallow `java.lang` / `java.util` rungs are cleared. The app now boots much deeper — through commons-logging and collection setup — until it hits an `InvocationTargetException` rooted in `java.util.EnumSet`, which is a genuine enum-reflection subsystem rather than a one-method gap. That frontier is pinned honestly for the next wave.

## How

- **`StringBuilder.append(Object)`** — new `native_sb_append_object` in `native/java_lang.rs`, mirroring the existing non-reentrant `String.valueOf(Object)` / `PrintStream.println(Object)` precedent: it renders the argument via the shared `heap_object_to_string` helper (String / boxed primitive / Class / UUID), appends `"null"` for a null ref, and returns `this`. Registered in `stdlib.rs` with descriptor `(Ljava/lang/Object;)Ljava/lang/StringBuilder;`.
- **String rungs** — `indexOf(II)`, `lastIndexOf(I)`, `lastIndexOf(II)`.
- **Collection rungs** — synthetic `LinkedHashSet`, `WeakHashMap`, `IdentityHashMap` (identity-compare, faithful), `AbstractMap`; capacity/load-factor ctors for `HashMap` / `HashSet` / `LinkedHashSet`; `HashSet.addAll(Collection)`; `Collections.addAll(...)` and `Collections.newSetFromMap(Map)`.
- **Ref rungs** — non-collecting `ReferenceQueue` (no-op init, `poll()` → null) and the two-arg `WeakReference(referent, ReferenceQueue)` ctor.
- The Spring APP pin constant in `duke/tests/spring_boot_real_app.rs` is advanced to the new verbatim frontier (`InvocationTargetException`), and `docs/findings/2026-07-10-spring-boot-real-app.md` records the mechanism, every rung, and the EnumSet stop rationale.

## Verification

- `cargo build --workspace` — clean
- `cargo test --workspace` — **3095 passed / 0 failed / 4 ignored** (matches baseline, no regressions)
- `cargo fmt --check` — clean
- CI clippy `RUSTFLAGS="-D warnings" cargo +1.97.0 clippy --workspace --all-targets -- -W clippy::pedantic -W clippy::nursery` — zero warnings
- HelloWorld both modes (`.class` run + `-jar`) — `Hello, World!`, exit 0
- Spring/real-jdk pins (`spring_boot_real_app`, `spring_boot_real_jdk`, `spring_boot_jar`) — all green

## New frontier (next wave)

- **APP:** `java exception: java/lang/reflect/InvocationTargetException` — root cause `NoClassDefFoundError: java/util/EnumSet`, and once EnumSet is registered a deeper `ExceptionInInitializerError` from an enum static initializer using EnumSet's `noneOf`/`allOf`/`range`. Needs enum-constant reflection + ordinal bit-set storage — a real subsystem, pinned not forced.
- **LADDER (unchanged):** `method not found: org/apache/commons/logging/impl/LogFactoryImpl.objectId(Ljava/lang/Object;)Ljava/lang/String;`

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDL1etGQ4GY6qj7mLHcyFS)_