### PR TITLE
Arc&lt;str&gt; class-name interning: share one allocation across the dispatch hot path (#1328 follow-up)

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -287,3 +287,74 @@ read dominated. Gate: `cargo test --workspace` = 3042 passed / 0 failed / 4 igno
   turn these into ref-count bumps (~485k allocs saved on benchFib), but the type flows
   through `native/common.rs`/`registry.rs`, which are owned by other lanes — deferred.
 - `bootstrap_stdlib` (~251 µs) remains the standing wall-clock startup term (stdlib.rs).
+
+## 2026-07-13: Arc<str> class-name interning — eliminate the 4 hot per-call class-name clones (#1328 follow-up)
+
+Date: 2026-07-13
+Hardware: CI container (same as the 2026-07-13 BEFORE capture)
+Duke version: trunk @ `b6c90ec` + `swarm/arcstr-interning` (rebased)
+HotSpot version: OpenJDK 21.0.10 (system `java`)
+
+This is the follow-up flagged under "Follow-ups" in the 2026-07-11 entry above.
+
+### Design (Arc<str> interning)
+
+Class identity keys are now interned `Arc<str>` shared across the registry and the dispatch
+hot path. `ClassRegistry.classes` is `HashMap<Arc<str>, ClassContext>`; `CallFrame.class_name`,
+`CachedDispatch.class_name`, `ExecutionState.current_class` and the `dispatch_cache` key are
+`Arc<str>`. `ClassRegistry::intern_key(&str) -> Arc<str>` hands cached class names a cheap `Arc`
+clone of the registry's existing key (or allocates a fresh one). Because `Arc<str>` hashes/compares
+by string *contents* and `Borrow<str>` keeps `.get(&str)` working, the `\0loader:`/`\0code:`
+provenance-suffix key identity from the #1317 real-jdk shadow scheme is preserved byte-for-byte —
+key computation (`class_key_from_provenance`) is unchanged; this is a representation change only.
+`ClassContext.class_name` and `HeapObject.class_name` were intentionally left `String` (out of the
+hot path; not worth the wider churn).
+
+### Clone sites eliminated (were `String` deep-copies, now `Arc` refcount bumps)
+
+- `cached.class_name.clone()` on the invokestatic fast path (`execution.rs`) — 1 per cache hit.
+- `class_name: current_class.clone()` in `activate_method_state` pushing the caller `CallFrame`
+  (`native/common.rs`) — 1 per *any* method call.
+- the same `cached.class_name.clone()` on the invokespecial and invokevirtual-PIC fast paths.
+
+benchFib incurs ~2 of these per call (~485k deep String copies over fib(25)); they are now
+atomic refcount bumps with no allocation.
+
+### Criterion (median, `--sample-size 10 --measurement-time 8`; isolates the execution loop)
+
+Isolated read = trunk `b6c90ec` re-benched back-to-back against HEAD on the same machine (strips
+the unrelated stdlib growth from #1348/#1349 that landed on trunk between the BEFORE capture and now).
+
+| Benchmark | trunk b6c90ec (ms) | Arc<str> (ms) | Δ (criterion verdict) |
+|-----------|-------------------:|--------------:|-----------------------|
+| benchSum        | 90.493 | 83.678 | -6.06% (improved, p<0.05) |
+| benchFib        | 72.577 | 71.655 | -1.15% (within noise) |
+| benchArrayList  | 8.4636 | 8.2565 | -0.92% (no change, p=0.54) |
+| benchHashMap    | 1.7773 | 1.8169 | +3.10% (regressed, p<0.05) |
+| bootstrap_stdlib (µs) | 515.25 | 514.54 | +1.02% (no change) |
+
+### Wall-clock vs HotSpot (compare.sh, median of 7)
+
+| Benchmark | Duke before (ms) | Duke after (ms) | HS JIT | Duke/JIT |
+|-----------|-----------------:|----------------:|-------:|----------|
+| benchSum       | 633 | 622 | 45 | 15x → 14x |
+| benchFib       | 393 | 398 | 44 | 10x → 9x  |
+| benchArrayList | 129 | 139 | 46 | 3x → 3x   |
+| benchHashMap   | 120 | 123 | 56 | 2x → 2x   |
+
+### Verdict (honest)
+
+Performance-neutral within measurement noise on this suite — the intended hot-path benchmark
+benchFib (tightest call loop) did **not** move outside noise (-1.1%). The class names here are
+short (~14 chars), so the eliminated String deep-copy is a cheap malloc+memcpy that the atomic
+Arc refcount bump+drop roughly offsets; benchSum's ~6% is machine variance (it is arithmetic-heavy,
+~1 call — not causally a call-path effect) and benchHashMap's ~3% is atomic-refcount overhead on
+the virtual-dispatch path. The change's value is the cleaner shared-allocation representation, not a
+measured throughput win. Fully behavior-identical: no error-message text changed.
+
+Gate: `cargo test --workspace` = **3095 passed / 0 failed / 4 ignored**; `cargo fmt --all --check`
+clean; `cargo clippy --workspace --all-targets -W clippy::pedantic -W clippy::nursery` clean.
+Extended gates all green: HelloWorld (synthetic + real-jdk, incl. `DUKE_LAYOUT_CHECK=fail`); the 3
+OSS canaries (slf4j-simple / gson / commons-lang3); Spring Boot synthetic + real-jdk pins; real-jdk
+shadow-key / provenance suites (`real_jdk_shadow`, `classloader_bootstrap_frontier`, `module_model`,
+`layout_coherence`) — the `\0loader:` loader-suffixed keys still resolve.

--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -568,7 +568,7 @@ pub fn run_execution(
         macro_rules! ensure_field_owner_loaded {
             ($class:expr, $key:expr) => {{
                 let owner_was_loaded =
-                    registry.ensure_loaded_from(&$class, Some(current_class.as_str()), loader)?;
+                    registry.ensure_loaded_from(&$class, Some(&**current_class), loader)?;
                 if !owner_was_loaded && !registry.contains(&$key) {
                     throw_no_class_def_found!($class);
                 }
@@ -590,7 +590,7 @@ pub fn run_execution(
             // ---- invokestatic ----
             Instruction::Invokestatic(cp_idx) => {
                 if let Some(cached) = dispatch_cache
-                    .get(current_class.as_str())
+                    .get(&**current_class)
                     .and_then(|m| m.get(&cp_idx.0))
                 {
                     // Fast path: cache hit — zero registry lookups.
@@ -637,13 +637,10 @@ pub fn run_execution(
                     let ctx = registry.get(current_class)?;
                     resolve_methodref(&ctx.constant_pool, usize::from(cp_idx.0))?
                 };
-                let class_was_loaded = registry.ensure_loaded_from(
-                    &callee_class,
-                    Some(current_class.as_str()),
-                    loader,
-                )?;
+                let class_was_loaded =
+                    registry.ensure_loaded_from(&callee_class, Some(&**current_class), loader)?;
                 let callee_class_key =
-                    registry.class_key_from_source(&callee_class, Some(current_class.as_str()));
+                    registry.class_key_from_source(&callee_class, Some(&**current_class));
                 if class_was_loaded {
                     route_class_init_result!(ensure_initialized(
                         registry,
@@ -710,7 +707,7 @@ pub fn run_execution(
                                 .insert(
                                     cp_idx.0,
                                     CachedDispatch {
-                                        class_name: callee_class_key.clone(),
+                                        class_name: registry.intern_key(&callee_class_key),
                                         method_idx: callee_idx,
                                         arg_count,
                                         param_types: parse_arg_types(&callee_desc),
@@ -744,7 +741,7 @@ pub fn run_execution(
                             instructions,
                             current_class,
                             call_stack,
-                            callee_class_key,
+                            registry.intern_key(&callee_class_key),
                             callee_idx,
                             callee_pc_to_idx,
                             callee_frame,
@@ -1669,8 +1666,8 @@ pub fn run_execution(
                     resolve_class_name(&ctx.constant_pool, usize::from(cp_idx.0))?
                 };
                 let target_class_key =
-                    registry.class_key_from_source(&target_class, Some(current_class.as_str()));
-                registry.ensure_loaded_from(&target_class, Some(current_class.as_str()), loader)?;
+                    registry.class_key_from_source(&target_class, Some(&**current_class));
+                registry.ensure_loaded_from(&target_class, Some(&**current_class), loader)?;
                 // NOTE: `new` on an *unresolvable* class is deliberately NOT turned
                 // into a NoClassDefFoundError here. Unlike the other opcode sites
                 // (invokestatic / get(field|static) / put(field|static)), which
@@ -1720,7 +1717,7 @@ pub fn run_execution(
                     resolve_fieldref(&ctx.constant_pool, usize::from(cp_idx.0))?
                 };
                 let target_class_key =
-                    registry.class_key_from_source(&target_class, Some(current_class.as_str()));
+                    registry.class_key_from_source(&target_class, Some(&**current_class));
                 let r = frame.pop_ref()?;
                 ensure_field_owner_loaded!(target_class, target_class_key);
                 let fidx = field_slot_idx(registry, &target_class_key, &field_name)?;
@@ -1782,7 +1779,7 @@ pub fn run_execution(
                     resolve_fieldref(&ctx.constant_pool, usize::from(cp_idx.0))?
                 };
                 let target_class_key =
-                    registry.class_key_from_source(&target_class, Some(current_class.as_str()));
+                    registry.class_key_from_source(&target_class, Some(&**current_class));
                 let val = frame.pop()?;
                 let r = frame.pop_ref()?;
                 ensure_field_owner_loaded!(target_class, target_class_key);
@@ -1842,7 +1839,7 @@ pub fn run_execution(
                     resolve_fieldref(&ctx.constant_pool, usize::from(cp_idx.0))?
                 };
                 let target_class_key =
-                    registry.class_key_from_source(&target_class, Some(current_class.as_str()));
+                    registry.class_key_from_source(&target_class, Some(&**current_class));
                 ensure_field_owner_loaded!(target_class, target_class_key);
                 route_class_init_result!(ensure_initialized(
                     registry,
@@ -1862,7 +1859,7 @@ pub fn run_execution(
                     resolve_fieldref(&ctx.constant_pool, usize::from(cp_idx.0))?
                 };
                 let target_class_key =
-                    registry.class_key_from_source(&target_class, Some(current_class.as_str()));
+                    registry.class_key_from_source(&target_class, Some(&**current_class));
                 let val = frame.pop()?;
                 ensure_field_owner_loaded!(target_class, target_class_key);
                 route_class_init_result!(ensure_initialized(
@@ -1886,7 +1883,7 @@ pub fn run_execution(
                 // Fast path: cache hit for invokespecial (static dispatch — safe to cache).
                 if matches!(instr, Instruction::Invokespecial(_))
                     && let Some(cached) = dispatch_cache
-                        .get(current_class.as_str())
+                        .get(&**current_class)
                         .and_then(|m| m.get(&cp_idx.0))
                 {
                     // Zero registry lookups — all data pre-cached.
@@ -1934,18 +1931,15 @@ pub fn run_execution(
                     resolve_methodref(&ctx.constant_pool, usize::from(cp_idx.0))?
                 };
                 let callee_class_key =
-                    registry.class_key_from_source(&callee_class, Some(current_class.as_str()));
+                    registry.class_key_from_source(&callee_class, Some(&**current_class));
                 // <clinit> (static initialiser) is not supported yet — skip silently.
                 if callee_name == "<clinit>" {
                     *idx += 1;
                     continue;
                 }
                 // Attempt to load the target class; soft-fail for unloadable.
-                let class_was_loaded = registry.ensure_loaded_from(
-                    &callee_class,
-                    Some(current_class.as_str()),
-                    loader,
-                )?;
+                let class_was_loaded =
+                    registry.ensure_loaded_from(&callee_class, Some(&**current_class), loader)?;
                 let virtual_start: Option<String> =
                     if matches!(instr, Instruction::Invokevirtual(_)) {
                         let arg_count = parse_arg_count(&callee_desc);
@@ -1994,7 +1988,7 @@ pub fn run_execution(
                 if matches!(instr, Instruction::Invokevirtual(_))
                     && let Some(ref runtime_class) = virtual_start
                     && let Some(cached) = vtable_cache
-                        .get(current_class.as_str())
+                        .get(&**current_class)
                         .and_then(|m| m.get(&cp_idx.0))
                         .and_then(|m| m.get(runtime_class.as_str()))
                 {
@@ -2122,12 +2116,12 @@ pub fn run_execution(
 
                                 let _ = registry.ensure_loaded_from(
                                     &lambda_info.impl_class,
-                                    Some(current_class.as_str()),
+                                    Some(&**current_class),
                                     loader,
                                 );
                                 let impl_class_key = registry.class_key_from_source(
                                     &lambda_info.impl_class,
-                                    Some(current_class.as_str()),
+                                    Some(&**current_class),
                                 );
 
                                 let resolved = resolve_method_in_hierarchy(
@@ -2172,7 +2166,7 @@ pub fn run_execution(
                                         instructions,
                                         current_class,
                                         call_stack,
-                                        dispatch_class,
+                                        registry.intern_key(&dispatch_class),
                                         impl_idx,
                                         callee_pc_to_idx,
                                         callee_frame,
@@ -2431,7 +2425,7 @@ pub fn run_execution(
                             .insert(
                                 cp_idx.0,
                                 CachedDispatch {
-                                    class_name: dispatch_class.clone(),
+                                    class_name: registry.intern_key(&dispatch_class),
                                     method_idx: callee_idx,
                                     arg_count,
                                     param_types: parse_arg_types(&callee_desc),
@@ -2450,7 +2444,7 @@ pub fn run_execution(
                             .insert(
                                 runtime_class.clone(),
                                 CachedDispatch {
-                                    class_name: dispatch_class.clone(),
+                                    class_name: registry.intern_key(&dispatch_class),
                                     method_idx: callee_idx,
                                     arg_count,
                                     param_types: parse_arg_types(&callee_desc),
@@ -2487,7 +2481,7 @@ pub fn run_execution(
                     instructions,
                     current_class,
                     call_stack,
-                    dispatch_class,
+                    registry.intern_key(&dispatch_class),
                     callee_idx,
                     callee_pc_to_idx,
                     callee_frame,
@@ -2841,7 +2835,7 @@ pub fn run_execution(
                             loader,
                             &actual,
                             &target,
-                            Some(current_class.as_str()),
+                            Some(&**current_class),
                         ) {
                             frame.push(slot)?;
                         } else {
@@ -2873,7 +2867,7 @@ pub fn run_execution(
                             loader,
                             &actual,
                             &target,
-                            Some(current_class.as_str()),
+                            Some(&**current_class),
                         ));
                         frame.push(Slot::Int(result))?;
                     }
@@ -3046,11 +3040,8 @@ pub fn run_execution(
                         heap.get_mut(r)?.fields[i] = slot;
                     }
 
-                    let _ = registry.ensure_loaded_from(
-                        &impl_class,
-                        Some(current_class.as_str()),
-                        loader,
-                    );
+                    let _ =
+                        registry.ensure_loaded_from(&impl_class, Some(&**current_class), loader);
 
                     frame.push(Slot::Reference(Some(r)))?;
                     if gc_allowed && heap.should_gc() {
@@ -3083,7 +3074,7 @@ pub fn run_execution(
                     resolve_methodref(&ctx.constant_pool, usize::from(cp_idx.0))?
                 };
                 let callee_class_key =
-                    registry.class_key_from_source(&callee_class, Some(current_class.as_str()));
+                    registry.class_key_from_source(&callee_class, Some(&**current_class));
                 if callee_name == "<clinit>" {
                     *idx += 1;
                     continue;
@@ -3336,12 +3327,12 @@ pub fn run_execution(
 
                             let _ = registry.ensure_loaded_from(
                                 &lambda_info.impl_class,
-                                Some(current_class.as_str()),
+                                Some(&**current_class),
                                 loader,
                             );
                             let impl_class_key = registry.class_key_from_source(
                                 &lambda_info.impl_class,
-                                Some(current_class.as_str()),
+                                Some(&**current_class),
                             );
 
                             if lambda_info.impl_kind == 6 {
@@ -3388,7 +3379,7 @@ pub fn run_execution(
                                         instructions,
                                         current_class,
                                         call_stack,
-                                        dispatch_class,
+                                        registry.intern_key(&dispatch_class),
                                         impl_idx,
                                         callee_pc_to_idx,
                                         callee_frame,
@@ -3412,7 +3403,7 @@ pub fn run_execution(
                                 // invokeVirtual / invokeInterface dispatch
                                 let impl_class_key = registry.class_key_from_source(
                                     &lambda_info.impl_class,
-                                    Some(current_class.as_str()),
+                                    Some(&**current_class),
                                 );
                                 let resolved = resolve_method_in_hierarchy(
                                     registry,
@@ -3456,7 +3447,7 @@ pub fn run_execution(
                                         instructions,
                                         current_class,
                                         call_stack,
-                                        dispatch_class,
+                                        registry.intern_key(&dispatch_class),
                                         impl_idx,
                                         callee_pc_to_idx,
                                         callee_frame,
@@ -3680,7 +3671,7 @@ pub fn run_execution(
                     instructions,
                     current_class,
                     call_stack,
-                    dispatch_class,
+                    registry.intern_key(&dispatch_class),
                     callee_idx,
                     callee_pc_to_idx,
                     callee_frame,

--- a/crates/duke-interpreter/src/native/common.rs
+++ b/crates/duke-interpreter/src/native/common.rs
@@ -8012,7 +8012,7 @@ impl FramePool {
 /// - `dispatch_cache`: `(caller_class, cp_idx)` for `invokestatic`/`invokespecial`
 /// - `vtable_cache`: `(caller_class, cp_idx, receiver_runtime_class)` for `invokevirtual`
 struct CachedDispatch {
-    class_name: String,
+    class_name: std::sync::Arc<str>,
     method_idx: usize,
     arg_count: usize,
     /// JVM primitive type chars for each parameter ('I', 'J', 'D', 'F', 'Z', 'B', 'C', 'S', 'L', '[').
@@ -8025,7 +8025,7 @@ struct CachedDispatch {
 }
 
 struct ExecutionState {
-    current_class: String,
+    current_class: std::sync::Arc<str>,
     method_idx: usize,
     pc_to_idx: std::sync::Arc<std::collections::HashMap<usize, usize>>,
     instructions: std::sync::Arc<[(usize, Instruction)]>,
@@ -8034,10 +8034,10 @@ struct ExecutionState {
     frame_pool: FramePool,
     /// Static dispatch cache for `invokestatic` and `invokespecial`.
     /// Key: (`caller_class`, `cp_idx`) → pre-resolved method data.
-    dispatch_cache: HashMap<String, HashMap<u16, CachedDispatch>>,
+    dispatch_cache: HashMap<std::sync::Arc<str>, HashMap<u16, CachedDispatch>>,
     /// Polymorphic inline cache for `invokevirtual`.
     /// Key: (`caller_class`, `cp_idx`, `receiver_runtime_class`) → pre-resolved method data.
-    vtable_cache: HashMap<String, HashMap<u16, HashMap<String, CachedDispatch>>>,
+    vtable_cache: HashMap<std::sync::Arc<str>, HashMap<u16, HashMap<String, CachedDispatch>>>,
     idx: usize,
     string_intern: HashMap<(u8, String), u64>,
     #[cfg(feature = "telemetry")]
@@ -8417,7 +8417,7 @@ impl ExecutionState {
         entry_idx: usize,
         args: &[Slot],
     ) -> Result<Self> {
-        let current_class = class_name.to_string();
+        let current_class = registry.intern_key(class_name);
         let pc_to_idx = {
             let ctx = registry.get(&current_class)?;
             std::sync::Arc::clone(&ctx.methods[entry_idx].pc_to_idx)
@@ -8485,9 +8485,9 @@ fn activate_method_state(
     method_idx: &mut usize,
     pc_to_idx: &mut std::sync::Arc<std::collections::HashMap<usize, usize>>,
     instructions: &mut std::sync::Arc<[(usize, Instruction)]>,
-    current_class: &mut String,
+    current_class: &mut std::sync::Arc<str>,
     call_stack: &mut Vec<CallFrame>,
-    callee_class: String,
+    callee_class: std::sync::Arc<str>,
     callee_idx: usize,
     callee_pc_to_idx: std::sync::Arc<std::collections::HashMap<usize, usize>>,
     callee_frame: Frame,
@@ -9797,7 +9797,7 @@ struct CallFrame {
     pc_to_idx: std::sync::Arc<std::collections::HashMap<usize, usize>>,
     resume_idx: usize,
     /// Class that was executing when this frame was pushed.
-    class_name: String,
+    class_name: std::sync::Arc<str>,
 }
 
 fn line_number_for_bci(line_number_table: &[(u16, u16)], bci: usize) -> i32 {

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -416,7 +416,12 @@ pub struct ReflectedClassInfo {
 }
 /// A registry managing loaded classes, their initialization state, and associated native methods.
 pub struct ClassRegistry {
-    classes: HashMap<String, ClassContext>,
+    /// Loaded classes keyed by their provenance-qualified identity key. The key is an
+    /// interned [`Arc<str>`] so registry keys and cached class names on the dispatch hot
+    /// path share a single allocation (see [`Self::intern_key`]). Hashing/equality is by
+    /// string contents, so the `\0loader:`/`\0code:` provenance-suffix key identity is
+    /// preserved byte-for-byte and `.get(&str)` lookups keep working via `Borrow<str>`.
+    classes: HashMap<Arc<str>, ClassContext>,
     natives: NativeRegistry,
     /// Tracks which classes have had their `<clinit>` run.
     initialized: HashSet<String>,
@@ -630,6 +635,21 @@ impl ClassRegistry {
         self.classes.contains_key(class)
             && !self.class_code_sources.contains_key(class)
             && !self.class_runtime_loaders.contains_key(class)
+    }
+
+    /// Intern a class identity key into a shared [`Arc<str>`].
+    ///
+    /// If a class is already registered under `key`, returns a cheap `Arc` clone of the
+    /// registry's existing key so cached class names on the dispatch hot path share the
+    /// registry's single allocation. Otherwise allocates a fresh `Arc<str>` from `key`.
+    ///
+    /// This is a representation change only: `key` must already be a fully-computed class
+    /// identity key (provenance suffix included) — see [`Self::class_key_from_provenance`].
+    #[must_use]
+    pub(crate) fn intern_key(&self, key: &str) -> Arc<str> {
+        self.classes
+            .get_key_value(key)
+            .map_or_else(|| Arc::from(key), |(existing, _)| Arc::clone(existing))
     }
 
     /// Compute the deterministic class identity key for a class reference under explicit provenance.
@@ -1018,7 +1038,7 @@ impl ClassRegistry {
             self.shadowed_classes.push(ctx.class_name);
             return;
         }
-        self.classes.insert(ctx.class_name.clone(), ctx);
+        self.classes.insert(Arc::from(ctx.class_name.as_str()), ctx);
     }
 
     /// Whether `class` (any provenance-keyed form) is a synthetic class that was
@@ -1064,7 +1084,7 @@ impl ClassRegistry {
                 let _ = self.ensure_loaded_from(&current, Some(start_class), loader);
                 current = self.class_key_from_source(&current, Some(start_class));
             }
-            let ctx = self.classes.get(&current)?;
+            let ctx = self.classes.get(current.as_str())?;
             if let Some(idx) = ctx
                 .methods
                 .iter()
@@ -1083,7 +1103,7 @@ impl ClassRegistry {
                 }
                 // Abstract override — keep walking supers for a concrete body.
             }
-            let super_class = self.classes.get(&current)?.super_class.clone();
+            let super_class = self.classes.get(current.as_str())?.super_class.clone();
             current = super_class?;
         }
     }
@@ -1242,7 +1262,7 @@ impl ClassRegistry {
     ) -> Result<bool> {
         let internal_name = class_internal_name_fragment(name).to_string();
         let class_key = self.class_key_from_provenance(&internal_name, code_source, runtime_loader);
-        if self.classes.contains_key(&class_key) {
+        if self.classes.contains_key(class_key.as_str()) {
             // Do not record provenance onto plain bootstrap classes. They are
             // loader-agnostic singletons (`java/lang/System`, `java/lang/ClassLoader`,
             // ...): `class_key_from_provenance` deliberately returns their plain key
@@ -1290,7 +1310,7 @@ impl ClassRegistry {
         ctx.class_name.clone_from(&class_key);
         ctx.super_class = resolved_super_class;
         ctx.interfaces = resolved_interfaces;
-        self.classes.insert(class_key.clone(), ctx);
+        self.classes.insert(Arc::from(class_key.as_str()), ctx);
         if let Some(path) = code_source {
             self.class_code_sources
                 .insert(class_key.clone(), path.to_string());
@@ -1325,7 +1345,7 @@ impl ClassRegistry {
             .classes
             .keys()
             .filter(|class| self.internal_name_for_class(class) == internal_name)
-            .cloned()
+            .map(ToString::to_string)
             .collect();
         match matches.as_slice() {
             [] => Err(Error::ClassNotFound {


### PR DESCRIPTION
> ⚠️ **No performance win.** This is a behavior-identical refactor that measured performance-neutral within noise (benchFib, the intended target, did not move; benchHashMap +3% from atomic refcount overhead; vs HotSpot unchanged). **Merge only if the shared-`Arc<str>` class-name representation is wanted for code cleanliness — not for throughput.** The standalone negative-result write-up is in #1352 (docs-only). All gates pass (3095/0/4, fmt/clippy clean, HelloWorld/OSS/Spring/real-jdk green).

---

## Before / After (plain language)

**Before:** every method call on the dispatch hot path deep-copied the callee/caller class name — a fresh `String` allocation + `memcpy` per call (up to 4 clone sites per call: invokestatic / invokespecial / invokevirtual fast paths + the `CallFrame` push). benchFib alone did ~485k of these class-name deep-copies over `fib(25)`.

**After:** class identity keys are interned `Arc<str>` shared between the registry and the dispatch caches, so those clones are now atomic refcount bumps — no allocation, no copy. One `Arc<str>` allocation per distinct class key is shared everywhere it's referenced.

## How

- `ClassRegistry.classes` is now `HashMap<Arc<str>, ClassContext>`; `CallFrame.class_name`, `CachedDispatch.class_name`, `ExecutionState.current_class` and the `dispatch_cache` key are `Arc<str>`.
- New `ClassRegistry::intern_key(&str) -> Arc<str>` hands cached class names a cheap `Arc` clone of the registry's existing key (or allocates a fresh one) at the cold cache-populate sites; the hot fast-path clones become `Arc::clone` refcount bumps.
- **Provenance key identity is preserved byte-for-byte.** `Arc<str>` hashes/compares by string *contents* and `Borrow<str>` keeps `.get(&str)` working, so the `\0loader:` / `\0code:` provenance-suffixed keys from the #1317 real-jdk shadow scheme resolve exactly as before. `class_key_from_provenance` is unchanged — this is a representation change only, not a change to how keys are computed.
- `ClassContext.class_name` (and `HeapObject.class_name`) were **intentionally left `String`** — off the hot path, not worth the wider churn.

Behavior-identical: no error-message text changed (`Arc<str>` derefs to `&str`, so every `format!` / reflection / message-assert path is untouched).

## Benchmarks (honest)

Isolated read: trunk `b6c90ec` re-benched back-to-back against this branch on the same machine (criterion `--sample-size 10 --measurement-time 8`), which strips the unrelated stdlib growth from #1348/#1349 that landed on trunk in between.

| Benchmark | trunk b6c90ec | Arc&lt;str&gt; | Δ (criterion verdict) |
|-----------|--------------:|-----------:|-----------------------|
| benchSum        | 90.493 ms | 83.678 ms | -6.06% (improved, p&lt;0.05) |
| benchFib        | 72.577 ms | 71.655 ms | -1.15% (within noise) |
| benchArrayList  | 8.4636 ms | 8.2565 ms | -0.92% (no change, p=0.54) |
| benchHashMap    | 1.7773 ms | 1.8169 ms | +3.10% (regressed, p&lt;0.05) |
| bootstrap_stdlib | 515.25 µs | 514.54 µs | +1.02% (no change) |

Wall-clock vs HotSpot (`compare.sh`, median of 7): benchSum 633→622 ms, benchFib 393→398 ms, benchArrayList 129→139 ms, benchHashMap 120→123 ms; Duke/JIT ratios essentially unchanged (15x→14x, 10x→9x).

**Verdict:** performance-neutral within measurement noise on this suite — the intended hot-path benchmark benchFib (tightest call loop) did **not** move outside noise (-1.1%). Class names here are short (~14 chars), so the eliminated deep-copy is a cheap malloc+memcpy that the atomic Arc refcount bump+drop roughly offsets; benchSum's ~6% is machine variance (it is arithmetic-heavy, ~1 call — not causally a call-path effect) and benchHashMap's ~3% is atomic-refcount overhead on the virtual-dispatch path. The change lands as a cleaner shared-allocation representation, not a measured throughput win.

## Gate results

- `cargo test --workspace` = **3095 passed / 0 failed / 4 ignored**
- `cargo fmt --all --check` clean
- `cargo clippy --workspace --all-targets -W clippy::pedantic -W clippy::nursery` clean
- **HelloWorld** runs clean in synthetic **and** real-jdk modes, including with `DUKE_LAYOUT_CHECK=fail`
- **OSS canaries** (all green): slf4j-simple, gson, commons-lang3
- **Spring Boot** synthetic pins (`spring_boot_jar`, `spring_boot_real_app`) + real-jdk pins (`spring_boot_real_jdk`) green
- **Real-jdk shadow-key / provenance** suites green: `real_jdk_shadow`, `classloader_bootstrap_frontier`, `module_model`, `layout_coherence`, and the `test_registry_class_key_from_provenance` unit test — the `\0loader:` loader-suffixed keys still resolve

Rebased cleanly onto trunk `b6c90ec` (no conflicts). See `benchmarks/RESULTS.md` (2026-07-13 entry) for the full write-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAdpi3qeiSsfhbxNDdU95p

---
_Generated by [Claude Code](https://claude.ai/code/session_01YAdpi3qeiSsfhbxNDdU95p)_