### PR TITLE
🔭 Vantage: Spec for java.util.EnumSet

### DIFF
--- a/docs/specs/vantage-spec-enumset.md
+++ b/docs/specs/vantage-spec-enumset.md
@@ -1,0 +1,26 @@
+# 🔭 Vantage: Spec for java.util.EnumSet
+
+## 👤 User Story
+"As a Backend Engineer building Spring Boot applications, I want the JVM to support `java.util.EnumSet` and its factory methods, so that my application's enum-based configurations and static initializers can boot successfully."
+
+## ❓ The "So What?"
+What business problem does this solve?
+Spring Boot is the de facto standard for Java backend development. Real-world Spring Boot applications rely heavily on enums and `EnumSet` for configuration management, properties parsing, and subsystem initialization. Currently, Duke crashes during the Spring Boot initialization phase because `java.util.EnumSet` and its underlying enum-constant reflection are missing. Without this, Duke cannot run standard Spring Boot applications, severely limiting its utility for enterprise workloads.
+
+## 📈 Metric Definition
+Success = The Spring Boot application fixture (`duke-spring-boot-app-3.5.12.jar`) advances past the `java.lang.reflect.InvocationTargetException` caused by `NoClassDefFoundError: java/util/EnumSet` and the subsequent `ExceptionInInitializerError`.
+
+## 🔍 Gap Analysis
+- **Current State:** Duke JVM lacks support for `java.util.EnumSet` and its required Class-typed factories (`noneOf`, `allOf`, `range`). Attempting to initialize enums that use `EnumSet` fails deeply inside reflection wraps.
+- **Market/Standard Lib:** Standard JVMs fully support `EnumSet` and the reflection necessary to extract enum ordinals and universe arrays.
+- **The Gap:** We need to implement the necessary synthetic class mirrors or native methods for `java.util.EnumSet` factories (`noneOf`, `allOf`, `range`) which require enum-constant reflection and ordinal bit-set storage.
+
+## ✅ Acceptance Criteria
+- Must implement support for `java.util.EnumSet.noneOf(Class)`.
+- Must implement support for `java.util.EnumSet.allOf(Class)`.
+- Must implement support for `java.util.EnumSet.range(Enum, Enum)`.
+- Must support the required enum-constant reflection to determine the universe of an enum class and its ordinals.
+
+## 🚫 Out of Scope
+- Performance optimizations distinguishing between `RegularEnumSet` (<= 64 elements) and `JumboEnumSet` (> 64 elements), as long as the base functionality operates correctly.
+- Full support for every mutable `Set` operation on the resulting set if not strictly required to pass the initialization blocker.


### PR DESCRIPTION
- **User Story:** As a Backend Engineer building Spring Boot applications, I want the JVM to support `java.util.EnumSet` and its factory methods, so that my application's enum-based configurations and static initializers can boot successfully.
- **Acceptance Criteria:**
  - Must implement support for `java.util.EnumSet.noneOf(Class)`.
  - Must implement support for `java.util.EnumSet.allOf(Class)`.
  - Must implement support for `java.util.EnumSet.range(Enum, Enum)`.
  - Must support the required enum-constant reflection to determine the universe of an enum class and its ordinals.
- **Out of Scope:**
  - Performance optimizations distinguishing between `RegularEnumSet` and `JumboEnumSet`.
  - Full support for every mutable `Set` operation not strictly required for initialization.

---
*PR created automatically by Jules for task [10099027453394082717](https://jules.google.com/task/10099027453394082717) started by @madmax983*