### PR TITLE
Match interfaces regardless of loader-qualified keys in instanceof/checkcast

### DIFF
--- a/crates/duke-interpreter/src/native/common.rs
+++ b/crates/duke-interpreter/src/native/common.rs
@@ -11463,7 +11463,18 @@ fn is_assignable_from(
             queue.push_back(sc);
         }
         for iface in interfaces {
-            if iface == to_key {
+            // A ClassContext's interface entries are stored either as plain internal
+            // names (classes built reflectively/synthetically via `build_class_context`,
+            // which never runs the loader-resolution pass) or as loader-qualified keys
+            // (classes resolved through `ensure_loaded_inner`, which rewrites each
+            // interface to a `name\0loader:N` key). `to_key` here is loader-qualified.
+            // A direct `iface == to_key` match therefore silently fails for the plain
+            // case — e.g. `x instanceof org/apache/commons/logging/Log` on a
+            // reflectively-built implementor returns a false negative. Interface
+            // assignability in Duke's model is keyed by internal name, so compare on the
+            // plain internal name (stripping any loader qualifier from both sides); this
+            // is loader-agnostic and consistent with how interface entries are recorded.
+            if class_internal_name_from_key(&iface) == to_internal {
                 return true;
             }
             queue.push_back(iface);

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -33582,3 +33582,61 @@ fn native_file_output_stream_init_ids_is_idempotent() {
         "an already-installed JavaLangAccess must not be overwritten"
     );
 }
+
+/// Regression for the false-negative `instanceof`/`checkcast` that walled the
+/// commons-logging ladder: `LogFactoryImpl.createLogFromClass` evaluates
+/// `newLogger instanceof org/apache/commons/logging/Log` on a reflectively-built
+/// `Jdk14Logger` whose `ClassContext` records its interface as a PLAIN internal
+/// name, while the resolved target key is LOADER-QUALIFIED (`name\0loader:N`). The
+/// old `iface == to_key` equality never matched the plain-vs-qualified pair, so a
+/// class that genuinely implements the interface reported `false`.
+#[test]
+fn is_assignable_from_matches_loader_qualified_interface() {
+    let iface_key = "com/example/Iface\0loader:7";
+    let impl_key = "com/example/Impl\0loader:7";
+    let unrelated_key = "com/example/Unrelated\0loader:7";
+
+    let make_ctx = |name: &str, interfaces: Vec<String>| ClassContext {
+        class_name: name.to_string(),
+        super_class: Some("java/lang/Object".to_string()),
+        interfaces,
+        constant_pool: Vec::new(),
+        methods: Vec::new(),
+        fields: Vec::new(),
+        static_fields: Vec::new(),
+        instance_field_count: 0,
+        bootstrap_methods: Vec::new(),
+        load_source: ClassLoadSource::Classfile,
+    };
+
+    let mut registry = ClassRegistry::new();
+    let mut heap = duke_gc::Heap::new();
+    bootstrap_stdlib(&mut registry, &mut heap);
+    registry.register(make_ctx(iface_key, Vec::new()));
+    // The interface entry is deliberately a PLAIN internal name (no loader
+    // qualifier), reproducing the reflective/synthetic build path that never runs
+    // the loader-resolution pass.
+    registry.register(make_ctx(impl_key, vec!["com/example/Iface".to_string()]));
+    registry.register(make_ctx(unrelated_key, Vec::new()));
+    let loader = make_simple_loader();
+
+    // Positive: `Impl` implements `Iface` even though the stored interface entry is
+    // plain and the resolved target key (`iface_key`) is loader-qualified.
+    assert!(
+        is_assignable_from(&mut registry, &loader, impl_key, iface_key, Some(impl_key)),
+        "plain interface entry must match a loader-qualified target key"
+    );
+
+    // Negative guard: a class that does not implement `Iface` must still report
+    // false, so the fix is not an unconditional true.
+    assert!(
+        !is_assignable_from(
+            &mut registry,
+            &loader,
+            unrelated_key,
+            iface_key,
+            Some(unrelated_key),
+        ),
+        "an unrelated class must not be assignable to Iface"
+    );
+}


### PR DESCRIPTION
> **Note:** Fast-merge requested — surgical interpreter class-identity fix. Fourth in a small set of correctness fixes unblocking the commons-logging ladder (companions: #1347 invokestatic super-walk, #1354 static-field resolution/JVMS-5.5). `native/common.rs` has no active owner this wave.

## Before

`instanceof` / `checkcast` returned a false negative when the target interface's key was loader-qualified but the class's stored interface entries were plain internal names — so a class that genuinely implements an interface tested as NOT an instance of it. Concretely, a reflectively-built `Jdk14Logger` (which `implements org/apache/commons/logging/Log`) failed `instanceof Log`, diverting commons-logging into a spurious `LogConfigurationException` (surfacing as a `Class.getInterfaces()` wall).

## After

`instanceof` / `checkcast` match interfaces by plain internal name, stripping any loader qualifier from both sides, so an implementing class is correctly recognized regardless of whether the interface key is loader-qualified. This clears commons-logging end-to-end on the ladder fixture (it now boots through logging into the application's own `main`).

## How

In `is_assignable_from` (`native/common.rs`), the interface-entry comparison changed from `iface == to_key` to comparing plain internal names (`class_internal_name_from_key(&iface) == to_internal`). Interface entries are stored plain for reflectively/synthetically-built classes but loader-qualified for loader-resolved classes, while the target key is always qualified — the old exact-key equality silently missed the plain case. Both `Instanceof` and `Checkcast` opcodes route through `is_assignable_from`, so both are fixed at this single site; the exact class-key fast path and the superclass walk are unchanged. (Note: this treats same-named interfaces as loader-agnostic, consistent with Duke's pre-existing interface-by-name identity model.)

## Tests

Self-contained regression test `is_assignable_from_matches_loader_qualified_interface` — asserts an implementing class matches a loader-qualified interface target (true) AND that a non-implementor still returns false (guards against over-broad matching). Fails on trunk (positive assertion panics), passes with the fix. Full workspace 3096 passed / 0 failed / 4 ignored — zero instanceof/checkcast/assignability/reflection regressions; fmt + clippy (1.97.0 pedantic+nursery -D warnings) + HelloWorld (class+jar) green. Only `native/common.rs` and `tests.rs` changed (no `registry.rs`, no `execution.rs`).

---
_Generated by [Claude Code](https://claude.ai/code/session_011jcMqddLn2cYdbeSqv744o)_