### PR TITLE
Add ARRAY_* base-offset/index-scale statics to synthetic Unsafe

### DIFF
--- a/crates/duke-interpreter/src/stdlib.rs
+++ b/crates/duke-interpreter/src/stdlib.rs
@@ -1367,13 +1367,62 @@ fn register_concurrent_hashmap_stdlib(registry: &mut ClassRegistry) {
 /// simpler than `HotSpot`'s real byte-addressed memory model but is
 /// self-consistent because Duke's field and array access are both positional.
 fn register_unsafe_stdlib(registry: &mut ClassRegistry) {
+    // Real `jdk/internal/misc/Unsafe` declares, per array element kind, a pair of
+    // `public static final int` constants: `ARRAY_<K>_BASE_OFFSET` and
+    // `ARRAY_<K>_INDEX_SCALE` (nine kinds: BOOLEAN, BYTE, CHAR, SHORT, INT, LONG,
+    // FLOAT, DOUBLE, OBJECT). Real bytecode addresses element `i` of an array as
+    // `BASE_OFFSET + (i << log2(INDEX_SCALE))`, i.e. a byte offset into
+    // HotSpot's byte-addressed heap.
+    //
+    // Duke's heap is positional: `HeapObject::fields` holds ONE `Slot` PER ARRAY
+    // ELEMENT regardless of the element's primitive width (see `duke-gc`). An
+    // Unsafe "offset" in Duke IS the positional slot index. Choosing
+    // BASE_OFFSET == 0 and INDEX_SCALE == 1 collapses the real address formula to
+    // `offset == i` exactly (ASHIFT == log2(1) == 0), which is precisely the
+    // contract Duke's Unsafe array natives already honor: `arrayBaseOffset()`
+    // returns 0 and `arrayIndexScale()` returns 1 (see the natives registered
+    // below and `native/jdk_internal.rs`). Seeding these constants as static
+    // fields lets real `getstatic Unsafe.ARRAY_<K>_BASE_OFFSET` /
+    // `..._INDEX_SCALE` bytecode resolve to the same coherent 0 / 1 values the
+    // method natives return. Duke never performs real pointer arithmetic with
+    // them — offsets are slot indices — so the collapsed formula is exact.
+    const ARRAY_KINDS: [&str; 9] = [
+        "BOOLEAN", "BYTE", "CHAR", "SHORT", "INT", "LONG", "FLOAT", "DOUBLE", "OBJECT",
+    ];
+    let mut unsafe_fields: Vec<FieldEntry> = Vec::with_capacity(ARRAY_KINDS.len() * 2);
+    let mut unsafe_static_values: Vec<Slot> = Vec::with_capacity(ARRAY_KINDS.len() * 2);
+    for kind in ARRAY_KINDS {
+        // BASE_OFFSET == 0: positional heap has no per-array header offset.
+        unsafe_fields.push(FieldEntry {
+            name: format!("ARRAY_{kind}_BASE_OFFSET"),
+            descriptor: "I".to_string(),
+            is_static: true,
+        });
+        unsafe_static_values.push(Slot::Int(0));
+        // INDEX_SCALE == 1: one slot per element, so element index == offset.
+        unsafe_fields.push(FieldEntry {
+            name: format!("ARRAY_{kind}_INDEX_SCALE"),
+            descriptor: "I".to_string(),
+            is_static: true,
+        });
+        unsafe_static_values.push(Slot::Int(1));
+    }
+    // NOTE: real `Unsafe` also declares platform constants `ADDRESS_SIZE` /
+    // `PAGE_SIZE` (materialized by `UnsafeConstants` in the real `<clinit>`, which
+    // Duke never runs). They are intentionally NOT seeded here: the real-JDK
+    // frontier this surface serves does not demand them — the 18 ARRAY_* constants
+    // alone clear the entire Unsafe intrinsics lane, after which the chain advances
+    // into `java/lang/String.<init>(Ljava/lang/StringBuilder;)V` (String work,
+    // owned elsewhere). If a future frontier issues `getstatic Unsafe.ADDRESS_SIZE`
+    // / `PAGE_SIZE`, seed them here with the real 64-bit values (8 / 4096); Duke
+    // does no real pointer/page arithmetic, so those values are guard-plausible.
     registry.register(ClassContext {
         class_name: "jdk/internal/misc/Unsafe".to_string(),
         super_class: Some("java/lang/Object".to_string()),
         constant_pool: Vec::new(),
         methods: Vec::new(),
-        fields: Vec::new(),
-        static_fields: Vec::new(),
+        fields: unsafe_fields,
+        static_fields: unsafe_static_values,
         instance_field_count: 0,
         interfaces: Vec::new(),
         bootstrap_methods: Vec::new(),

--- a/crates/duke-interpreter/tests/classloader_bootstrap_frontier.rs
+++ b/crates/duke-interpreter/tests/classloader_bootstrap_frontier.rs
@@ -148,18 +148,29 @@ fn slf4j_real_jdk_shadow_classloader_frontier_pin() {
     // (`([BIIBI)V`) — are now provided as coder-converting copy natives, so the
     // getBytes wall is cleared and real String encode bytecode runs past it.
     //
-    // The new honest frontier is `InvalidFieldref { index: 0 }`: once the String
-    // encode path completes, bootstrap advances well past String into a `getstatic
+    // The former wall was `InvalidFieldref { index: 0 }`: once the String encode
+    // path completed, bootstrap advanced past String into a `getstatic
     // jdk/internal/misc/Unsafe.ARRAY_BOOLEAN_INDEX_SCALE`, a static field the
-    // synthetic `Unsafe` does not declare. `resolve_static_field` reports a static
-    // miss as the hardcoded `InvalidFieldref { index: 0 }`. This is a distinct,
-    // downstream lane (Unsafe intrinsics), entirely separate from the String
-    // real-layout / KEEP_SYNTHETIC work. We pin the error variant only, since the
-    // hardcoded index makes it stable across which static first surfaces.
+    // synthetic `Unsafe` did not declare. The synthetic `Unsafe` now declares the
+    // full 9-kind array-intrinsics surface — `ARRAY_<K>_BASE_OFFSET` (== 0) and
+    // `ARRAY_<K>_INDEX_SCALE` (== 1) for each of BOOLEAN/BYTE/CHAR/SHORT/INT/LONG/
+    // FLOAT/DOUBLE/OBJECT — seeded as static-final int fields (see
+    // `register_unsafe_stdlib` in `stdlib.rs`). Those values are coherent with
+    // Duke's positional one-slot-per-element heap (offset == index ⇒ base 0,
+    // scale 1) and with the existing `arrayBaseOffset()==0` / `arrayIndexScale()==1`
+    // natives. `getstatic Unsafe.ARRAY_*` now resolves, clearing the entire Unsafe
+    // intrinsics lane in one move.
+    //
+    // The new honest frontier is
+    // `MethodNotFound { name: "java/lang/String.<init>", descriptor: "(Ljava/lang/StringBuilder;)V" }`:
+    // past the Unsafe lane, the chain reaches the `String(StringBuilder)`
+    // constructor, which the synthetic `String` does not provide as a native. That
+    // is String work (String stages 3-4), a distinct lane owned elsewhere, so we
+    // stop and pin here rather than force past it.
     //
     // When a native pushes the wall past this point, re-run with `-- --nocapture`,
     // read the new verbatim blocker above, and update this substring to lock it in.
-    const EXPECTED_FRONTIER: &str = "InvalidFieldref { index: 0 }";
+    const EXPECTED_FRONTIER: &str = "MethodNotFound { name: \"java/lang/String.<init>\", descriptor: \"(Ljava/lang/StringBuilder;)V\" }";
 
     let rendered = match run_slf4j_real_jdk_shadow() {
         Ok(()) => {

--- a/docs/findings/2026-07-19-unsafe-array-intrinsics.md
+++ b/docs/findings/2026-07-19-unsafe-array-intrinsics.md
@@ -1,0 +1,127 @@
+# jdk/internal/misc/Unsafe: array-intrinsics statics (2026-07-19)
+
+Durable record of adding the array base-offset / index-scale constant surface to
+the synthetic `jdk/internal/misc/Unsafe`, clearing the Unsafe-intrinsics wall on
+the real-JDK bootstrap frontier.
+
+---
+
+## 1. Context / TL;DR
+
+Under `DUKE_REAL_JDK` shadow, the String-encode bootstrap path advanced past
+`java/lang/String` and reached
+`getstatic jdk/internal/misc/Unsafe.ARRAY_BOOLEAN_INDEX_SCALE`. The synthetic
+`Unsafe` (KEEP_SYNTHETIC; `registry.rs:22`) declared **no static fields at all**,
+so `resolve_static_field` (`native/common.rs:12450`) walked its superclass chain,
+found nothing, and returned the hardcoded `Err(InvalidFieldref { index: 0 })`.
+
+**Baseline.** origin/trunk `595f0bc`, `cargo test --workspace` =
+**3147 passed / 0 failed / 3 ignored**.
+
+**Wave outcome.** The synthetic `Unsafe` now declares the full 9-kind array
+intrinsics surface — 18 `public static final int` fields — seeded with constant
+values. `getstatic Unsafe.ARRAY_*` now resolves, clearing the entire Unsafe
+intrinsics lane in one move. The frontier advances to the `String(StringBuilder)`
+constructor, which is String work owned elsewhere; we stop and pin there.
+
+---
+
+## 2. Mechanism (how a synthetic KEEP_SYNTHETIC class exposes a static field)
+
+A static field's value is read by the `Getstatic` handler
+(`execution.rs:1857`) as `registry.get(&decl_class)?.static_fields[sidx]`, where
+`(decl_class, sidx)` come from `resolve_static_field` (`native/common.rs:12450`).
+That resolver walks the superclass chain and, per class, computes
+`ctx.fields.iter().filter(|f| f.is_static).position(|f| f.name == name)` — i.e.
+the index is the **position among static-only `FieldEntry`s**, and the value lives
+at that same index in the parallel `static_fields: Vec<Slot>`.
+
+So exposing a static constant requires two parallel, order-matched additions on
+the `ClassContext`:
+
+1. a `FieldEntry { name, descriptor, is_static: true }` in `fields`, and
+2. its value as a `Slot` at the matching static-position in `static_fields`.
+
+This mirrors exactly how synthetic `java/lang/System` exposes `out`/`err`/`in`
+(`stdlib.rs` ~:2214-2235). Since synthetic `Unsafe` has only static fields, the
+`fields` and `static_fields` vectors are a direct 1:1 by construction.
+
+---
+
+## 3. Statics modeled + values + semantics
+
+For each element kind `K` in
+{BOOLEAN, BYTE, CHAR, SHORT, INT, LONG, FLOAT, DOUBLE, OBJECT}:
+
+| Field                   | Descriptor | Value |
+|-------------------------|-----------|-------|
+| `ARRAY_<K>_BASE_OFFSET` | `I`       | `0`   |
+| `ARRAY_<K>_INDEX_SCALE` | `I`       | `1`   |
+
+18 fields total, seeded in `register_unsafe_stdlib` (`stdlib.rs`).
+
+**Semantics justification.** Real bytecode addresses array element `i` as
+`BASE_OFFSET + (i << log2(INDEX_SCALE))` — a byte offset into HotSpot's
+byte-addressed heap. Duke's heap is **positional**: `HeapObject::fields` holds one
+`Slot` per array element regardless of the element's primitive width
+(`duke-gc`), and an Unsafe "offset" in Duke *is* the positional slot index.
+Choosing `BASE_OFFSET == 0` and `INDEX_SCALE == 1` collapses the real formula to
+`offset == i` exactly (`ASHIFT == log2(1) == 0`). This is the same contract the
+existing `arrayBaseOffset()` (returns 0) and `arrayIndexScale()` (returns 1)
+natives already honor (`stdlib.rs:1398,1403`; `native/jdk_internal.rs`), and the
+offset-encoding contract documented at `native/common.rs:17690-17703`. Duke never
+performs real pointer arithmetic with these values — offsets are slot indices — so
+the collapsed formula is not an approximation but exact for Duke's model.
+
+**`ADDRESS_SIZE` / `PAGE_SIZE`: intentionally NOT added.** Real `Unsafe` also
+declares these platform constants (materialized by `UnsafeConstants` in the real
+`<clinit>`, which Duke never runs). Empirically, the real-JDK frontier this surface
+serves does **not** demand them: with only the 18 ARRAY_* constants seeded, the
+chain advances straight past the Unsafe lane into `java/lang/String.<init>`. A probe
+build that omitted ADDRESS_SIZE/PAGE_SIZE produced the identical downstream
+frontier, confirming they are not on this path. Added only if a future frontier
+issues `getstatic Unsafe.ADDRESS_SIZE`/`PAGE_SIZE` (seed with the real 64-bit
+values 8 / 4096 — guard-plausible, since Duke does no real pointer/page arithmetic).
+A code comment in `register_unsafe_stdlib` records this decision.
+
+---
+
+## 4. Frontier: before / after (verbatim)
+
+### classloader_bootstrap_frontier :: slf4j_real_jdk_shadow_classloader_frontier_pin
+
+BEFORE (verbatim harness output):
+
+```
+InvalidFieldref { index: 0 }
+```
+
+AFTER (verbatim harness output):
+
+```
+MethodNotFound { name: "java/lang/String.<init>", descriptor: "(Ljava/lang/StringBuilder;)V" }
+```
+
+The pin's `EXPECTED_FRONTIER` and documenting comment are updated to this new
+verbatim string.
+
+### writer_graph_frontier :: writer_graph_probe_real_jdk_shadow_completes_with_hello_bytes
+
+UNCHANGED. This is not an Unsafe pin but an **end-to-end completion milestone**:
+the real `OutputStreamWriter -> StreamEncoder -> Charset` writer graph already runs
+to completion (its former `getstatic ByteBuffer.UNSAFE` wall was cleared long ago
+by PR #1354, inherited-static resolution + eager superclass `<clinit>`). Adding the
+ARRAY_* statics does not touch that path; the test still completes and emits the
+exact UTF-8 bytes of `"hello\n"` (`[104, 101, 108, 108, 111, 10]`). Left as-is.
+
+---
+
+## 5. Where we stopped and why
+
+Stopped at
+`MethodNotFound { name: "java/lang/String.<init>", descriptor: "(Ljava/lang/StringBuilder;)V" }`.
+The `String(StringBuilder)` constructor is **String work (String stages 3-4)**, a
+distinct lane owned elsewhere — not an Unsafe intrinsic, not a jdk_internal static.
+Per the ownership boundary, we pin honestly here rather than force past into
+String territory. The Unsafe intrinsics lane is fully cleared: every
+`getstatic Unsafe.ARRAY_*` the real bootstrap issues now resolves.

--- a/duke/tests/spring_boot_real_jdk.rs
+++ b/duke/tests/spring_boot_real_jdk.rs
@@ -70,15 +70,24 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 // are now provided as coder-converting copy natives, so the getBytes wall is cleared and the
 // real String encode path runs past it.
 //
+// The former `--real-jdk` frontier was the CLI runtime error
+// `constant pool index 0 is not a valid Fieldref`: after String encode completed, bootstrap
+// advanced past String into a `getstatic jdk/internal/misc/Unsafe.ARRAY_BOOLEAN_INDEX_SCALE`,
+// a static field the synthetic `Unsafe` did not declare (a static miss reported as the
+// hardcoded `InvalidFieldref { index: 0 }`). The synthetic `Unsafe` now declares the full
+// 9-kind array-intrinsics surface — `ARRAY_<K>_BASE_OFFSET` (== 0) / `ARRAY_<K>_INDEX_SCALE`
+// (== 1) for each element kind — so `getstatic Unsafe.ARRAY_*` resolves and the entire Unsafe
+// intrinsics lane clears (see `register_unsafe_stdlib` in `crates/duke-interpreter/src/stdlib.rs`).
+//
 // The new `--real-jdk` frontier is the CLI runtime error
-// `constant pool index 0 is not a valid Fieldref`: after String encode completes, bootstrap
-// advances well past String into a `getstatic jdk/internal/misc/Unsafe.ARRAY_BOOLEAN_INDEX_SCALE`,
-// a static field the synthetic `Unsafe` does not declare (a static miss is reported as the
-// hardcoded `InvalidFieldref { index: 0 }`). This is the SAME frontier pinned by
+// `method not found: java/lang/String.<init>(Ljava/lang/StringBuilder;)V`: past the Unsafe lane,
+// the chain reaches the `String(StringBuilder)` constructor, which the synthetic `String` does
+// not provide as a native. This is the SAME frontier pinned by
 // `crates/duke-interpreter/tests/classloader_bootstrap_frontier.rs` (rendered there as
-// `InvalidFieldref { index: 0 }`), a distinct downstream lane (Unsafe intrinsics). Out of scope
-// here. If either boot advances past this, re-observe and update.
-const REAL_JDK_FRONTIER: &str = "constant pool index 0 is not a valid Fieldref";
+// `MethodNotFound { name: "java/lang/String.<init>", descriptor: "(Ljava/lang/StringBuilder;)V" }`),
+// a distinct downstream lane (String stages 3-4). Out of scope here. If either boot advances
+// past this, re-observe and update.
+const REAL_JDK_FRONTIER: &str = "method not found: java/lang/String.<init>(Ljava/lang/StringBuilder;)V";
 
 // Markers of the OLD raw panic that this fix eliminates. None of these must appear.
 const RAW_PANIC_MARKERS: &[&str] = &["index out of bounds", "execution.rs", "panicked at"];

--- a/duke/tests/spring_boot_real_jdk.rs
+++ b/duke/tests/spring_boot_real_jdk.rs
@@ -87,7 +87,8 @@ const LADDER_JAR: &str = "duke-spring-boot-ladder-3.5.12.jar";
 // `MethodNotFound { name: "java/lang/String.<init>", descriptor: "(Ljava/lang/StringBuilder;)V" }`),
 // a distinct downstream lane (String stages 3-4). Out of scope here. If either boot advances
 // past this, re-observe and update.
-const REAL_JDK_FRONTIER: &str = "method not found: java/lang/String.<init>(Ljava/lang/StringBuilder;)V";
+const REAL_JDK_FRONTIER: &str =
+    "method not found: java/lang/String.<init>(Ljava/lang/StringBuilder;)V";
 
 // Markers of the OLD raw panic that this fix eliminates. None of these must appear.
 const RAW_PANIC_MARKERS: &[&str] = &["index out of bounds", "execution.rs", "panicked at"];


### PR DESCRIPTION
## Before

Under real-JDK shadow (`--real-jdk` / `DUKE_REAL_JDK=1`), the String-encode bootstrap path halted at `getstatic jdk/internal/misc/Unsafe.ARRAY_BOOLEAN_INDEX_SCALE`. The synthetic `Unsafe` (KEEP_SYNTHETIC) declared **no static fields at all**, so `resolve_static_field` walked its chain, missed, and returned the hardcoded `InvalidFieldref { index: 0 }`. Two real-jdk pins captured this wall verbatim:

- `classloader_bootstrap_frontier` :: `slf4j_real_jdk_shadow_classloader_frontier_pin` — `InvalidFieldref { index: 0 }`
- `spring_boot_real_jdk` (CLI) — `constant pool index 0 is not a valid Fieldref`

## After

The synthetic `Unsafe` now exposes the array base-offset / index-scale constants. For each of the 9 element kinds (BOOLEAN, BYTE, CHAR, SHORT, INT, LONG, FLOAT, DOUBLE, OBJECT) it declares `ARRAY_<K>_BASE_OFFSET = 0` and `ARRAY_<K>_INDEX_SCALE = 1` as `public static final int` fields (18 total). These values are coherent with Duke's one-slot-per-element positional heap — offset == index, so base 0 / scale 1 — and match the existing `arrayBaseOffset()==0` / `arrayIndexScale()==1` natives. Duke never does real pointer arithmetic with them (offsets are slot indices), so the collapsed address formula `BASE + (i << log2(SCALE))` reduces to `offset == i` exactly.

`getstatic Unsafe.ARRAY_*` now resolves, clearing the entire Unsafe intrinsics lane in one move. The real-JDK frontier advances to `java/lang/String.<init>(Ljava/lang/StringBuilder;)V` — the `String(StringBuilder)` constructor, which is String stages 3-4 work owned elsewhere. Both real-jdk pins are updated to that new verbatim blocker:

- `classloader_bootstrap_frontier` — `MethodNotFound { name: "java/lang/String.<init>", descriptor: "(Ljava/lang/StringBuilder;)V" }`
- `spring_boot_real_jdk` (CLI) — `method not found: java/lang/String.<init>(Ljava/lang/StringBuilder;)V`

`ADDRESS_SIZE` / `PAGE_SIZE` were probed but are **not** demanded by this chain (a build omitting them produced the identical downstream frontier), so they are intentionally left out; a code comment documents seeding them with the real 64-bit values (8 / 4096) if a future frontier needs them.

## How

- `crates/duke-interpreter/src/stdlib.rs` — `register_unsafe_stdlib` seeds the 18 `FieldEntry { is_static: true }` + parallel `static_fields: Vec<Slot>` values on the synthetic `Unsafe` `ClassContext`. This is the same static-exposure mechanism `java/lang/System` uses for `out`/`err`/`in`: `resolve_static_field` chain-walks static fields by name and `Getstatic` reads `static_fields[idx]`.
- `crates/duke-interpreter/tests/classloader_bootstrap_frontier.rs` and `duke/tests/spring_boot_real_jdk.rs` — pins + documenting comments updated to the new verbatim String-constructor frontier.
- `docs/findings/2026-07-19-unsafe-array-intrinsics.md` — findings record: mechanism, statics/values/semantics, before/after frontier for both pins, and stop rationale.

The `writer_graph_frontier` completion milestone is unaffected (it cleared the old `ByteBuffer.UNSAFE` wall long ago via PR #1354) and still runs end-to-end.

## Gate

- `cargo build --workspace` — clean
- `cargo test --workspace` — **3147 passed / 0 failed / 3 ignored**
- `cargo fmt --all --check` — clean
- `cargo +1.97.0 clippy --workspace --all-targets -- -W clippy::pedantic -W clippy::nursery` under `RUSTFLAGS=-D warnings` — clean
- HelloWorld smoke exits 0 in synthetic, `DUKE_LAYOUT_CHECK=fail`, and `--real-jdk` modes
- OSS canaries (gson / slf4j / commons-lang3) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSgHUM1sPc4KvsAGYniWeg)_