### PR TITLE
Make real-jdk String.getBytes frontier pins JDK-build-independent

### DIFF
--- a/crates/duke-interpreter/tests/classloader_bootstrap_frontier.rs
+++ b/crates/duke-interpreter/tests/classloader_bootstrap_frontier.rs
@@ -141,17 +141,23 @@ fn slf4j_real_jdk_shadow_classloader_frontier_pin() {
     // `getstatic java/lang/String.COMPACT_STRINGS` fieldref wall is cleared and real
     // String bytecode advances into `String.coder()`. That instance method is now
     // provided as a native reading real-layout slot1 (0=Latin1/1=UTF16), so the coder
-    // wall is cleared and real String bytecode advances into `String.getBytes([BIB)V`,
-    // the package-private `getBytes(byte[] dst, int dstBegin, byte coder)` copy helper
-    // the synthetic KEEP_SYNTHETIC `java/lang/String` does not provide, which surfaces
-    // as `MethodNotFound { name: "java/lang/String.getBytes", descriptor: "([BIB)V" }`.
-    // That is a separate lane (String real-layout / KEEP_SYNTHETIC allowlist), out of
-    // scope for the system-properties lane.
+    // wall is cleared and real String bytecode advances into a `String.getBytes` copy
+    // helper, one of the package-private `getBytes(byte[] dst, int dstBegin, byte coder)`
+    // / `getBytes(byte[] dst, int dstBegin, int dstEnd, byte coder)` overloads the
+    // synthetic KEEP_SYNTHETIC `java/lang/String` does not provide, which surfaces as a
+    // `MethodNotFound { name: "java/lang/String.getBytes", descriptor: ... }`. That is a
+    // separate lane (String real-layout / KEEP_SYNTHETIC allowlist), out of scope for the
+    // system-properties lane.
+    //
+    // We pin the method NAME only and deliberately do NOT pin the exact descriptor: both
+    // `([BIB)V` and `([BIIBI)V` are valid JDK-21 overloads of the package-private copy
+    // helper, and which one is the *first-missing* method in the encode path is
+    // JDK-build-specific (differs between local and CI runner JDKs). The frontier is the
+    // getBytes copy-helper wall regardless of which overload surfaces first.
     //
     // When a native pushes the wall past this point, re-run with `-- --nocapture`,
     // read the new verbatim blocker above, and update this substring to lock it in.
-    const EXPECTED_FRONTIER: &str =
-        "MethodNotFound { name: \"java/lang/String.getBytes\", descriptor: \"([BIB)V\" }";
+    const EXPECTED_FRONTIER: &str = "MethodNotFound { name: \"java/lang/String.getBytes\",";
 
     let rendered = match run_slf4j_real_jdk_shadow() {
         Ok(()) => {

--- a/duke/tests/spring_boot_real_jdk.rs
+++ b/duke/tests/spring_boot_real_jdk.rs
@@ -64,14 +64,21 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 // former `getstatic java/lang/String.COMPACT_STRINGS` fieldref wall is cleared and real String
 // bytecode advances into `String.coder()`. That instance method is now provided as a native
 // reading real-layout slot1 (0=Latin1/1=UTF16), so the coder wall is cleared and real String
-// bytecode advances into `String.getBytes([BIB)V`, the package-private
-// `getBytes(byte[] dst, int dstBegin, byte coder)` copy helper the synthetic KEEP_SYNTHETIC
-// `java/lang/String` does not provide, which surfaces as the CLI runtime error
-// `method not found: java/lang/String.getBytes([BIB)V`. That is a separate lane (String
+// bytecode advances into a `String.getBytes` copy helper, one of the package-private
+// `getBytes(byte[] dst, int dstBegin, byte coder)` / `getBytes(byte[] dst, int dstBegin,
+// int dstEnd, byte coder)` overloads the synthetic KEEP_SYNTHETIC `java/lang/String` does
+// not provide, which surfaces as the CLI runtime error
+// `method not found: java/lang/String.getBytes(...)`. That is a separate lane (String
 // real-layout / KEEP_SYNTHETIC allowlist), the SAME frontier pinned by
 // `crates/duke-interpreter/tests/classloader_bootstrap_frontier.rs`. Out of scope here.
 // If either boot advances past this, re-observe and update.
-const REAL_JDK_FRONTIER: &str = "method not found: java/lang/String.getBytes([BIB)V";
+//
+// We prefix-match on `java/lang/String.getBytes(` and deliberately do NOT pin the exact
+// descriptor: both `([BIB)V` and `([BIIBI)V` are valid JDK-21 overloads of the
+// package-private copy helper, and which one is the *first-missing* method in the encode
+// path is JDK-build-specific (differs between local and CI runner JDKs). The frontier is
+// the getBytes copy-helper wall regardless of which overload surfaces first.
+const REAL_JDK_FRONTIER: &str = "method not found: java/lang/String.getBytes(";
 
 // Markers of the OLD raw panic that this fix eliminates. None of these must appear.
 const RAW_PANIC_MARKERS: &[&str] = &["index out of bounds", "execution.rs", "panicked at"];


### PR DESCRIPTION
## Summary

Relaxes two brittle real-jdk frontier pins so CI is JDK-build-independent. These pins are red on trunk itself (inherited from #1369 String Stage 1), so this de-reds every in-flight PR at once.

**Flagged for FAST MERGE** since it turns every open PR's Test CI green in one shot.

### Before
Two real-jdk frontier tests hard-pin the first-missing method in the real `java/lang/String` encode path as `String.getBytes([BIB)V`:
- `duke/tests/spring_boot_real_jdk.rs` (ladder + app) — asserts the CLI runtime error `method not found: java/lang/String.getBytes([BIB)V`
- `crates/duke-interpreter/tests/classloader_bootstrap_frontier.rs` — asserts `MethodNotFound { name: "java/lang/String.getBytes", descriptor: "([BIB)V" }`

On CI's runner JDK the encode path surfaces the sibling overload `getBytes([BIIBI)V` first, so the pins fail — red on trunk for every in-flight PR.

### After
Pins match `java/lang/String.getBytes` regardless of descriptor. Both `([BIB)V` and `([BIIBI)V` are valid JDK-21 overloads of the package-private copy helper (`getBytes(byte[] dst, int dstBegin, byte coder)` / `getBytes(byte[] dst, int dstBegin, int dstEnd, byte coder)`); which one is *first-missing* in the encode path is JDK-build-specific (differs between local and CI runner JDKs). ci.yml has no setup-java, so the runner JDK is not fixed.

Real intent preserved: (a) no raw panic / index-out-of-bounds markers (still asserted absent in the spring_boot pins), and (b) boot still pinned at the real `String.getBytes` copy-helper frontier. Touches only the two test files.

### How
- `spring_boot_real_jdk.rs`: prefix-match the CLI error on `method not found: java/lang/String.getBytes(` (trailing `(`), instead of the full `([BIB)V` descriptor. Shared `assert_no_url_panic_and_pinned` helper covers both the ladder and app tests.
- `classloader_bootstrap_frontier.rs`: name-only match on `MethodNotFound { name: "java/lang/String.getBytes",`, dropping the exact-descriptor requirement.
- Both changes carry a comment explaining the JDK-build sensitivity.
- **No ci.yml setup-java change** — pin robustness is the right fix.

### Gate (local, all green)
- `cargo build` clean
- `cargo test --workspace`: 0 failed. Both spring_boot_real_jdk tests and classloader_bootstrap_frontier PASS locally (local JDK sees `([BIB)V`; prefix/name match covers it).
- `cargo fmt --all --check` clean
- `RUSTFLAGS="-D warnings" cargo +1.97.0 clippy --workspace --all-targets -- -W clippy::pedantic -W clippy::nursery` clean
- HelloWorld all 3 modes (synthetic / `DUKE_REAL_JDK=1` / `+DUKE_LAYOUT_CHECK=fail`) exit 0
- `git diff --name-only origin/trunk` touches only the two test files

---
_Generated by [Claude Code](https://claude.ai/code/session_0134i9XswZjUF6kAk7jcxonU)_