### PR TITLE
Pin java.util.concurrent / java.lang callback natives across ops.invoke (GC-safe, via NativeRootScope)

### DIFF
--- a/crates/duke-interpreter/src/native/java_lang.rs
+++ b/crates/duke-interpreter/src/native/java_lang.rs
@@ -1364,15 +1364,23 @@ pub(crate) fn native_class_new_instance(
         });
     }
 
-    let instance_ref = ops.allocate_instance(heap, output, &class_key)?;
-    match ops.invoke(
+    let mut instance_ref = ops.allocate_instance(heap, output, &class_key)?;
+    // Pin the freshly allocated instance across the constructor callback: a nested
+    // `<init>` can allocate heavily and trigger one or more GCs, which would
+    // relocate or reclaim the bare instance reference we return. The pin keeps it
+    // alive and forwarded in place on every collection.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut instance_ref);
+    let init_result = ops.invoke(
         heap,
         output,
         &class_key,
         "<init>",
         &constructor.descriptor,
         vec![Slot::Reference(Some(instance_ref))],
-    ) {
+    );
+    drop(scope);
+    match init_result {
         Ok(_) => Ok(Some(Slot::Reference(Some(instance_ref)))),
         Err(err) => Err(err),
     }

--- a/crates/duke-interpreter/src/native/java_lang.rs
+++ b/crates/duke-interpreter/src/native/java_lang.rs
@@ -1716,7 +1716,14 @@ pub(crate) fn native_system_get_properties(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     ops.ensure_class_initialized(heap, output, "java/util/Properties")?;
-    let properties_ref = ops.allocate_instance(heap, output, "java/util/Properties")?;
+    let mut properties_ref = ops.allocate_instance(heap, output, "java/util/Properties")?;
+    // Pin the Properties instance across the `<init>` invoke AND the whole
+    // setProperty loop: it is re-dereferenced on every iteration (and returned at
+    // the end), while each iteration both runs a callback and allocates fresh
+    // key/value strings that may trigger GC. The pin keeps it alive and forwarded
+    // in place across ANY number of collections.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut properties_ref);
     ops.invoke(
         heap,
         output,
@@ -1743,6 +1750,7 @@ pub(crate) fn native_system_get_properties(
         )?;
     }
 
+    drop(scope);
     Ok(Some(Slot::Reference(Some(properties_ref))))
 }
 /// Native: `System.getSecurityManager()SecurityManager` - Duke runs without a security manager.

--- a/crates/duke-interpreter/src/native/java_util_concurrent.rs
+++ b/crates/duke-interpreter/src/native/java_util_concurrent.rs
@@ -2128,24 +2128,46 @@ pub(crate) fn native_concurrent_hashmap_for_each(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let consumer_ref = extract_ref_arg(args, 1)?;
-    let consumer_slot = Slot::Reference(Some(consumer_ref));
+    let mut consumer_ref = extract_ref_arg(args, 1)?;
     let consumer_class = heap.get(consumer_ref)?.class_name.clone();
     let lock = concurrent_hashmap_lock(heap, this_ref)?;
     let entries = {
         let _guard = concurrent_hashmap_guard(&lock);
         chm_entry_snapshot(heap, this_ref)?
     };
+    // Flatten the (key, value) snapshot into a single interleaved
+    // [k0,v0,k1,v1,...] buffer so the whole run of not-yet-visited slots can be
+    // pinned as one GC handle. Empty map -> empty buffer -> pin_slots is a no-op
+    // and the loop runs zero times.
+    let mut entries_flat: Vec<Slot> = Vec::with_capacity(entries.len() * 2);
     for (key, value) in entries {
+        entries_flat.push(key);
+        entries_flat.push(value);
+    }
+    // Pin the consumer and the snapshot buffer across the callback loop: each
+    // collection the consumer triggers keeps them alive (gather_roots) and
+    // forwards them in place (patch_forwarded_slots), so the not-yet-visited
+    // pairs stay valid across ANY number of collections.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut consumer_ref);
+    scope.pin_slots(&mut entries_flat);
+    // Index access (not `.iter()`) is deliberate: iterating by reference would
+    // hold a live `&[Slot]` borrow of the pinned buffer across `ops.invoke`,
+    // which the collector writes through the pin handle.
+    let pair_count = entries_flat.len() / 2;
+    for i in 0..pair_count {
+        let key = entries_flat[i * 2];
+        let value = entries_flat[i * 2 + 1];
         ops.invoke(
             heap,
             out,
             &consumer_class,
             "accept",
             "(Ljava/lang/Object;Ljava/lang/Object;)V",
-            vec![consumer_slot, key, value],
+            vec![Slot::Reference(Some(consumer_ref)), key, value],
         )?;
     }
+    drop(scope);
     Ok(None)
 }
 

--- a/crates/duke-interpreter/src/native/java_util_concurrent.rs
+++ b/crates/duke-interpreter/src/native/java_util_concurrent.rs
@@ -1886,8 +1886,8 @@ pub(crate) fn native_concurrent_hashmap_compute_if_absent(
     _control: &mut NativeControl,
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    let key = chm_non_null_arg(args, 1)?;
+    let mut this_ref = extract_ref_arg(args, 0)?;
+    let mut key = chm_non_null_arg(args, 1)?;
     let fn_ref = extract_ref_arg(args, 2)?;
     let fn_slot = Slot::Reference(Some(fn_ref));
     let fn_class = heap.get(fn_ref)?.class_name.clone();
@@ -1900,6 +1900,12 @@ pub(crate) fn native_concurrent_hashmap_compute_if_absent(
         }
     }
 
+    // Pin `this_ref`/`key` across the mapping function: the lock is dropped for
+    // the callback, so both must survive and be forwarded in place on every
+    // collection it triggers before we re-lock and re-read the map below.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut this_ref);
+    scope.pin_slot(&mut key);
     let computed = ops.invoke(
         heap,
         out,
@@ -1908,6 +1914,7 @@ pub(crate) fn native_concurrent_hashmap_compute_if_absent(
         "(Ljava/lang/Object;)Ljava/lang/Object;",
         vec![fn_slot, key],
     )?;
+    drop(scope);
     let Some(value) = computed else {
         return Ok(Some(Slot::Reference(None)));
     };
@@ -1935,8 +1942,8 @@ pub(crate) fn native_concurrent_hashmap_compute_if_present(
     _control: &mut NativeControl,
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    let key = chm_non_null_arg(args, 1)?;
+    let mut this_ref = extract_ref_arg(args, 0)?;
+    let mut key = chm_non_null_arg(args, 1)?;
     let fn_ref = extract_ref_arg(args, 2)?;
     let fn_slot = Slot::Reference(Some(fn_ref));
     let fn_class = heap.get(fn_ref)?.class_name.clone();
@@ -1950,6 +1957,11 @@ pub(crate) fn native_concurrent_hashmap_compute_if_present(
         }
     };
 
+    // Pin `this_ref`/`key` across the remapping function so both survive and are
+    // forwarded in place on every collection it triggers before we re-lock.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut this_ref);
+    scope.pin_slot(&mut key);
     let new_value = ops.invoke(
         heap,
         out,
@@ -1958,6 +1970,7 @@ pub(crate) fn native_concurrent_hashmap_compute_if_present(
         "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
         vec![fn_slot, key, old_value],
     )?;
+    drop(scope);
     let _guard = concurrent_hashmap_guard(&lock);
     match new_value {
         Some(value) if !matches!(value, Slot::Reference(None)) => {
@@ -1987,8 +2000,8 @@ pub(crate) fn native_concurrent_hashmap_compute(
     _control: &mut NativeControl,
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    let key = chm_non_null_arg(args, 1)?;
+    let mut this_ref = extract_ref_arg(args, 0)?;
+    let mut key = chm_non_null_arg(args, 1)?;
     let fn_ref = extract_ref_arg(args, 2)?;
     let fn_slot = Slot::Reference(Some(fn_ref));
     let fn_class = heap.get(fn_ref)?.class_name.clone();
@@ -2000,6 +2013,11 @@ pub(crate) fn native_concurrent_hashmap_compute(
             .map_or(Slot::Reference(None), |i| fields[i + 1])
     };
 
+    // Pin `this_ref`/`key` across the remapping function so both survive and are
+    // forwarded in place on every collection it triggers before we re-lock.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut this_ref);
+    scope.pin_slot(&mut key);
     let new_value = ops.invoke(
         heap,
         out,
@@ -2008,6 +2026,7 @@ pub(crate) fn native_concurrent_hashmap_compute(
         "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
         vec![fn_slot, key, old_value],
     )?;
+    drop(scope);
     let _guard = concurrent_hashmap_guard(&lock);
     match new_value {
         Some(value) if !matches!(value, Slot::Reference(None)) => {
@@ -2037,8 +2056,8 @@ pub(crate) fn native_concurrent_hashmap_merge(
     _control: &mut NativeControl,
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
-    let this_ref = extract_ref_arg(args, 0)?;
-    let key = chm_non_null_arg(args, 1)?;
+    let mut this_ref = extract_ref_arg(args, 0)?;
+    let mut key = chm_non_null_arg(args, 1)?;
     let value = chm_non_null_arg(args, 2)?;
     let fn_ref = extract_ref_arg(args, 3)?;
     let fn_slot = Slot::Reference(Some(fn_ref));
@@ -2063,6 +2082,12 @@ pub(crate) fn native_concurrent_hashmap_merge(
         return Ok(Some(value));
     };
 
+    // Pin `this_ref`/`key` across the remapping function so the read-modify-write
+    // stays linearizable: both are forwarded in place on every collection the
+    // callback triggers, so the write-back below always lands on the right entry.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut this_ref);
+    scope.pin_slot(&mut key);
     let merged = ops.invoke(
         heap,
         out,
@@ -2071,6 +2096,7 @@ pub(crate) fn native_concurrent_hashmap_merge(
         "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
         vec![fn_slot, old_value, value],
     )?;
+    drop(scope);
     let _guard = concurrent_hashmap_guard(&lock);
     match merged {
         Some(merged_value) if !matches!(merged_value, Slot::Reference(None)) => {

--- a/crates/duke-interpreter/src/native/java_util_concurrent.rs
+++ b/crates/duke-interpreter/src/native/java_util_concurrent.rs
@@ -2499,11 +2499,19 @@ fn lbq_drain_into(
     heap: &mut duke_gc::Heap,
     output: &mut dyn Write,
     ops: &mut dyn CallbackOps,
-    this_ref: u64,
-    target_ref: u64,
+    mut this_ref: u64,
+    mut target_ref: u64,
     max: i32,
 ) -> Result<Option<Slot>> {
     let target_class = heap.get(target_ref)?.class_name.clone();
+    // Pin the queue and the target across the whole drain loop. Each `add`
+    // callback may trigger GC, and both refs are re-dereferenced afterwards on
+    // the next iteration (lbq_dequeue reads `this_ref`, and `target_ref` is
+    // re-passed into the callback). The pin forwards them in place on every
+    // collection, so both stay valid across ANY number of GCs.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut this_ref);
+    scope.pin_ref(&mut target_ref);
     let mut count: i32 = 0;
     while count < max {
         let Some(elem) = lbq_dequeue(heap, this_ref)? else {
@@ -2519,6 +2527,7 @@ fn lbq_drain_into(
         )?;
         count += 1;
     }
+    drop(scope);
     Ok(Some(Slot::Int(count)))
 }
 

--- a/crates/duke-interpreter/src/native/java_util_logging.rs
+++ b/crates/duke-interpreter/src/native/java_util_logging.rs
@@ -599,8 +599,14 @@ pub(crate) fn native_jul_log_manager_read_configuration_stream(
     _control: &mut NativeControl,
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
-    let stream_ref = extract_ref_arg(args, 1)?;
+    let mut stream_ref = extract_ref_arg(args, 1)?;
     let stream_class = heap.get(stream_ref)?.class_name.clone();
+    // Pin the stream across the read loop: each `read()` callback may trigger GC,
+    // and `stream_ref` is re-dereferenced (re-passed) on the next iteration. The
+    // pin keeps it alive and forwarded in place on every collection, so it stays
+    // valid across ANY number of GCs.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut stream_ref);
     for _ in 0..1_048_576 {
         match ops.invoke(
             heap,
@@ -616,6 +622,7 @@ pub(crate) fn native_jul_log_manager_read_configuration_stream(
             Err(err) => return Err(err),
         }
     }
+    drop(scope);
     Ok(None)
 }
 pub(crate) fn native_jul_log_manager_add_logger(

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -35063,3 +35063,182 @@ fn hashmap_for_each_survives_mid_iteration_gc() {
         0
     );
 }
+
+// ---------------------------------------------------------------------------
+// GC-pin regression tests for the java.util.concurrent / java.lang callback
+// natives converted to `NativeRootScope` (see the pin API in common.rs). Each
+// drives a `CallbackOps` double whose `invoke` fires TWO promoting collections
+// (crossing the multi-GC regime that the old one-shot patch corrupts under),
+// then asserts the native's held reference tracked its object correctly. Every
+// test fails if the native holds a BARE reference across `ops.invoke`, and
+// passes with the pin. Modeled on the java_util shapes at
+// `hashmap_compute_if_absent_does_not_corrupt_key_across_two_gcs` /
+// `hashmap_for_each_survives_two_gcs_during_callback`.
+// ---------------------------------------------------------------------------
+
+/// Family 1 (CHM compute group). `ConcurrentHashMap.computeIfAbsent` holds
+/// `key`/`this_ref` across the mapping function. Under two collections with
+/// young-index reuse a one-shot post-invoke patch rewrites the held `key` onto
+/// an unrelated live decoy; with `NativeRootScope` the pin forwards `key` from
+/// its CURRENT value at every collect and the ORIGINAL key is stored. Mirror of
+/// the `HashMap` corruption repro, exercising the converted CHM native (which
+/// re-reads `this_ref`/`key` after re-locking, the same hazard shape).
+#[test]
+#[allow(clippy::too_many_lines)]
+fn concurrent_hashmap_compute_if_absent_does_not_corrupt_key_across_two_gcs() {
+    use std::collections::HashMap;
+
+    const KEY_TAG: i32 = 777;
+    const DECOY_TAG: i32 = 888;
+    const VALUE_TAG: i32 = 555;
+
+    struct ComputeGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        key_idx: u64,
+    }
+
+    impl ComputeGcOps {
+        fn collect_once(&mut self, heap: &mut duke_gc::Heap) {
+            let roots = gather_roots(&self.caller_frame, &[], &self.registry, &self.string_intern);
+            heap.collect(&roots);
+            patch_forwarded_slots(
+                &mut self.caller_frame,
+                &mut [],
+                &mut self.registry,
+                heap,
+                &mut self.string_intern,
+            );
+        }
+    }
+
+    impl CallbackOps for ComputeGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            _args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            // GC1: relocates `key` (its native-local copy goes stale).
+            self.collect_once(heap);
+
+            // Place a live, rooted decoy at the key's now-freed original young
+            // index, so that index becomes a live from-key in GC2's rebuilt map.
+            let decoy = loop {
+                let idx = heap.allocate("duke/test/Decoy".to_string(), 1);
+                assert!(
+                    idx <= self.key_idx,
+                    "overshot the freed key index while placing the decoy"
+                );
+                if idx == self.key_idx {
+                    heap.get_mut(idx).unwrap().fields[0] = Slot::Int(DECOY_TAG);
+                    break idx;
+                }
+            };
+            self.caller_frame
+                .store_local(3, Slot::Reference(Some(decoy)))
+                .unwrap();
+
+            // GC2: forwards the decoy from `key_idx`. A one-shot patch would now
+            // rewrite `key` (== key_idx) onto the decoy.
+            self.collect_once(heap);
+
+            let v = heap.allocate("duke/test/Val".to_string(), 1);
+            heap.get_mut(v).unwrap().fields[0] = Slot::Int(VALUE_TAG);
+            Ok(Some(Slot::Reference(Some(v))))
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+
+    // Promote the map to the old gen so `this_ref` is address-stable across the
+    // minor collections, isolating the test on `key` corruption.
+    let mut map_ref = heap.allocate("java/util/concurrent/ConcurrentHashMap".to_string(), 1);
+    heap.get_mut(map_ref).unwrap().fields[0] = Slot::Int(0);
+    for _ in 0..8 {
+        if map_ref & (1u64 << 63) != 0 {
+            break;
+        }
+        heap.collect(&[Slot::Reference(Some(map_ref))]);
+        let mut s = Slot::Reference(Some(map_ref));
+        heap.apply_forward(&mut s);
+        map_ref = s.as_reference().unwrap();
+    }
+    assert!(
+        map_ref & (1u64 << 63) != 0,
+        "map should have been promoted to the old generation"
+    );
+
+    let fn_ref = heap.allocate("duke/test/Fn".to_string(), 0);
+    for _ in 0..8 {
+        let _ = heap.allocate("duke/test/Pad".to_string(), 1);
+    }
+    let key_ref = heap.allocate("duke/test/Val".to_string(), 1);
+    heap.get_mut(key_ref).unwrap().fields[0] = Slot::Int(KEY_TAG);
+    assert_eq!(
+        key_ref & (1u64 << 63),
+        0,
+        "key must be a young reference for the index-reuse scenario"
+    );
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        8,
+        vec![
+            Slot::Reference(Some(map_ref)),
+            Slot::Reference(Some(key_ref)),
+            Slot::Reference(Some(fn_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = ComputeGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        key_idx: key_ref,
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    native_concurrent_hashmap_compute_if_absent(
+        &[
+            Slot::Reference(Some(map_ref)),
+            Slot::Reference(Some(key_ref)),
+            Slot::Reference(Some(fn_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    let stored = heap.get(map_ref).unwrap();
+    assert_eq!(stored.fields[0], Slot::Int(1), "one entry should be stored");
+    let stored_key = match stored.fields[1] {
+        Slot::Reference(Some(r)) => r,
+        other => panic!("stored key is not a reference: {other:?}"),
+    };
+    let stored_key_tag = match heap.get(stored_key).unwrap().fields.first() {
+        Some(Slot::Int(n)) => *n,
+        other => panic!("stored key has no int tag: {other:?}"),
+    };
+    assert_eq!(
+        stored_key_tag, KEY_TAG,
+        "computeIfAbsent stored a CORRUPTED key (decoy) after two GCs; a \
+         bare held key would have been rewritten onto an unrelated object"
+    );
+}

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -35446,8 +35446,7 @@ fn lbq_drain_to_survives_two_gcs_during_callback() {
 
     let mut heap = duke_gc::Heap::new();
     // Queue: fields[0] = size, fields[1..] = elements.
-    let queue_ref =
-        heap.allocate("java/util/concurrent/LinkedBlockingQueue".to_string(), 4);
+    let queue_ref = heap.allocate("java/util/concurrent/LinkedBlockingQueue".to_string(), 4);
     let target_ref = heap.allocate("java/util/ArrayList".to_string(), 1);
     heap.get_mut(target_ref).unwrap().fields[0] = Slot::Int(0);
 

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -35246,10 +35246,11 @@ fn concurrent_hashmap_compute_if_absent_does_not_corrupt_key_across_two_gcs() {
 /// Family 2 (CHM forEach). `ConcurrentHashMap.forEach` snapshots (key, value)
 /// pairs and invokes the consumer once per pair. This consumer double forces TWO
 /// full collections per callback. With a bare snapshot the not-yet-visited pairs
-/// go stale and the consumer observes wrong tags / i32::MIN; with the pinned
+/// go stale and the consumer observes wrong tags / `i32::MIN`; with the pinned
 /// snapshot buffer every value is forwarded in place after each collect and
 /// observed correctly. Mirror of `hashmap_for_each_survives_two_gcs_during_callback`.
 #[test]
+#[allow(clippy::too_many_lines)]
 fn concurrent_hashmap_for_each_survives_two_gcs_during_callback() {
     use std::collections::HashMap;
 
@@ -35380,6 +35381,7 @@ fn concurrent_hashmap_for_each_survives_two_gcs_during_callback() {
 /// so the drain stops short or reads garbage. With `NativeRootScope` both refs are
 /// forwarded in place on every collect and the full queue drains in order.
 #[test]
+#[allow(clippy::too_many_lines)]
 fn lbq_drain_to_survives_two_gcs_during_callback() {
     use std::collections::HashMap;
 
@@ -35517,8 +35519,8 @@ fn lbq_drain_to_survives_two_gcs_during_callback() {
 /// while every iteration both runs a callback and allocates fresh key/value
 /// strings. With a bare ref the instance is unrooted across the callback GCs and
 /// its slot is reused, so the returned handle is corrupt. With `NativeRootScope`
-/// the pin keeps it alive (via gather_roots) and forwarded (via
-/// patch_forwarded_slots) across every collection, so the original instance is
+/// the pin keeps it alive (via `gather_roots`) and forwarded (via
+/// `patch_forwarded_slots`) across every collection, so the original instance is
 /// returned intact.
 #[test]
 fn system_get_properties_survives_gc_during_callbacks() {

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -35242,3 +35242,132 @@ fn concurrent_hashmap_compute_if_absent_does_not_corrupt_key_across_two_gcs() {
          bare held key would have been rewritten onto an unrelated object"
     );
 }
+
+/// Family 2 (CHM forEach). `ConcurrentHashMap.forEach` snapshots (key, value)
+/// pairs and invokes the consumer once per pair. This consumer double forces TWO
+/// full collections per callback. With a bare snapshot the not-yet-visited pairs
+/// go stale and the consumer observes wrong tags / i32::MIN; with the pinned
+/// snapshot buffer every value is forwarded in place after each collect and
+/// observed correctly. Mirror of `hashmap_for_each_survives_two_gcs_during_callback`.
+#[test]
+fn concurrent_hashmap_for_each_survives_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    struct ForEachGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        observed_tags: Vec<i32>,
+    }
+
+    impl CallbackOps for ForEachGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            let tag = match args.get(2) {
+                Some(Slot::Reference(Some(r))) => heap
+                    .get(*r)
+                    .ok()
+                    .and_then(|o| match o.fields.first() {
+                        Some(Slot::Int(n)) => Some(*n),
+                        _ => None,
+                    })
+                    .unwrap_or(i32::MIN),
+                _ => i32::MIN,
+            };
+            self.observed_tags.push(tag);
+
+            for _ in 0..2 {
+                for _ in 0..4 {
+                    let g = heap.allocate("duke/test/Garbage".to_string(), 1);
+                    if let Ok(o) = heap.get_mut(g) {
+                        o.fields[0] = Slot::Int(-777);
+                    }
+                }
+                let roots =
+                    gather_roots(&self.caller_frame, &[], &self.registry, &self.string_intern);
+                heap.collect(&roots);
+                patch_forwarded_slots(
+                    &mut self.caller_frame,
+                    &mut [],
+                    &mut self.registry,
+                    heap,
+                    &mut self.string_intern,
+                );
+            }
+            Ok(None)
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let map_ref = heap.allocate("java/util/concurrent/ConcurrentHashMap".to_string(), 7);
+    let consumer_ref = heap.allocate("duke/test/Consumer".to_string(), 0);
+
+    let mut kv = Vec::new();
+    for i in 0..3i32 {
+        let k = heap.allocate_string(format!("k{i}"));
+        let v = heap.allocate("duke/test/Val".to_string(), 1);
+        heap.get_mut(v).unwrap().fields[0] = Slot::Int(100 + i);
+        kv.push((k, v));
+    }
+    {
+        let m = heap.get_mut(map_ref).unwrap();
+        m.fields[0] = Slot::Int(3);
+        for (i, (k, v)) in kv.iter().enumerate() {
+            m.fields[1 + i * 2] = Slot::Reference(Some(*k));
+            m.fields[2 + i * 2] = Slot::Reference(Some(*v));
+        }
+    }
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(map_ref)),
+            Slot::Reference(Some(consumer_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = ForEachGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        observed_tags: Vec::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    native_concurrent_hashmap_for_each(
+        &[
+            Slot::Reference(Some(map_ref)),
+            Slot::Reference(Some(consumer_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    assert_eq!(
+        ops.observed_tags,
+        vec![100, 101, 102],
+        "consumer observed stale/relocated values after multiple GCs \
+         (dangling snapshot references)"
+    );
+}

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -35511,3 +35511,108 @@ fn lbq_drain_to_survives_two_gcs_during_callback() {
         "drainTo should have drained all three elements"
     );
 }
+
+/// Family 4 (System.getProperties). `native_system_get_properties` allocates a
+/// Properties instance and holds it across the `<init>` callback and the whole
+/// setProperty loop (re-passing it each iteration and returning it at the end),
+/// while every iteration both runs a callback and allocates fresh key/value
+/// strings. With a bare ref the instance is unrooted across the callback GCs and
+/// its slot is reused, so the returned handle is corrupt. With `NativeRootScope`
+/// the pin keeps it alive (via gather_roots) and forwarded (via
+/// patch_forwarded_slots) across every collection, so the original instance is
+/// returned intact.
+#[test]
+fn system_get_properties_survives_gc_during_callbacks() {
+    use std::collections::HashMap;
+
+    const SENTINEL: i32 = 424_242;
+
+    struct PropsGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+    }
+
+    impl CallbackOps for PropsGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            _args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            // Two collections per callback, allocating garbage so a freed slot is
+            // reused (an unpinned Properties handle would then read garbage).
+            for _ in 0..2 {
+                for _ in 0..4 {
+                    let g = heap.allocate("duke/test/Garbage".to_string(), 1);
+                    if let Ok(o) = heap.get_mut(g) {
+                        o.fields[0] = Slot::Int(-777);
+                    }
+                }
+                let roots =
+                    gather_roots(&self.caller_frame, &[], &self.registry, &self.string_intern);
+                heap.collect(&roots);
+                patch_forwarded_slots(
+                    &mut self.caller_frame,
+                    &mut [],
+                    &mut self.registry,
+                    heap,
+                    &mut self.string_intern,
+                );
+            }
+            Ok(None)
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+
+        fn allocate_instance(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            class: &str,
+        ) -> Result<u64> {
+            let r = heap.allocate(class.to_string(), 4);
+            // Tag the instance so we can prove the RETURNED handle still points at
+            // this exact object after the callback collections.
+            heap.get_mut(r)?.fields[0] = Slot::Int(SENTINEL);
+            Ok(r)
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let caller_frame = duke_runtime::Frame::new(4, 1, vec![]).unwrap();
+
+    let mut ops = PropsGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result =
+        native_system_get_properties(&[], &mut heap, &mut out, &mut control, &mut ops).unwrap();
+
+    let props_ref = match result {
+        Some(Slot::Reference(Some(r))) => r,
+        other => panic!("getProperties did not return a reference: {other:?}"),
+    };
+    let tag = match heap.get(props_ref).unwrap().fields.first() {
+        Some(Slot::Int(n)) => *n,
+        other => panic!("returned Properties has no int tag: {other:?}"),
+    };
+    assert_eq!(
+        tag, SENTINEL,
+        "getProperties returned a CORRUPTED handle after callback GCs; a bare \
+         held ref was collected/reused across the <init> + setProperty callbacks"
+    );
+}

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -35371,3 +35371,143 @@ fn concurrent_hashmap_for_each_survives_two_gcs_during_callback() {
          (dangling snapshot references)"
     );
 }
+
+/// Family 3 (LinkedBlockingQueue.drainTo). `lbq_drain_into` dequeues an element
+/// from the queue, hands it to `target.add(elem)`, and loops — re-dereferencing
+/// the bare `this_ref` (to dequeue the next element) and re-passing `target_ref`
+/// on every iteration. Each `add` callback fires two collections; with bare refs
+/// the queue/target relocate and the next dequeue reads a stale (reused) address,
+/// so the drain stops short or reads garbage. With `NativeRootScope` both refs are
+/// forwarded in place on every collect and the full queue drains in order.
+#[test]
+fn lbq_drain_to_survives_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    struct AddGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        observed_tags: Vec<i32>,
+    }
+
+    impl CallbackOps for AddGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            // args[0] = target, args[1] = the element handed to target.add(...).
+            let tag = match args.get(1) {
+                Some(Slot::Reference(Some(r))) => heap
+                    .get(*r)
+                    .ok()
+                    .and_then(|o| match o.fields.first() {
+                        Some(Slot::Int(n)) => Some(*n),
+                        _ => None,
+                    })
+                    .unwrap_or(i32::MIN),
+                _ => i32::MIN,
+            };
+            self.observed_tags.push(tag);
+
+            for _ in 0..2 {
+                for _ in 0..4 {
+                    let g = heap.allocate("duke/test/Garbage".to_string(), 1);
+                    if let Ok(o) = heap.get_mut(g) {
+                        o.fields[0] = Slot::Int(-777);
+                    }
+                }
+                let roots =
+                    gather_roots(&self.caller_frame, &[], &self.registry, &self.string_intern);
+                heap.collect(&roots);
+                patch_forwarded_slots(
+                    &mut self.caller_frame,
+                    &mut [],
+                    &mut self.registry,
+                    heap,
+                    &mut self.string_intern,
+                );
+            }
+            Ok(Some(Slot::Int(1)))
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    // Queue: fields[0] = size, fields[1..] = elements.
+    let queue_ref =
+        heap.allocate("java/util/concurrent/LinkedBlockingQueue".to_string(), 4);
+    let target_ref = heap.allocate("java/util/ArrayList".to_string(), 1);
+    heap.get_mut(target_ref).unwrap().fields[0] = Slot::Int(0);
+
+    let mut elems = Vec::new();
+    for i in 0..3i32 {
+        let v = heap.allocate("duke/test/Val".to_string(), 1);
+        heap.get_mut(v).unwrap().fields[0] = Slot::Int(100 + i);
+        elems.push(v);
+    }
+    {
+        let q = heap.get_mut(queue_ref).unwrap();
+        q.fields[0] = Slot::Int(3);
+        for (i, v) in elems.iter().enumerate() {
+            q.fields[1 + i] = Slot::Reference(Some(*v));
+        }
+    }
+
+    // Caller frame roots the LIVE queue + target (as an interpreter frame would),
+    // so those survive and are forwarded; only the native's private bare
+    // this_ref/target_ref copies are at risk without the pin.
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(queue_ref)),
+            Slot::Reference(Some(target_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = AddGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        observed_tags: Vec::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_lbq_drain_to(
+        &[
+            Slot::Reference(Some(queue_ref)),
+            Slot::Reference(Some(target_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    assert_eq!(
+        ops.observed_tags,
+        vec![100, 101, 102],
+        "drainTo handed target.add stale/wrong elements after multiple GCs \
+         (dangling queue reference across the drain loop)"
+    );
+    assert_eq!(
+        result,
+        Some(Slot::Int(3)),
+        "drainTo should have drained all three elements"
+    );
+}

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -35616,3 +35616,242 @@ fn system_get_properties_survives_gc_during_callbacks() {
          held ref was collected/reused across the <init> + setProperty callbacks"
     );
 }
+
+/// Family 5a (Class.newInstance). `native_class_new_instance` allocates the
+/// instance, then holds its bare reference across the `<init>` constructor
+/// callback and returns it. A nested constructor can allocate heavily and trigger
+/// GC; with a bare ref the instance is unrooted and its slot reused, so the
+/// returned handle is corrupt. With `NativeRootScope` the pin keeps it alive and
+/// forwarded across every collection and the original instance is returned.
+#[test]
+fn class_new_instance_survives_gc_during_constructor() {
+    use std::collections::HashMap;
+
+    const SENTINEL: i32 = 313_131;
+
+    struct NewInstanceGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+    }
+
+    impl CallbackOps for NewInstanceGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            _args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            for _ in 0..2 {
+                for _ in 0..4 {
+                    let g = heap.allocate("duke/test/Garbage".to_string(), 1);
+                    if let Ok(o) = heap.get_mut(g) {
+                        o.fields[0] = Slot::Int(-777);
+                    }
+                }
+                let roots =
+                    gather_roots(&self.caller_frame, &[], &self.registry, &self.string_intern);
+                heap.collect(&roots);
+                patch_forwarded_slots(
+                    &mut self.caller_frame,
+                    &mut [],
+                    &mut self.registry,
+                    heap,
+                    &mut self.string_intern,
+                );
+            }
+            Ok(None)
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, class: &str) -> Result<ReflectedClassInfo> {
+            let mut info = empty_reflected_class_info();
+            info.internal_name = class.to_string();
+            info.binary_name = class.replace('/', ".");
+            info.methods = vec![ReflectedMethodInfo {
+                name: "<init>".to_string(),
+                descriptor: "()V".to_string(),
+                is_public: true,
+                is_static: false,
+                annotations: Vec::new(),
+                annotation_default: None,
+            }];
+            Ok(info)
+        }
+
+        fn allocate_instance(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            class: &str,
+        ) -> Result<u64> {
+            let r = heap.allocate(class.to_string(), 4);
+            heap.get_mut(r)?.fields[0] = Slot::Int(SENTINEL);
+            Ok(r)
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    // The `Class` object: `class_key_from_ref` reads its string_value as the key.
+    let class_ref = heap.allocate_string("duke/test/Thing".to_string());
+    let caller_frame =
+        duke_runtime::Frame::new(4, 1, vec![Slot::Reference(Some(class_ref))]).unwrap();
+
+    let mut ops = NewInstanceGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_class_new_instance(
+        &[Slot::Reference(Some(class_ref))],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    let instance_ref = match result {
+        Some(Slot::Reference(Some(r))) => r,
+        other => panic!("newInstance did not return a reference: {other:?}"),
+    };
+    let tag = match heap.get(instance_ref).unwrap().fields.first() {
+        Some(Slot::Int(n)) => *n,
+        other => panic!("returned instance has no int tag: {other:?}"),
+    };
+    assert_eq!(
+        tag, SENTINEL,
+        "newInstance returned a CORRUPTED handle after the constructor GCs; a \
+         bare held instance ref was collected/reused across the <init> callback"
+    );
+}
+
+/// Family 5b (LogManager.readConfiguration(InputStream)). The JUL read-config
+/// native holds a bare `stream_ref` across a loop of `read()` callbacks,
+/// re-passing it each iteration. Each `read()` fires two collections; with a bare
+/// ref the stream is unrooted and its slot reused, so the next `read()` gets a
+/// corrupt stream handle. With `NativeRootScope` the pin keeps it alive and
+/// forwarded across every collection, so every `read()` sees the intact stream.
+#[test]
+fn jul_read_configuration_stream_survives_gc_during_reads() {
+    use std::collections::HashMap;
+
+    const SENTINEL: i32 = 909_090;
+
+    struct ReadGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        calls: i32,
+        observed_tags: Vec<i32>,
+    }
+
+    impl CallbackOps for ReadGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            // args[0] is the stream handle the native re-passes each iteration.
+            let tag = match args.first() {
+                Some(Slot::Reference(Some(r))) => heap
+                    .get(*r)
+                    .ok()
+                    .and_then(|o| match o.fields.first() {
+                        Some(Slot::Int(n)) => Some(*n),
+                        _ => None,
+                    })
+                    .unwrap_or(i32::MIN),
+                _ => i32::MIN,
+            };
+            self.observed_tags.push(tag);
+
+            for _ in 0..2 {
+                for _ in 0..4 {
+                    let g = heap.allocate("duke/test/Garbage".to_string(), 1);
+                    if let Ok(o) = heap.get_mut(g) {
+                        o.fields[0] = Slot::Int(-777);
+                    }
+                }
+                let roots =
+                    gather_roots(&self.caller_frame, &[], &self.registry, &self.string_intern);
+                heap.collect(&roots);
+                patch_forwarded_slots(
+                    &mut self.caller_frame,
+                    &mut [],
+                    &mut self.registry,
+                    heap,
+                    &mut self.string_intern,
+                );
+            }
+
+            self.calls += 1;
+            // Continue for the first three reads, then signal EOF (-1) to stop.
+            if self.calls >= 3 {
+                Ok(Some(Slot::Int(-1)))
+            } else {
+                Ok(Some(Slot::Int(1)))
+            }
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let manager_ref = heap.allocate("java/util/logging/LogManager".to_string(), 1);
+    let stream_ref = heap.allocate("duke/io/ResourceInputStream".to_string(), 1);
+    heap.get_mut(stream_ref).unwrap().fields[0] = Slot::Int(SENTINEL);
+
+    // Deliberately do NOT root the stream in the caller frame: only the native's
+    // pin should keep it alive across the read callbacks.
+    let caller_frame =
+        duke_runtime::Frame::new(4, 1, vec![Slot::Reference(Some(manager_ref))]).unwrap();
+
+    let mut ops = ReadGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        calls: 0,
+        observed_tags: Vec::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    native_jul_log_manager_read_configuration_stream(
+        &[
+            Slot::Reference(Some(manager_ref)),
+            Slot::Reference(Some(stream_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    assert_eq!(
+        ops.observed_tags,
+        vec![SENTINEL, SENTINEL, SENTINEL],
+        "readConfiguration re-passed a stale/corrupt stream handle after \
+         callback GCs (dangling stream reference across the read loop)"
+    );
+}


### PR DESCRIPTION
## Before

Several native methods in `java_util_concurrent.rs` and `java_lang.rs` read a heap
reference (the map, the queue, a freshly-allocated instance, a stream) into a plain
Rust local, then run a user callback via `ops.invoke`, then dereference that same
bare local again after the callback returns. `ops.invoke` runs arbitrary Java, which
allocates and can fire one or more relocating garbage collections. A heap reference
sitting in a native's Rust local is invisible to the collector — it is not in any
interpreter frame slot — so across the callback it goes **stale** (points at the
object's old address) and, if the address is reused, silently **aliases an unrelated
live object**. The native then reads or writes the wrong object: a lost update, a
corrupted key, a wrong element, or a corrupt returned handle.

The prior single-hop `patch_forwarded_*` fix-up (from an earlier, closed attempt) is
**not** a sound fix here: it re-applies one collection's forward map after the
callback, which is correct under at most one GC per invoke but corrupts under more
than one GC plus young-index reuse. That is exactly what regressed
`concurrent_hashmap_contention_merge_is_linearizable` and is why these sites were
deferred.

## After

Each of these natives now pins the references it holds across the callback on a
`NativeRootScope` (the JNI-local-handle-style pin API in `common.rs`, from PR #1386).
The pin does two things on **every** collection the callback triggers: `gather_roots`
keeps the pinned target alive, and `patch_forwarded_slots` forwards the pinned local
in place (A→B, then B→C, …). So the native's held reference tracks its object across
**any** number of GCs — the only sound fix, and the one that keeps the linearizability
test green.

### Sites converted, per family

- **Family 1 — CHM compute group** (`java_util_concurrent.rs`): `computeIfAbsent`,
  `computeIfPresent`, `compute`, `merge`. Pin `this_ref` (`pin_ref`) + `key`
  (`pin_slot`) across the mapping/remapping function, drop after the invoke, then
  re-lock and write back. `merge` is the read-modify-write whose atomicity the
  linearizability test asserts. — `6433409`
- **Family 2 — CHM forEach** (`java_util_concurrent.rs`): flatten the `(key,value)`
  snapshot into one interleaved buffer, `pin_ref` the consumer + `pin_slots` the
  buffer, index-walk it (never by `&`-reference). Mirrors `native_properties_for_each`.
  — `db00959`
- **Family 3 — LinkedBlockingQueue.drainTo** (`java_util_concurrent.rs`): `pin_ref`
  the queue and the target across the whole drain loop (the queue is re-dequeued and
  the target re-passed every iteration). — `2270cdb`
- **Family 4 — System.getProperties** (`java_lang.rs`): `pin_ref` the Properties
  instance across the `<init>` invoke and the entire setProperty loop (re-passed each
  iteration, allocations in between, returned at the end). — `1a93cf3`
- **Family 5 — in-scope extras** (`java_lang.rs`, `java_util_logging.rs`):
  `native_class_new_instance` pins the freshly-allocated instance across the `<init>`
  constructor callback it returns; the JUL `readConfiguration(InputStream)` native
  pins the stream across its up-to-1M `read()` callback loop. Both are the same
  held-ref-across-`ops.invoke` shape and both converted cleanly with no semantic
  change. — `a85749a`

Follow-up commits: `7f628de` (fmt), `e83748e` (CI clippy pedantic/nursery on the new
tests).

## How

Mirror the existing `NativeRootScope` idiom already used at 18 call sites in
`java_util.rs` (exemplar: `native_properties_for_each`, PR #1389): snapshot/read →
`NativeRootScope::new()` → `pin_ref`/`pin_slot`/`pin_slots` immediately before the
invoke(s) → `drop(scope)` after the last use. No `patch_forwarded_*` single-hop
fix-ups anywhere. Every conversion is semantics-preserving; **no site was left
unconverted**.

### Why the pin API and not `patch_forwarded_*`

`native_concurrent_hashmap_merge` reads `old_value`/`key`/`this_ref` under the map
lock, drops the lock, and calls `Integer::sum` — which autoboxes, so the callback
allocates and, over 2000 accumulating merges against a growing live map, can fire more
than one GC. A single-hop post-invoke `apply_forward(this_ref)`/`(key)` under that
regime can rewrite a still-valid `this_ref`/`key` onto an unrelated young object
(stale from-address re-keyed against a later collection's forward map), so the
write-back lands on the wrong entry — a lost update, and the accumulator ends below
2000. The pin forwards the held refs in place on every collection instead, so the
write-back always lands on the right entry and every merge stays linearizable.

## Proof (final gate)

- `cargo build --workspace` — clean.
- `cargo test --workspace` — **3153 passed / 0 failed / 3 ignored** (baseline 3147 + 6
  new regression tests). `concurrent_hashmap_contention_merge_is_linearizable` and both
  existing `*_survives_mid_iteration_gc` repros stay green.
- `cargo fmt --all -- --check` — clean.
- CI clippy: `RUSTFLAGS="-D warnings" cargo +1.97.0 clippy --workspace --all-targets --
  -W clippy::pedantic -W clippy::nursery` — clean.
- HelloWorld both modes: `duke run HelloWorld.class` → `Hello, World!`;
  `DUKE_REAL_JDK=1 duke run HelloWorld.class` → real-jdk banner + `Hello, World!`.
- Canaries & non-ignored pins (classloader/streamencoder frontiers, spring_boot_jar,
  etc.) — all green in the workspace run.

### New regression tests (one per family; each sabotage-verified to FAIL without the pin and PASS with it)

- `concurrent_hashmap_compute_if_absent_does_not_corrupt_key_across_two_gcs` (decoy +
  young-index-reuse corruption repro, mirrors the `HashMap` one)
- `concurrent_hashmap_for_each_survives_two_gcs_during_callback`
- `lbq_drain_to_survives_two_gcs_during_callback`
- `system_get_properties_survives_gc_during_callbacks`
- `class_new_instance_survives_gc_during_constructor`
- `jul_read_configuration_stream_survives_gc_during_reads`

The merge family's atomicity is covered by the existing
`concurrent_hashmap_contention_merge_is_linearizable` (kept green), per the linearizability
rationale above.

## Sweep findings (in / out of scope)

Modules with **zero** `ops.invoke` cannot have this hazard: `java_io.rs`, `java_time.rs`,
`java_net.rs`, `java_security.rs`, `java_util_regex.rs`, `jdk_internal.rs`. `java_util.rs`
was already fully converted (18 pin sites). `common.rs` already uses the pin API. This PR
closes the remaining in-scope callback natives. **Out of scope / not touched:** `reflect.rs`
(`Method.invoke` / `Constructor.newInstance` — same shape, explicitly excluded),
registry/loader array-class paths, `jdk_internal.rs`.

## Follow-up

- **`duke_util.rs` (~130 `ops.invoke` sites)** — synthetic `duke/util` collection/stream/
  comparator natives. The dominant pattern there is safe (pass slots *into* invoke, return
  without re-dereferencing a held ref), but a subset of stream/iterator/collector natives
  that hold element refs across per-element callbacks may be the same shape. Flagged as a
  **separate follow-up audit**, out of this bounded lane.
- `reflect.rs` `native_reflect_method_invoke` / `native_reflect_constructor_new_instance`
  are the same shape and would convert identically when that module is in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4ptsL1tcQxScUFjq9TqHX

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4ptsL1tcQxScUFjq9TqHX)_