### PR TITLE
Interpreter dispatch perf: benchSum 80.55→69.00 ms, benchFib 69.35→62.64 ms

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -358,3 +358,86 @@ Extended gates all green: HelloWorld (synthetic + real-jdk, incl. `DUKE_LAYOUT_C
 OSS canaries (slf4j-simple / gson / commons-lang3); Spring Boot synthetic + real-jdk pins; real-jdk
 shadow-key / provenance suites (`real_jdk_shadow`, `classloader_bootstrap_frontier`, `module_model`,
 `layout_coherence`) — the `\0loader:` loader-suffixed keys still resolve.
+
+## 2026-07-18: Interpreter dispatch hot-path — kill per-call arg alloc, cache caller bytecode, single-borrow Ldc (`swarm/dispatch-perf`)
+
+Date: 2026-07-18
+Hardware: CI container
+Duke version: trunk @ `3ab296b` + `swarm/dispatch-perf`
+HotSpot version: OpenJDK 21 (system `java`); interpreter reference is `-Xint`
+
+Three behavior-identical changes on the method-dispatch and constant-load hot paths. The two
+dispatch-heavy benchmarks (benchSum, benchFib) moved well outside noise; the small object-churn
+benchmarks (benchArrayList, benchHashMap) are neutral within noise, as expected — they are not
+call-loop-bound.
+
+### Changes
+
+- **R1 — `pop_typed_args_into_locals` (`native/common.rs`)**: the function allocated a throwaway
+  `vec![Slot::Int(0); count]` on **every** method invoke to stage popped operands before copying
+  them into the locals array. It now pops operands directly into the already-sized `locals` buffer,
+  walking the destination local index backward in lock-step with the reverse pop so wide (J/D)
+  two-slot placement is preserved exactly. Padding slots stay at the resize-initialized
+  `Slot::Int(0)`. Called on all six invoke fast paths (invokestatic / -special / -virtual /
+  -interface / lambda / method-ref). Removes one heap alloc + free per call.
+
+- **R2 — cache caller bytecode in `CallFrame` (`native/common.rs` + `execution.rs`)**: `do_return!`
+  re-fetched the caller method's instruction slice on every return via
+  `registry.get(current_class)?.methods[idx].instructions`, re-walking the `ClassRegistry` HashMap.
+  `CallFrame` now carries the caller's `instructions: Arc<[(usize, Instruction)]>`, cloned once at
+  call-push (one cheap Arc refcount bump) and restored with a move on return — exactly mirroring the
+  already-cached `pc_to_idx`. The exception-unwind restore site is updated to match. An on-stack
+  method's bytecode is immutable for the life of the frame, so the cached Arc equals the re-fetched
+  one; behavior is byte-identical.
+
+- **R3 — single-borrow Ldc (`execution.rs`)**: the `Ldc` arm re-fetched `ctx = registry.get(...)`
+  and re-resolved the constant pool up to three times per execution (String probe, then Class probe,
+  then the `ldc_push` fallback). It now classifies the constant once under a single borrow into
+  String / Class / Other (cloning the resolved value out so the borrow releases before the heap and
+  intern-map mutations), then branches. Byte-identical, including the `InvalidCpIndex` error on an
+  unresolved String entry and the Class→Other fallthrough.
+
+- **R7 — not taken**: skipping the per-dispatch quantum decrement/compare when `quantum` is `None`
+  would require duplicating the multi-thousand-line dispatch `match` (or a risky extraction). The
+  `remaining == 0` branch is already highly predictable and `saturating_sub(1)` is a single
+  instruction; not worth the restructuring risk. Recorded as a neutral no-op.
+
+### Criterion (median, `--sample-size 10 --measurement-time 8`; isolates the execution loop)
+
+| Benchmark | BEFORE trunk `3ab296b` (ms) | AFTER (ms) | Δ (criterion verdict) |
+|-----------|----------------------------:|-----------:|-----------------------|
+| benchSum (500k int adds)        | 80.55 | 69.00 | **-14.3%** (improved, p<0.05) |
+| benchFib (fib(25), ~500k calls) | 69.35 | 62.64 | **-9.7%** (improved, p<0.05) |
+| benchArrayList (5k ArrayList.add) | 7.39 | 7.51 | neutral (re-run p=0.71, "no change") |
+| benchHashMap (200 put + 200 get)  | 1.99 | 2.05 | neutral (p=0.19, "no change") |
+
+benchArrayList's first read showed +4.6% but the immediate re-run reported "no change in
+performance detected" (p=0.71) with a median of 7.51 ms — the first read was machine noise, matching
+the #1350 precedent that flags benchArrayList/benchHashMap as noisy on this suite. Both are recorded
+here as negative/neutral results per the #1350 convention.
+
+Interpreter-vs-interpreter target (HotSpot `-Xint`: benchSum 63 ms, benchFib 40 ms): benchSum closes
+to within ~10% of `-Xint`; benchFib remains the larger gap (Frame/dispatch structural cost beyond
+these three point wins).
+
+### Verdict (honest)
+
+Real, causal wins on the two dispatch-bound benchmarks: benchFib (the tightest call loop) improved
+9.7% outside noise, driven by R1 (one fewer alloc/free per of ~485k calls) and R2 (one fewer
+registry HashMap walk per return); benchSum's 14.3% comes from R1/R3 shrinking per-instruction
+overhead on its tight arithmetic + Ldc loop. The object-churn benchmarks are unmoved because they
+are not call-loop-bound. Fully behavior-identical: no fixture output, error text, or wide-type
+placement changed.
+
+Gate: `cargo test --workspace` = **3146 passed / 0 failed / 4 ignored** (≥ the #1350 3095/0/4
+baseline; full run restored); `cargo fmt --all -- --check` clean; exact CI clippy
+`RUSTFLAGS="-D warnings" cargo +1.97.0 clippy --workspace --all-targets -- -W clippy::pedantic
+-W clippy::nursery` clean. Extended gates all green: HelloWorld (synthetic + real-jdk, incl.
+`DUKE_LAYOUT_CHECK=fail`) — identical `Hello, World!`, exit 0 in both modes; the 3 OSS canaries
+(slf4j-simple / gson / commons-lang3); Spring Boot synthetic + real-jdk pins; real-jdk shadow-key /
+provenance suites (`real_jdk_shadow`, `classloader_bootstrap_frontier`, `module_model`,
+`layout_coherence`).
+
+Note: the duplicate-test-fn workspace-build unbreak (the two `hashmap_for_each_survives_mid_iteration_gc`
+definitions from #1384/#1386, E0428) is handled in a separate lane's PR, not this branch. This branch
+should be rebased onto trunk once that lands so `cargo test --workspace` compiles in CI.

--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -940,51 +940,51 @@ pub fn run_execution(
             Instruction::Sipush(v) => frame.push(Slot::Int(i32::from(*v)))?,
             Instruction::Ldc(raw_idx) => {
                 let cp_idx = usize::from(*raw_idx);
-                let string_info = {
+                // Classify the constant under a single ClassRegistry borrow instead
+                // of re-fetching the ctx / re-resolving the constant pool up to three
+                // times. String and Class values are cloned out so the borrow is
+                // released before the heap / intern-map mutations below.
+                enum LdcConst {
+                    StringConst(String),
+                    ClassConst(String),
+                    Other,
+                }
+                let kind = {
                     let ctx = registry.get(current_class)?;
-                    if let Some(CpEntry::String { string_index }) =
-                        ctx.constant_pool.get(cp_idx).and_then(|e| e.as_ref())
-                    {
-                        let si = string_index.0 as usize;
-                        let s = match ctx.constant_pool.get(si).and_then(|e| e.as_ref()) {
-                            Some(CpEntry::Utf8(s)) => s.clone(),
-                            _ => return Err(Error::InvalidCpIndex { index: si }),
-                        };
-                        Some(s)
-                    } else {
-                        None
-                    }
-                };
-                if let Some(s) = string_info {
-                    let intern_key = (0, s);
-                    let r = if let Some(&cached) = string_intern.get(&intern_key) {
-                        cached
-                    } else {
-                        let r = heap.allocate_string(intern_key.1.clone());
-                        string_intern.insert(intern_key, r);
-                        r
-                    };
-                    frame.push(Slot::Reference(Some(r)))?;
-                } else {
-                    // Check for Class constant
-                    let class_info = {
-                        let ctx = registry.get(current_class)?;
-                        if let Some(CpEntry::Class { name_index }) =
-                            ctx.constant_pool.get(cp_idx).and_then(|e| e.as_ref())
-                        {
+                    match ctx.constant_pool.get(cp_idx).and_then(|e| e.as_ref()) {
+                        Some(CpEntry::String { string_index }) => {
+                            let si = string_index.0 as usize;
+                            match ctx.constant_pool.get(si).and_then(|e| e.as_ref()) {
+                                Some(CpEntry::Utf8(s)) => LdcConst::StringConst(s.clone()),
+                                _ => return Err(Error::InvalidCpIndex { index: si }),
+                            }
+                        }
+                        Some(CpEntry::Class { name_index }) => {
                             match ctx
                                 .constant_pool
                                 .get(name_index.0 as usize)
                                 .and_then(|e| e.as_ref())
                             {
-                                Some(CpEntry::Utf8(s)) => Some(s.clone()),
-                                _ => None,
+                                Some(CpEntry::Utf8(s)) => LdcConst::ClassConst(s.clone()),
+                                _ => LdcConst::Other,
                             }
-                        } else {
-                            None
                         }
-                    };
-                    if let Some(class_name) = class_info {
+                        _ => LdcConst::Other,
+                    }
+                };
+                match kind {
+                    LdcConst::StringConst(s) => {
+                        let intern_key = (0, s);
+                        let r = if let Some(&cached) = string_intern.get(&intern_key) {
+                            cached
+                        } else {
+                            let r = heap.allocate_string(intern_key.1.clone());
+                            string_intern.insert(intern_key, r);
+                            r
+                        };
+                        frame.push(Slot::Reference(Some(r)))?;
+                    }
+                    LdcConst::ClassConst(class_name) => {
                         let intern_key = (1, class_name);
                         let r = if let Some(&cached) = string_intern.get(&intern_key) {
                             cached
@@ -994,7 +994,8 @@ pub fn run_execution(
                             r
                         };
                         frame.push(Slot::Reference(Some(r)))?;
-                    } else {
+                    }
+                    LdcConst::Other => {
                         let ctx = registry.get(current_class)?;
                         ldc_push(frame, &ctx.constant_pool, cp_idx)?;
                     }

--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -320,9 +320,10 @@ pub fn run_execution(
                         *pc_to_idx = caller.pc_to_idx;
                         *idx = caller.resume_idx;
                         *current_class = caller.class_name;
-                        *instructions = std::sync::Arc::clone(
-                            &registry.get(&current_class)?.methods[*method_idx].instructions,
-                        );
+                        // Restore the caller's cached bytecode directly, avoiding a
+                        // ClassRegistry lookup + constant-pool re-resolution on every
+                        // return. Mirrors the cached `pc_to_idx` restore above.
+                        *instructions = caller.instructions;
                         #[cfg(feature = "telemetry")]
                         {
                             *current_method = registry
@@ -406,9 +407,9 @@ pub fn run_execution(
                             *method_idx = caller.method_idx;
                             *pc_to_idx = caller.pc_to_idx;
                             *current_class = caller.class_name;
-                            *instructions = std::sync::Arc::clone(
-                                &registry.get(&current_class)?.methods[*method_idx].instructions,
-                            );
+                            // Restore the caller's cached bytecode directly (mirrors
+                            // the do_return! restore).
+                            *instructions = caller.instructions;
                             #[cfg(feature = "telemetry")]
                             {
                                 *current_method = registry

--- a/crates/duke-interpreter/src/native/common.rs
+++ b/crates/duke-interpreter/src/native/common.rs
@@ -12037,19 +12037,21 @@ fn pop_typed_args_into_locals(
     locals: &mut [Slot],
     start_idx: usize,
 ) -> Result<()> {
-    let count = param_types.len();
-    let mut args = vec![Slot::Int(0); count];
-    for i in (0..count).rev() {
-        args[i] = frame.pop()?;
-    }
+    // The operand stack holds the args in forward order (last param on top), so we
+    // pop in reverse. Walk the destination local index backward in lock-step: the
+    // total slot span accounts for wide J/D params occupying two slots, and each
+    // param's slot is derived by subtracting its width before the store. This pops
+    // args directly into the pre-sized `locals` buffer, avoiding the per-call
+    // temporary `Vec` the previous implementation allocated on every invoke.
     let mut local_idx = start_idx;
-    for (slot, &tc) in args.iter().zip(param_types.iter()) {
+    for &tc in param_types {
+        local_idx += if tc == 'J' || tc == 'D' { 2 } else { 1 };
+    }
+    for &tc in param_types.iter().rev() {
+        local_idx -= if tc == 'J' || tc == 'D' { 2 } else { 1 };
+        let value = frame.pop()?;
         if local_idx < locals.len() {
-            locals[local_idx] = *slot;
-        }
-        local_idx += 1;
-        if tc == 'J' || tc == 'D' {
-            local_idx += 1; // wide type: skip the padding slot
+            locals[local_idx] = value;
         }
     }
     Ok(())

--- a/crates/duke-interpreter/src/native/common.rs
+++ b/crates/duke-interpreter/src/native/common.rs
@@ -8572,6 +8572,7 @@ fn activate_method_state(
         frame: std::mem::replace(frame, callee_frame),
         method_idx: *method_idx,
         pc_to_idx: std::sync::Arc::clone(pc_to_idx),
+        instructions: std::sync::Arc::clone(instructions),
         resume_idx,
         class_name: current_class.clone(),
     });
@@ -9862,6 +9863,10 @@ struct CallFrame {
     frame: Frame,
     method_idx: usize,
     pc_to_idx: std::sync::Arc<std::collections::HashMap<usize, usize>>,
+    /// Bytecode of the caller method, cached so `do_return!` can restore it with
+    /// a cheap `Arc` move instead of a `ClassRegistry` lookup + constant-pool
+    /// re-resolution on every return. Mirrors the cached `pc_to_idx` above.
+    instructions: std::sync::Arc<[(usize, Instruction)]>,
     resume_idx: usize,
     /// Class that was executing when this frame was pushed.
     class_name: std::sync::Arc<str>,


### PR DESCRIPTION
## What

Three behavior-identical optimizations on the interpreter's method-dispatch and constant-load hot paths.

Criterion medians (`--sample-size 10 --measurement-time 8`, same machine):

| Benchmark | BEFORE (ms) | AFTER (ms) | Δ (criterion verdict) |
|-----------|------------:|-----------:|-----------------------|
| benchSum (500k int adds)          | 80.55 | 69.00 | **-14.3%** (improved, p<0.05) |
| benchFib (fib(25), ~500k calls)   | 69.35 | 62.64 | **-9.7%** (improved, p<0.05) |
| benchArrayList (5k ArrayList.add) | 7.39  | 7.51  | neutral (re-run "no change", p=0.71) |
| benchHashMap (200 put + 200 get)  | 1.99  | 2.05  | neutral ("no change", p=0.19) |

The two dispatch-bound benchmarks move well outside noise; the small object-churn benchmarks are neutral within noise (not call-loop-bound). benchArrayList's first read showed +4.6% but the immediate re-run reported "no change" (median 7.51 ms) — machine noise, matching the noisy-bench precedent for these two. Interpreter-vs-interpreter target is HotSpot `-Xint` (benchSum 63 ms, benchFib 40 ms); benchSum now closes to within ~10% of `-Xint`.

## How

- **R1 — pop invoke args into pre-sized locals** (`crates/duke-interpreter/src/native/common.rs`): `pop_typed_args_into_locals` allocated a throwaway `vec[Slot::Int(0); count]` on **every** invoke to stage popped operands. It now pops directly into the already-sized `locals` buffer, walking the destination index backward in lock-step with the reverse pop so wide (J/D) two-slot placement is preserved exactly; padding slots stay at the resize-initialized `Slot::Int(0)`. Hit by all six invoke fast paths (static/special/virtual/interface/lambda/method-ref). Removes one heap alloc+free per call.
- **R2 — cache caller bytecode in `CallFrame`** (`native/common.rs` + `execution.rs`): `do_return!` re-fetched the caller's instruction slice on every return via `registry.get(current_class)?.methods[idx].instructions`, re-walking the `ClassRegistry` HashMap. `CallFrame` now carries the caller's `instructions: Arc<[(usize, Instruction)]>`, cloned once at call-push (cheap Arc refcount bump) and restored with a move on return — mirroring the already-cached `pc_to_idx`. The exception-unwind restore site is updated to match. An on-stack method's bytecode is immutable for the life of the frame, so the cached Arc equals the re-fetched one; byte-identical.
- **R3 — single-borrow Ldc** (`execution.rs`): the `Ldc` arm re-fetched `ctx` and re-resolved the constant pool up to three times (String probe, Class probe, `ldc_push` fallback). It now classifies the constant once under a single borrow into String/Class/Other (cloning the value out so the borrow releases before heap/intern mutations), then branches. Byte-identical, including the `InvalidCpIndex` error on an unresolved String entry and the Class→Other fallthrough.
- **R7 — not taken**: skipping the per-dispatch quantum decrement when `quantum` is `None` would require duplicating the multi-thousand-line dispatch `match`; the `remaining == 0` branch is already well-predicted and `saturating_sub(1)` is one instruction. Not worth the restructuring risk.

Each optimization is its own commit; `benchmarks/RESULTS.md` carries a dated 2026-07-18 entry documenting the design, before/after numbers, and the neutral/negative results.

## Note on the workspace build

`cargo test --workspace` on trunk currently fails to compile (E0428: duplicate `hashmap_for_each_survives_mid_iteration_gc` from #1384 + #1386). That unbreak is owned by a **separate lane's PR** and is intentionally **not** part of this branch — this branch touches only `execution.rs`, `native/common.rs`, and `RESULTS.md`. Rebase this branch onto trunk once the dup-test fix lands so CI's `cargo test --workspace` compiles. Local gating for this PR was run with that dup-fix applied as an uncommitted working-tree change.

## Gate (all green, run locally with the dup-fix applied)

- `cargo build --workspace` clean.
- `cargo test --workspace` = **3146 passed / 0 failed / 4 ignored** (≥ the 3095/0/4 baseline; full run restored).
- `cargo fmt --all -- --check` clean.
- Exact CI clippy `RUSTFLAGS="-D warnings" cargo +1.97.0 clippy --workspace --all-targets -- -W clippy::pedantic -W clippy::nursery` clean.
- HelloWorld synthetic + `--real-jdk` (incl. `DUKE_LAYOUT_CHECK=fail`): identical `Hello, World!`, exit 0 in both modes.
- 3 OSS canaries (slf4j-simple / gson / commons-lang3); Spring Boot synthetic + real-jdk pins; real-jdk shadow-key / provenance suites (`real_jdk_shadow`, `classloader_bootstrap_frontier`, `module_model`, `layout_coherence`) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDx4urU9oFd6XQkPB5dk9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDx4urU9oFd6XQkPB5dk9w)_