### PR TITLE
duke_util.rs: pin heap refs held across ops.invoke (GC-safety)

### DIFF
--- a/crates/duke-interpreter/src/native/duke_util.rs
+++ b/crates/duke-interpreter/src/native/duke_util.rs
@@ -3684,17 +3684,27 @@ pub(crate) fn native_then_comparing_compare(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let a = extract_slot_arg(args, 1);
-    let b = extract_slot_arg(args, 2);
+    let mut a = extract_slot_arg(args, 1);
+    let mut b = extract_slot_arg(args, 2);
     let primary = extract_first_field_arg(heap, this_ref)?;
-    let secondary = extract_field_arg(heap, this_ref, 1)?;
+    let mut secondary = extract_field_arg(heap, this_ref, 1)?;
+    // `secondary`, `a`, and `b` are held across the primary comparator's
+    // `compare` invoke (a GC point) and reused for the tie-break invoke.
+    // Without pinning, a relocating GC inside the primary callback would leave
+    // them stale before the secondary comparator runs.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut secondary);
+    scope.pin_slot(&mut a);
+    scope.pin_slot(&mut b);
     // Invoke primary.compare(a, b)
     let result = invoke_comparator(primary, a, b, heap, out, ops)?;
     if result != 0 {
+        drop(scope);
         return Ok(Some(Slot::Int(result)));
     }
     // Tie-break with secondary
     let result2 = invoke_comparator(secondary, a, b, heap, out, ops)?;
+    drop(scope);
     Ok(Some(Slot::Int(result2)))
 }
 /// Native: `AndPredicate.test(O)Z` — both predicates must return true.
@@ -3706,14 +3716,22 @@ pub(crate) fn native_and_predicate_test(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let elem = extract_slot_arg(args, 1);
+    let mut elem = extract_slot_arg(args, 1);
     let left = extract_first_field_arg(heap, this_ref)?;
-    let right = extract_field_arg(heap, this_ref, 1)?;
+    let mut right = extract_field_arg(heap, this_ref, 1)?;
+    // `right` and `elem` are held across the left predicate's `test` invoke
+    // (a GC point) and reused for the right predicate. Pin them so a relocating
+    // GC inside the left callback cannot leave them stale.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut right);
+    scope.pin_slot(&mut elem);
     let la = invoke_predicate_test(left, elem, heap, out, ops)?;
     if !la {
+        drop(scope);
         return Ok(Some(Slot::Int(0)));
     }
     let rb = invoke_predicate_test(right, elem, heap, out, ops)?;
+    drop(scope);
     Ok(Some(Slot::Int(i32::from(rb))))
 }
 /// Native: `OrPredicate.test(O)Z` — either predicate returning true is sufficient.
@@ -3725,14 +3743,22 @@ pub(crate) fn native_or_predicate_test(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let elem = extract_slot_arg(args, 1);
+    let mut elem = extract_slot_arg(args, 1);
     let left = extract_first_field_arg(heap, this_ref)?;
-    let right = extract_field_arg(heap, this_ref, 1)?;
+    let mut right = extract_field_arg(heap, this_ref, 1)?;
+    // `right` and `elem` are held across the left predicate's `test` invoke
+    // (a GC point) and reused for the right predicate. Pin them so a relocating
+    // GC inside the left callback cannot leave them stale.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut right);
+    scope.pin_slot(&mut elem);
     let la = invoke_predicate_test(left, elem, heap, out, ops)?;
     if la {
+        drop(scope);
         return Ok(Some(Slot::Int(1)));
     }
     let rb = invoke_predicate_test(right, elem, heap, out, ops)?;
+    drop(scope);
     Ok(Some(Slot::Int(i32::from(rb))))
 }
 /// Native: `NegatedPredicate.test(O)Z` — inverts the wrapped predicate.
@@ -3760,9 +3786,16 @@ pub(crate) fn native_and_then_function_apply(
     let this_ref = extract_ref_arg(args, 0)?;
     let input = extract_slot_arg(args, 1);
     let first = extract_first_field_arg(heap, this_ref)?;
-    let second = extract_field_arg(heap, this_ref, 1)?;
+    let mut second = extract_field_arg(heap, this_ref, 1)?;
+    // `second` is held across the first function's `apply` invoke (a GC point)
+    // and only consumed by the second-stage apply. Pin it so a relocating GC
+    // inside the first callback cannot leave it stale.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut second);
     let mid = invoke_function_apply(first, input, heap, out, ops)?;
-    invoke_function_apply(second, mid, heap, out, ops).map(Some)
+    let result = invoke_function_apply(second, mid, heap, out, ops)?;
+    drop(scope);
+    Ok(Some(result))
 }
 /// Native: `AndThenConsumer.accept(O)V` — runs first then second consumer.
 pub(crate) fn native_and_then_consumer_accept(
@@ -3773,11 +3806,18 @@ pub(crate) fn native_and_then_consumer_accept(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let arg = extract_slot_arg(args, 1);
+    let mut arg = extract_slot_arg(args, 1);
     let first = extract_first_field_arg(heap, this_ref)?;
-    let second = extract_field_arg(heap, this_ref, 1)?;
+    let mut second = extract_field_arg(heap, this_ref, 1)?;
+    // `second` and `arg` are held across the first consumer's `accept` invoke
+    // (a GC point) and reused for the second consumer. Pin them so a relocating
+    // GC inside the first callback cannot leave them stale.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut second);
+    scope.pin_slot(&mut arg);
     invoke_consumer_accept(first, arg, heap, out, ops)?;
     invoke_consumer_accept(second, arg, heap, out, ops)?;
+    drop(scope);
     Ok(None)
 }
 /// Native: `ComposeFunction.apply(O)O` — applies inner then outer.
@@ -3790,10 +3830,17 @@ pub(crate) fn native_compose_function_apply(
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
     let input = extract_slot_arg(args, 1);
-    let outer = extract_first_field_arg(heap, this_ref)?;
+    let mut outer = extract_first_field_arg(heap, this_ref)?;
     let inner = extract_field_arg(heap, this_ref, 1)?;
+    // `outer` is held across the inner function's `apply` invoke (a GC point)
+    // and only consumed by the outer-stage apply. Pin it so a relocating GC
+    // inside the inner callback cannot leave it stale.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut outer);
     let mid = invoke_function_apply(inner, input, heap, out, ops)?;
-    invoke_function_apply(outer, mid, heap, out, ops).map(Some)
+    let result = invoke_function_apply(outer, mid, heap, out, ops)?;
+    drop(scope);
+    Ok(Some(result))
 }
 /// Native: `BiFunction.andThen(Function)BiFunction` — returns `BiFunctionAndThen` proxy.
 pub(crate) fn native_bifunction_and_then(

--- a/crates/duke-interpreter/src/native/duke_util.rs
+++ b/crates/duke-interpreter/src/native/duke_util.rs
@@ -1427,6 +1427,12 @@ pub(crate) fn native_stream_collect(
         // them alive and forwarded.
         let mut scope = NativeRootScope::new();
         scope.pin_slot(&mut collector_slot);
+        // `elems` is a stable snapshot taken before this branch and is never
+        // reassigned or mutated here (only read by index below), so pin it now —
+        // BEFORE the supplier()/get()/accumulator() `ops.invoke` GC points that
+        // its element refs must survive. Pinning it later (after those callbacks)
+        // cannot repair refs already relocated by a collection they lived through.
+        scope.pin_slots(&mut elems);
 
         // container = collector.supplier().get()
         let supplier = ops
@@ -1471,7 +1477,6 @@ pub(crate) fn native_stream_collect(
         };
         let acc_class = heap.get(acc_ref)?.class_name.clone();
         scope.pin_slot(&mut accumulator);
-        scope.pin_slots(&mut elems);
         #[allow(clippy::needless_range_loop)]
         for i in 0..elems.len() {
             let elem = elems[i];

--- a/crates/duke-interpreter/src/native/duke_util.rs
+++ b/crates/duke-interpreter/src/native/duke_util.rs
@@ -176,6 +176,79 @@ pub(crate) fn native_stream_for_each(
     drop(scope);
     Ok(None)
 }
+
+/// Shared `toMap`/`toUnmodifiableMap` body: applies `key_fn`/`val_fn` to every
+/// element and assembles a `map_class` map of the boxed results.
+///
+/// GC-safety: references produced *inside* a callback and then stored into a heap
+/// object's fields are only forwarded one-hop by `patch_forwarded_slots`, which
+/// aliases under multiple relocating collections + address reuse. So instead of
+/// pushing each key/value into the result map during the callback loop, the
+/// boxed results accumulate in two pre-sized, *pinned* Rust buffers (the handle
+/// stack is forwarded correctly on every collection), and the map is assembled
+/// only after the last callback — when no further collection can run. The
+/// receivers and the element snapshot are pinned across the callbacks too.
+#[allow(clippy::too_many_arguments)]
+fn collect_into_map(
+    heap: &mut duke_gc::Heap,
+    out: &mut dyn Write,
+    ops: &mut dyn CallbackOps,
+    key_fn: &mut Slot,
+    val_fn: &mut Slot,
+    elems: &mut [Slot],
+    key_class: &str,
+    val_class: &str,
+    map_class: &str,
+) -> Result<u64> {
+    let n = elems.len();
+    let mut keys_buf: Vec<Slot> = vec![Slot::Reference(None); n];
+    let mut vals_buf: Vec<Slot> = vec![Slot::Reference(None); n];
+    {
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(key_fn);
+        scope.pin_slot(val_fn);
+        scope.pin_slots(elems);
+        scope.pin_slots(&mut keys_buf);
+        scope.pin_slots(&mut vals_buf);
+        for i in 0..n {
+            let k_raw = ops
+                .invoke(
+                    heap,
+                    out,
+                    key_class,
+                    "apply",
+                    "(Ljava/lang/Object;)Ljava/lang/Object;",
+                    vec![*key_fn, elems[i]],
+                )?
+                .unwrap_or(Slot::Reference(None));
+            // Box and stash in the pinned buffer BEFORE the value callback so the
+            // key survives the value callback's (and every later) collection.
+            keys_buf[i] = box_primitive_slot(k_raw, heap);
+            let v_raw = ops
+                .invoke(
+                    heap,
+                    out,
+                    val_class,
+                    "apply",
+                    "(Ljava/lang/Object;)Ljava/lang/Object;",
+                    vec![*val_fn, elems[i]],
+                )?
+                .unwrap_or(Slot::Reference(None));
+            vals_buf[i] = box_primitive_slot(v_raw, heap);
+        }
+        // Assemble the map after the last callback: no collection runs here, so a
+        // single one-hop-free write of each pinned buffer entry is safe.
+        let map_ref = heap.allocate(map_class.to_string(), 1);
+        heap.get_mut(map_ref)?.fields[0] = Slot::Int(i32::try_from(n).unwrap_or(i32::MAX));
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..n {
+            heap.get_mut(map_ref)?.fields.push(keys_buf[i]);
+            heap.get_mut(map_ref)?.fields.push(vals_buf[i]);
+        }
+        drop(scope);
+        Ok(map_ref)
+    }
+}
 /// Native: `Stream.collect(Collector)Object` — collects to list (only toList collector supported).
 #[allow(
     clippy::too_many_lines,
@@ -194,7 +267,7 @@ pub(crate) fn native_stream_collect(
         Some(Slot::Int(n)) => *n,
         _ => 0,
     };
-    let elems: Vec<Slot> =
+    let mut elems: Vec<Slot> =
         heap.get(stream_ref)?.fields[1..=usize::try_from(size).unwrap_or(0)].to_vec();
 
     // Dispatch on collector type.
@@ -266,15 +339,30 @@ pub(crate) fn native_stream_collect(
     } else if collector_class == "duke/util/GroupingByCollector" {
         // GroupingByCollector: fields[0] = key function slot
         let collector_ref = extract_ref_arg(args, 1)?;
-        let fn_slot = extract_first_field_arg(heap, collector_ref)?;
+        let mut fn_slot = extract_first_field_arg(heap, collector_ref)?;
         let Slot::Reference(Some(fn_ref)) = fn_slot else {
             return Ok(Some(Slot::Reference(None)));
         };
         let fn_class = heap.get(fn_ref)?.class_name.clone();
-        // Build a HashMap: key → ArrayList of values
-        let map_ref = heap.allocate("java/util/HashMap".to_string(), 1);
-        heap.get_mut(map_ref)?.fields[0] = Slot::Int(0);
-        for elem in elems {
+        // Group by key WITHOUT touching the heap map during the callback loop:
+        // per-element keys accumulate in a pre-sized, PINNED buffer (`keys_buf`),
+        // and group membership is tracked as plain element-index lists (usize —
+        // no heap refs, so GC-immune). Refs stored into a heap object mid-loop
+        // are only forwarded one-hop and alias under multiple collections; the
+        // pinned handle stack is forwarded correctly every collection. The map of
+        // ArrayLists is assembled after the last callback, when no GC can run.
+        let n = elems.len();
+        let mut keys_buf: Vec<Slot> = vec![Slot::Reference(None); n];
+        let mut group_keys: Vec<Slot> = vec![Slot::Reference(None); n];
+        let mut group_members: Vec<Vec<usize>> = Vec::new();
+        let mut group_count = 0usize;
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut fn_slot);
+        scope.pin_slots(&mut elems);
+        scope.pin_slots(&mut keys_buf);
+        scope.pin_slots(&mut group_keys);
+        #[allow(clippy::needless_range_loop)]
+        for ei in 0..n {
             let key = ops
                 .invoke(
                     heap,
@@ -282,47 +370,42 @@ pub(crate) fn native_stream_collect(
                     &fn_class,
                     "apply",
                     "(Ljava/lang/Object;)Ljava/lang/Object;",
-                    vec![fn_slot, elem],
+                    vec![fn_slot, elems[ei]],
                 )?
                 .unwrap_or(Slot::Reference(None));
-            // find existing bucket or create new list
-            let fields = heap.get(map_ref)?.fields.clone();
-            let size_n = match fields.first() {
-                Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
-                _ => 0,
-            };
-            let mut found_ki = None;
-            for i in 0..size_n {
-                let ki = 1 + i * 2;
-                if fields.get(ki).is_some_and(|k| slots_equal(k, &key, heap)) {
-                    found_ki = Some(ki);
+            keys_buf[ei] = key;
+            let mut found = None;
+            for g in 0..group_count {
+                if slots_equal(&group_keys[g], &keys_buf[ei], heap) {
+                    found = Some(g);
                     break;
                 }
             }
-            if let Some(ki) = found_ki {
-                // Append elem to existing list
-                let list_slot = extract_field_arg(heap, map_ref, ki + 1)?;
-                if let Slot::Reference(Some(list_ref)) = list_slot {
-                    let list_size = match heap.get(list_ref)?.fields.first() {
-                        Some(Slot::Int(n)) => *n,
-                        _ => 0,
-                    };
-                    heap.get_mut(list_ref)?.fields.push(elem);
-                    heap.get_mut(list_ref)?.fields[0] = Slot::Int(list_size + 1);
-                }
+            if let Some(g) = found {
+                group_members[g].push(ei);
             } else {
-                // New key — create list with one element
-                let list_ref = heap.allocate("java/util/ArrayList".to_string(), 1);
-                heap.get_mut(list_ref)?.fields[0] = Slot::Int(1);
-                heap.get_mut(list_ref)?.fields.push(elem);
-                heap.get_mut(map_ref)?.fields.push(key);
-                heap.get_mut(map_ref)?
-                    .fields
-                    .push(Slot::Reference(Some(list_ref)));
-                heap.get_mut(map_ref)?.fields[0] =
-                    Slot::Int(i32::try_from(size_n + 1).unwrap_or(i32::MAX));
+                group_keys[group_count] = keys_buf[ei];
+                group_members.push(vec![ei]);
+                group_count += 1;
             }
         }
+        // Assemble the map (key -> ArrayList) after the last callback.
+        let map_ref = heap.allocate("java/util/HashMap".to_string(), 1);
+        heap.get_mut(map_ref)?.fields[0] = Slot::Int(i32::try_from(group_count).unwrap_or(i32::MAX));
+        #[allow(clippy::needless_range_loop)]
+        for g in 0..group_count {
+            let list_ref = heap.allocate("java/util/ArrayList".to_string(), 1);
+            let members = &group_members[g];
+            heap.get_mut(list_ref)?.fields[0] = Slot::Int(i32::try_from(members.len()).unwrap_or(i32::MAX));
+            for &ei in members {
+                heap.get_mut(list_ref)?.fields.push(elems[ei]);
+            }
+            heap.get_mut(map_ref)?.fields.push(group_keys[g]);
+            heap.get_mut(map_ref)?
+                .fields
+                .push(Slot::Reference(Some(list_ref)));
+        }
+        drop(scope);
         Ok(Some(Slot::Reference(Some(map_ref))))
     } else if collector_class == "duke/util/ToSetCollector" {
         // Collect into HashSet (deduplicates).
@@ -351,8 +434,8 @@ pub(crate) fn native_stream_collect(
     } else if collector_class == "duke/util/ToMapCollector" {
         // Collect into HashMap using key/val extractor functions.
         let collector_ref = extract_ref_arg(args, 1)?;
-        let key_fn = extract_first_field_arg(heap, collector_ref)?;
-        let val_fn = extract_field_arg(heap, collector_ref, 1)?;
+        let mut key_fn = extract_first_field_arg(heap, collector_ref)?;
+        let mut val_fn = extract_field_arg(heap, collector_ref, 1)?;
         let Slot::Reference(Some(key_ref)) = key_fn else {
             return Err(Error::NullPointerException);
         };
@@ -361,46 +444,16 @@ pub(crate) fn native_stream_collect(
         };
         let key_class = heap.get(key_ref)?.class_name.clone();
         let val_class = heap.get(val_ref)?.class_name.clone();
-        let map_ref = heap.allocate("java/util/HashMap".to_string(), 1);
-        heap.get_mut(map_ref)?.fields[0] = Slot::Int(0);
-        for elem in elems {
-            let k_raw = ops
-                .invoke(
-                    heap,
-                    out,
-                    &key_class,
-                    "apply",
-                    "(Ljava/lang/Object;)Ljava/lang/Object;",
-                    vec![key_fn, elem],
-                )?
-                .unwrap_or(Slot::Reference(None));
-            let v_raw = ops
-                .invoke(
-                    heap,
-                    out,
-                    &val_class,
-                    "apply",
-                    "(Ljava/lang/Object;)Ljava/lang/Object;",
-                    vec![val_fn, elem],
-                )?
-                .unwrap_or(Slot::Reference(None));
-            // Box primitives so the map stores References (Object contract).
-            let k = box_primitive_slot(k_raw, heap);
-            let v = box_primitive_slot(v_raw, heap);
-            let cur_size = match heap.get(map_ref)?.fields.first() {
-                Some(Slot::Int(n)) => *n,
-                _ => 0,
-            };
-            heap.get_mut(map_ref)?.fields.push(k);
-            heap.get_mut(map_ref)?.fields.push(v);
-            heap.get_mut(map_ref)?.fields[0] = Slot::Int(cur_size + 1);
-        }
+        let map_ref = collect_into_map(
+            heap, out, ops, &mut key_fn, &mut val_fn, &mut elems, &key_class, &val_class,
+            "java/util/HashMap",
+        )?;
         Ok(Some(Slot::Reference(Some(map_ref))))
     } else if collector_class == "duke/util/ToUnmodifiableMapCollector" {
         // Same as ToMapCollector but produces an UnmodifiableMap.
         let collector_ref = extract_ref_arg(args, 1)?;
-        let key_fn = extract_first_field_arg(heap, collector_ref)?;
-        let val_fn = extract_field_arg(heap, collector_ref, 1)?;
+        let mut key_fn = extract_first_field_arg(heap, collector_ref)?;
+        let mut val_fn = extract_field_arg(heap, collector_ref, 1)?;
         let Slot::Reference(Some(key_ref)) = key_fn else {
             return Err(Error::NullPointerException);
         };
@@ -409,46 +462,17 @@ pub(crate) fn native_stream_collect(
         };
         let key_class = heap.get(key_ref)?.class_name.clone();
         let val_class = heap.get(val_ref)?.class_name.clone();
-        let map_ref = heap.allocate("java/util/UnmodifiableMap".to_string(), 1);
-        heap.get_mut(map_ref)?.fields[0] = Slot::Int(0);
-        for elem in elems {
-            let k_raw = ops
-                .invoke(
-                    heap,
-                    out,
-                    &key_class,
-                    "apply",
-                    "(Ljava/lang/Object;)Ljava/lang/Object;",
-                    vec![key_fn, elem],
-                )?
-                .unwrap_or(Slot::Reference(None));
-            let v_raw = ops
-                .invoke(
-                    heap,
-                    out,
-                    &val_class,
-                    "apply",
-                    "(Ljava/lang/Object;)Ljava/lang/Object;",
-                    vec![val_fn, elem],
-                )?
-                .unwrap_or(Slot::Reference(None));
-            let k = box_primitive_slot(k_raw, heap);
-            let v = box_primitive_slot(v_raw, heap);
-            let cur_size = match heap.get(map_ref)?.fields.first() {
-                Some(Slot::Int(n)) => *n,
-                _ => 0,
-            };
-            heap.get_mut(map_ref)?.fields.push(k);
-            heap.get_mut(map_ref)?.fields.push(v);
-            heap.get_mut(map_ref)?.fields[0] = Slot::Int(cur_size + 1);
-        }
+        let map_ref = collect_into_map(
+            heap, out, ops, &mut key_fn, &mut val_fn, &mut elems, &key_class, &val_class,
+            "java/util/UnmodifiableMap",
+        )?;
         Ok(Some(Slot::Reference(Some(map_ref))))
     } else if collector_class == "duke/util/ToMapMergeCollector" {
         // Collect into HashMap with merge function for duplicate keys.
         let collector_ref = extract_ref_arg(args, 1)?;
-        let key_fn = extract_first_field_arg(heap, collector_ref)?;
-        let val_fn = extract_field_arg(heap, collector_ref, 1)?;
-        let merge_fn = extract_field_arg(heap, collector_ref, 2)?;
+        let mut key_fn = extract_first_field_arg(heap, collector_ref)?;
+        let mut val_fn = extract_field_arg(heap, collector_ref, 1)?;
+        let mut merge_fn = extract_field_arg(heap, collector_ref, 2)?;
         let Slot::Reference(Some(key_ref)) = key_fn else {
             return Err(Error::NullPointerException);
         };
@@ -461,33 +485,59 @@ pub(crate) fn native_stream_collect(
         let key_class = heap.get(key_ref)?.class_name.clone();
         let val_class = heap.get(val_ref)?.class_name.clone();
         let merge_class = heap.get(merge_ref)?.class_name.clone();
-        let map_ref = heap.allocate("java/util/HashMap".to_string(), 1);
-        heap.get_mut(map_ref)?.fields[0] = Slot::Int(0);
-        for elem in elems {
-            let k = ops
+        // Accumulate distinct (key, value) entries into pre-sized, PINNED Rust
+        // buffers rather than into the heap map during the loop: refs stored into
+        // a heap object mid-loop are only forwarded one-hop and alias under
+        // multiple collections, whereas the pinned handle stack is forwarded
+        // correctly on every collection. `entry_count` tracks the distinct keys
+        // (dedup can only shrink, so `n` slots suffice); `k_slot`/`v_slot` are
+        // pinned scratch for the results held across the value/merge callbacks.
+        let n = elems.len();
+        let mut keys_buf: Vec<Slot> = vec![Slot::Reference(None); n];
+        let mut vals_buf: Vec<Slot> = vec![Slot::Reference(None); n];
+        let mut entry_count = 0usize;
+        let mut k_slot = Slot::Reference(None);
+        let mut v_slot = Slot::Reference(None);
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut key_fn);
+        scope.pin_slot(&mut val_fn);
+        scope.pin_slot(&mut merge_fn);
+        scope.pin_slots(&mut elems);
+        scope.pin_slots(&mut keys_buf);
+        scope.pin_slots(&mut vals_buf);
+        scope.pin_slot(&mut k_slot);
+        scope.pin_slot(&mut v_slot);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..n {
+            k_slot = ops
                 .invoke(
                     heap,
                     out,
                     &key_class,
                     "apply",
                     "(Ljava/lang/Object;)Ljava/lang/Object;",
-                    vec![key_fn, elem],
+                    vec![key_fn, elems[i]],
                 )?
                 .unwrap_or(Slot::Reference(None));
-            let v = ops
+            v_slot = ops
                 .invoke(
                     heap,
                     out,
                     &val_class,
                     "apply",
                     "(Ljava/lang/Object;)Ljava/lang/Object;",
-                    vec![val_fn, elem],
+                    vec![val_fn, elems[i]],
                 )?
                 .unwrap_or(Slot::Reference(None));
-            let fields = heap.get(map_ref)?.fields.clone();
-            if let Some(i) = find_hashmap_entry_index(&fields, &k, heap) {
-                // Duplicate key — apply merge function: merge(existing, new)
-                let existing = fields[i + 1];
+            let mut found = None;
+            for p in 0..entry_count {
+                if slots_equal(&keys_buf[p], &k_slot, heap) {
+                    found = Some(p);
+                    break;
+                }
+            }
+            if let Some(p) = found {
+                // Duplicate key — apply merge function: merge(existing, new).
                 let merged = ops
                     .invoke(
                         heap,
@@ -495,52 +545,72 @@ pub(crate) fn native_stream_collect(
                         &merge_class,
                         "apply",
                         "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
-                        vec![merge_fn, existing, v],
+                        vec![merge_fn, vals_buf[p], v_slot],
                     )?
                     .unwrap_or(Slot::Reference(None));
-                heap.get_mut(map_ref)?.fields[i + 1] = merged;
+                vals_buf[p] = merged;
             } else {
-                let cur_size = match heap.get(map_ref)?.fields.first() {
-                    Some(Slot::Int(n)) => *n,
-                    _ => 0,
-                };
-                heap.get_mut(map_ref)?.fields.push(k);
-                heap.get_mut(map_ref)?.fields.push(v);
-                heap.get_mut(map_ref)?.fields[0] = Slot::Int(cur_size + 1);
+                keys_buf[entry_count] = k_slot;
+                vals_buf[entry_count] = v_slot;
+                entry_count += 1;
             }
         }
+        // Assemble the map after the last callback (no collection runs here).
+        let map_ref = heap.allocate("java/util/HashMap".to_string(), 1);
+        heap.get_mut(map_ref)?.fields[0] = Slot::Int(i32::try_from(entry_count).unwrap_or(i32::MAX));
+        #[allow(clippy::needless_range_loop)]
+        for p in 0..entry_count {
+            heap.get_mut(map_ref)?.fields.push(keys_buf[p]);
+            heap.get_mut(map_ref)?.fields.push(vals_buf[p]);
+        }
+        drop(scope);
         Ok(Some(Slot::Reference(Some(map_ref))))
     } else if collector_class == "duke/util/PartitioningByCollector" {
         // Collect into a Map<Boolean, List> partitioned by predicate.
         let collector_ref = extract_ref_arg(args, 1)?;
         let pred_slot = extract_first_field_arg(heap, collector_ref)?;
-        let Slot::Reference(Some(pred_ref)) = pred_slot else {
+        let Slot::Reference(Some(mut pred_ref)) = pred_slot else {
             return Err(Error::NullPointerException);
         };
         let pred_class = heap.get(pred_ref)?.class_name.clone();
-        // Create two lists and the result map.
-        let true_list = heap.allocate("java/util/ArrayList".to_string(), 1);
-        heap.get_mut(true_list)?.fields[0] = Slot::Int(0);
-        let false_list = heap.allocate("java/util/ArrayList".to_string(), 1);
-        heap.get_mut(false_list)?.fields[0] = Slot::Int(0);
-        for elem in elems {
+        // Pin the predicate receiver and element snapshot across the callbacks,
+        // and record partition membership as plain element indices (usize — no
+        // heap refs, GC-immune). The two ArrayLists are materialised from the
+        // pinned snapshot after the loop; storing elements into a heap list
+        // during the loop would expose them to multi-collection aliasing.
+        let mut true_idx: Vec<usize> = Vec::new();
+        let mut false_idx: Vec<usize> = Vec::new();
+        let mut scope = NativeRootScope::new();
+        scope.pin_ref(&mut pred_ref);
+        scope.pin_slots(&mut elems);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..elems.len() {
             let result = ops.invoke(
                 heap,
                 out,
                 &pred_class,
                 "test",
                 "(Ljava/lang/Object;)Z",
-                vec![Slot::Reference(Some(pred_ref)), elem],
+                vec![Slot::Reference(Some(pred_ref)), elems[i]],
             )?;
-            let is_true = matches!(result, Some(Slot::Int(n)) if n != 0);
-            let target = if is_true { true_list } else { false_list };
-            let cur_size = match heap.get(target)?.fields.first() {
-                Some(Slot::Int(n)) => *n,
-                _ => 0,
-            };
-            heap.get_mut(target)?.fields.push(elem);
-            heap.get_mut(target)?.fields[0] = Slot::Int(cur_size + 1);
+            if matches!(result, Some(Slot::Int(n)) if n != 0) {
+                true_idx.push(i);
+            } else {
+                false_idx.push(i);
+            }
         }
+        // Materialise both lists and the result map after the last callback.
+        let true_list = heap.allocate("java/util/ArrayList".to_string(), 1);
+        heap.get_mut(true_list)?.fields[0] = Slot::Int(i32::try_from(true_idx.len()).unwrap_or(i32::MAX));
+        for &i in &true_idx {
+            heap.get_mut(true_list)?.fields.push(elems[i]);
+        }
+        let false_list = heap.allocate("java/util/ArrayList".to_string(), 1);
+        heap.get_mut(false_list)?.fields[0] = Slot::Int(i32::try_from(false_idx.len()).unwrap_or(i32::MAX));
+        for &i in &false_idx {
+            heap.get_mut(false_list)?.fields.push(elems[i]);
+        }
+        drop(scope);
         // Build HashMap: Boolean(1)→trueList, Boolean(0)→falseList
         let map_ref = heap.allocate("java/util/HashMap".to_string(), 1);
         heap.get_mut(map_ref)?.fields[0] = Slot::Int(2);
@@ -566,13 +636,23 @@ pub(crate) fn native_stream_collect(
         let collector_ref = extract_ref_arg(args, 1)?;
         let pred_slot = extract_first_field_arg(heap, collector_ref)?;
         let downstream_slot = extract_field_arg(heap, collector_ref, 1)?;
-        let Slot::Reference(Some(pred_ref)) = pred_slot else {
+        let Slot::Reference(Some(mut pred_ref)) = pred_slot else {
             return Err(Error::NullPointerException);
         };
         let pred_class = heap.get(pred_ref)?.class_name.clone();
-        let mut true_elems: Vec<Slot> = Vec::new();
-        let mut false_elems: Vec<Slot> = Vec::new();
-        for elem in elems {
+        // Pin the predicate receiver and the element snapshot across the per-
+        // element `ops.invoke`. Record partition membership as indices into the
+        // pinned snapshot (a growing `Vec<Slot>` of refs would itself go stale
+        // and cannot be pinned across reallocation), then materialise each
+        // partition from the pinned elements after the loop.
+        let mut true_idx: Vec<usize> = Vec::new();
+        let mut false_idx: Vec<usize> = Vec::new();
+        let mut scope = NativeRootScope::new();
+        scope.pin_ref(&mut pred_ref);
+        scope.pin_slots(&mut elems);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..elems.len() {
+            let elem = elems[i];
             let result = ops.invoke(
                 heap,
                 out,
@@ -582,11 +662,14 @@ pub(crate) fn native_stream_collect(
                 vec![Slot::Reference(Some(pred_ref)), elem],
             )?;
             if matches!(result, Some(Slot::Int(n)) if n != 0) {
-                true_elems.push(elem);
+                true_idx.push(i);
             } else {
-                false_elems.push(elem);
+                false_idx.push(i);
             }
         }
+        let true_elems: Vec<Slot> = true_idx.iter().map(|&i| elems[i]).collect();
+        let false_elems: Vec<Slot> = false_idx.iter().map(|&i| elems[i]).collect();
+        drop(scope);
         // Apply downstream collector to each partition by building a mini stream.
         let apply_downstream = |elems_sub: Vec<Slot>,
                                 heap: &mut duke_gc::Heap,
@@ -649,13 +732,21 @@ pub(crate) fn native_stream_collect(
     } else if collector_class == "duke/util/SummingIntCollector" {
         // Sum via applyAsInt(elem) for each element.
         let collector_ref = extract_ref_arg(args, 1)?;
-        let fn_slot = extract_first_field_arg(heap, collector_ref)?;
+        let mut fn_slot = extract_first_field_arg(heap, collector_ref)?;
         let Slot::Reference(Some(fn_ref)) = fn_slot else {
             return Err(Error::NullPointerException);
         };
         let fn_class = heap.get(fn_ref)?.class_name.clone();
+        // Pin the mapper receiver (re-passed each iteration) and the element
+        // snapshot across the per-element `ops.invoke`; the numeric result is
+        // accumulated in a primitive local (no heap ref at risk there).
         let mut sum = 0_i32;
-        for elem in elems {
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut fn_slot);
+        scope.pin_slots(&mut elems);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..elems.len() {
+            let elem = elems[i];
             let result = ops.invoke(
                 heap,
                 out,
@@ -668,6 +759,7 @@ pub(crate) fn native_stream_collect(
                 sum = sum.wrapping_add(n);
             }
         }
+        drop(scope);
         // Return boxed Integer
         let boxed = heap.allocate("java/lang/Integer".to_string(), 1);
         heap.get_mut(boxed)?.fields[0] = Slot::Int(sum);
@@ -675,14 +767,20 @@ pub(crate) fn native_stream_collect(
     } else if collector_class == "duke/util/AveragingIntCollector" {
         // Average via applyAsInt(elem) for each element.
         let collector_ref = extract_ref_arg(args, 1)?;
-        let fn_slot = extract_first_field_arg(heap, collector_ref)?;
+        let mut fn_slot = extract_first_field_arg(heap, collector_ref)?;
         let Slot::Reference(Some(fn_ref)) = fn_slot else {
             return Err(Error::NullPointerException);
         };
         let fn_class = heap.get(fn_ref)?.class_name.clone();
+        // Pin the mapper receiver and element snapshot across the callbacks.
         let mut sum = 0_i64;
         let mut count = 0_usize;
-        for elem in elems {
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut fn_slot);
+        scope.pin_slots(&mut elems);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..elems.len() {
+            let elem = elems[i];
             let result = ops.invoke(
                 heap,
                 out,
@@ -696,6 +794,7 @@ pub(crate) fn native_stream_collect(
                 count += 1;
             }
         }
+        drop(scope);
         #[allow(clippy::cast_precision_loss)]
         let avg = if count == 0 {
             0.0
@@ -709,16 +808,22 @@ pub(crate) fn native_stream_collect(
     } else if collector_class == "duke/util/SummarizingIntCollector" {
         // IntSummaryStatistics via applyAsInt(elem) for each element.
         let collector_ref = extract_ref_arg(args, 1)?;
-        let fn_slot = extract_first_field_arg(heap, collector_ref)?;
+        let mut fn_slot = extract_first_field_arg(heap, collector_ref)?;
         let Slot::Reference(Some(fn_ref)) = fn_slot else {
             return Err(Error::NullPointerException);
         };
         let fn_class = heap.get(fn_ref)?.class_name.clone();
+        // Pin the mapper receiver and element snapshot across the callbacks.
         let mut sum = 0_i64;
         let mut min = i32::MAX;
         let mut max = i32::MIN;
         let mut count = 0_i64;
-        for elem in elems {
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut fn_slot);
+        scope.pin_slots(&mut elems);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..elems.len() {
+            let elem = elems[i];
             let result = ops.invoke(
                 heap,
                 out,
@@ -738,6 +843,7 @@ pub(crate) fn native_stream_collect(
                 count += 1;
             }
         }
+        drop(scope);
         if count == 0 {
             min = 0;
             max = 0;
@@ -752,13 +858,19 @@ pub(crate) fn native_stream_collect(
     } else if collector_class == "duke/util/SummingLongCollector" {
         // Sum via applyAsLong(elem) for each element.
         let collector_ref = extract_ref_arg(args, 1)?;
-        let fn_slot = extract_first_field_arg(heap, collector_ref)?;
+        let mut fn_slot = extract_first_field_arg(heap, collector_ref)?;
         let Slot::Reference(Some(fn_ref)) = fn_slot else {
             return Err(Error::NullPointerException);
         };
         let fn_class = heap.get(fn_ref)?.class_name.clone();
+        // Pin the mapper receiver and element snapshot across the callbacks.
         let mut sum = 0_i64;
-        for elem in elems {
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut fn_slot);
+        scope.pin_slots(&mut elems);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..elems.len() {
+            let elem = elems[i];
             let result = ops.invoke(
                 heap,
                 out,
@@ -773,6 +885,7 @@ pub(crate) fn native_stream_collect(
                 _ => {}
             }
         }
+        drop(scope);
         // Return boxed Long
         let boxed = heap.allocate("java/lang/Long".to_string(), 1);
         heap.get_mut(boxed)?.fields[0] = Slot::Long(sum);
@@ -780,14 +893,20 @@ pub(crate) fn native_stream_collect(
     } else if collector_class == "duke/util/AveragingDoubleCollector" {
         // Average via applyAsDouble(elem) for each element.
         let collector_ref = extract_ref_arg(args, 1)?;
-        let fn_slot = extract_first_field_arg(heap, collector_ref)?;
+        let mut fn_slot = extract_first_field_arg(heap, collector_ref)?;
         let Slot::Reference(Some(fn_ref)) = fn_slot else {
             return Err(Error::NullPointerException);
         };
         let fn_class = heap.get(fn_ref)?.class_name.clone();
+        // Pin the mapper receiver and element snapshot across the callbacks.
         let mut sum = 0.0_f64;
         let mut count = 0_usize;
-        for elem in elems {
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut fn_slot);
+        scope.pin_slots(&mut elems);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..elems.len() {
+            let elem = elems[i];
             let result = ops.invoke(
                 heap,
                 out,
@@ -812,6 +931,7 @@ pub(crate) fn native_stream_collect(
                 _ => {}
             }
         }
+        drop(scope);
         #[allow(clippy::cast_precision_loss)]
         let avg = if count == 0 { 0.0 } else { sum / count as f64 };
         // Return boxed Double
@@ -821,15 +941,25 @@ pub(crate) fn native_stream_collect(
     } else if collector_class == "duke/util/MappingCollector" {
         // MappingCollector: fields[0]=mapper fn, fields[1]=downstream collector
         let collector_ref = extract_ref_arg(args, 1)?;
-        let mapper_slot = extract_first_field_arg(heap, collector_ref)?;
-        let downstream_slot = extract_field_arg(heap, collector_ref, 1)?;
+        let mut mapper_slot = extract_first_field_arg(heap, collector_ref)?;
+        let mut downstream_slot = extract_field_arg(heap, collector_ref, 1)?;
         let Slot::Reference(Some(mapper_ref)) = mapper_slot else {
             return Err(Error::NullPointerException);
         };
         let mapper_class = heap.get(mapper_ref)?.class_name.clone();
-        // Map each element through the mapper function
-        let mut mapped_elems = Vec::with_capacity(elems.len());
-        for elem in elems {
+        // Map each element through the mapper function. Pin the mapper receiver,
+        // the downstream collector ref (used after the loop), the element
+        // snapshot, and the produced-result buffer. `mapped_elems` is pre-sized
+        // and index-assigned (never pushed) so its pinned buffer never
+        // reallocates while refs live in it across later callbacks.
+        let mut mapped_elems: Vec<Slot> = vec![Slot::Reference(None); elems.len()];
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut mapper_slot);
+        scope.pin_slot(&mut downstream_slot);
+        scope.pin_slots(&mut elems);
+        scope.pin_slots(&mut mapped_elems);
+        for i in 0..elems.len() {
+            let elem = elems[i];
             let mapped = ops
                 .invoke(
                     heap,
@@ -840,28 +970,46 @@ pub(crate) fn native_stream_collect(
                     vec![mapper_slot, elem],
                 )?
                 .unwrap_or(Slot::Reference(None));
-            mapped_elems.push(mapped);
+            mapped_elems[i] = mapped;
         }
         // Build a temporary stream from mapped elements and collect with downstream
         let mapped_size = i32::try_from(mapped_elems.len()).unwrap_or(0);
         let tmp_stream = heap.allocate("duke/util/Stream".to_string(), 1);
         heap.get_mut(tmp_stream)?.fields[0] = Slot::Int(mapped_size);
-        heap.get_mut(tmp_stream)?.fields.extend(mapped_elems);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..mapped_elems.len() {
+            let m = mapped_elems[i];
+            heap.get_mut(tmp_stream)?.fields.push(m);
+        }
         let tmp_args = vec![Slot::Reference(Some(tmp_stream)), downstream_slot];
+        drop(scope);
         native_stream_collect(&tmp_args, heap, out, control, ops)
     } else if collector_class == "duke/util/GroupingBy2Collector" {
         // groupingBy(keyFn, downstream): fields[0]=keyFn, fields[1]=downstream collector
         let collector_ref = extract_ref_arg(args, 1)?;
-        let fn_slot = extract_first_field_arg(heap, collector_ref)?;
-        let downstream_slot = extract_field_arg(heap, collector_ref, 1)?;
+        let mut fn_slot = extract_first_field_arg(heap, collector_ref)?;
+        let mut downstream_slot = extract_field_arg(heap, collector_ref, 1)?;
         let Slot::Reference(Some(fn_ref)) = fn_slot else {
             return Err(Error::NullPointerException);
         };
         let fn_class = heap.get(fn_ref)?.class_name.clone();
-        // First pass: group raw elements by key into HashMap<key, ArrayList<elem>>
-        let raw_map = heap.allocate("java/util/HashMap".to_string(), 1);
-        heap.get_mut(raw_map)?.fields[0] = Slot::Int(0);
-        for elem in elems {
+        // First pass: group element INDICES by boxed key, accumulating into
+        // pinned buffers (`keys_buf`/`group_keys`) and plain usize index lists —
+        // never touching a heap map during the callback loop (heap-stored refs
+        // alias under multiple collections; the pinned handle stack does not).
+        let n = elems.len();
+        let mut keys_buf: Vec<Slot> = vec![Slot::Reference(None); n];
+        let mut group_keys: Vec<Slot> = vec![Slot::Reference(None); n];
+        let mut group_members: Vec<Vec<usize>> = Vec::new();
+        let mut group_count = 0usize;
+        let mut scope1 = NativeRootScope::new();
+        scope1.pin_slot(&mut fn_slot);
+        scope1.pin_slot(&mut downstream_slot);
+        scope1.pin_slots(&mut elems);
+        scope1.pin_slots(&mut keys_buf);
+        scope1.pin_slots(&mut group_keys);
+        #[allow(clippy::needless_range_loop)]
+        for ei in 0..n {
             let key_raw = ops
                 .invoke(
                     heap,
@@ -869,105 +1017,84 @@ pub(crate) fn native_stream_collect(
                     &fn_class,
                     "apply",
                     "(Ljava/lang/Object;)Ljava/lang/Object;",
-                    vec![fn_slot, elem],
+                    vec![fn_slot, elems[ei]],
                 )?
                 .unwrap_or(Slot::Reference(None));
-            // Box primitive keys so HashMap.get(boxed) can match them via slots_equal
-            let key = box_primitive_slot(key_raw, heap);
-            let fields = heap.get(raw_map)?.fields.clone();
-            let size_n = match fields.first() {
-                Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
-                _ => 0,
-            };
-            let mut found_ki = None;
-            for i in 0..size_n {
-                let ki = 1 + i * 2;
-                if fields.get(ki).is_some_and(|k| slots_equal(k, &key, heap)) {
-                    found_ki = Some(ki);
+            // Box primitive keys so they match via slots_equal, and stash in the
+            // pinned buffer so the boxed key survives every later callback.
+            keys_buf[ei] = box_primitive_slot(key_raw, heap);
+            let mut found = None;
+            for g in 0..group_count {
+                if slots_equal(&group_keys[g], &keys_buf[ei], heap) {
+                    found = Some(g);
                     break;
                 }
             }
-            if let Some(ki) = found_ki {
-                let list_slot = extract_field_arg(heap, raw_map, ki + 1)?;
-                if let Slot::Reference(Some(list_ref)) = list_slot {
-                    let list_size = match heap.get(list_ref)?.fields.first() {
-                        Some(Slot::Int(n)) => *n,
-                        _ => 0,
-                    };
-                    heap.get_mut(list_ref)?.fields.push(elem);
-                    heap.get_mut(list_ref)?.fields[0] = Slot::Int(list_size + 1);
-                }
+            if let Some(g) = found {
+                group_members[g].push(ei);
             } else {
-                let list_ref = heap.allocate("java/util/ArrayList".to_string(), 1);
-                heap.get_mut(list_ref)?.fields[0] = Slot::Int(1);
-                heap.get_mut(list_ref)?.fields.push(elem);
-                heap.get_mut(raw_map)?.fields.push(key);
-                heap.get_mut(raw_map)?
-                    .fields
-                    .push(Slot::Reference(Some(list_ref)));
-                heap.get_mut(raw_map)?.fields[0] =
-                    Slot::Int(i32::try_from(size_n + 1).unwrap_or(i32::MAX));
+                group_keys[group_count] = keys_buf[ei];
+                group_members.push(vec![ei]);
+                group_count += 1;
             }
         }
-        // Second pass: apply downstream collector to each group's ArrayList
-        let result_map = heap.allocate("java/util/HashMap".to_string(), 1);
-        heap.get_mut(result_map)?.fields[0] = Slot::Int(0);
-        let raw_fields = heap.get(raw_map)?.fields.clone();
-        let group_count = match raw_fields.first() {
-            Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
-            _ => 0,
-        };
-        for i in 0..group_count {
-            let key = raw_fields
-                .get(1 + i * 2)
-                .copied()
-                .unwrap_or(Slot::Reference(None));
-            let list_slot = raw_fields
-                .get(2 + i * 2)
-                .copied()
-                .unwrap_or(Slot::Reference(None));
-            let Slot::Reference(Some(list_ref)) = list_slot else {
-                continue;
-            };
-            let group_size_field = heap
-                .get(list_ref)?
-                .fields
-                .first()
-                .copied()
-                .unwrap_or(Slot::Int(0));
-            let group_size = match group_size_field {
-                Slot::Int(n) => n,
-                _ => 0,
-            };
+        drop(scope1);
+        // Second pass: apply the downstream collector to each group's elements,
+        // accumulating the (key, collected) pairs into pinned buffers. The
+        // recursive `native_stream_collect` is a GC point, so `group_keys` and the
+        // collected results are kept on the pinned handle stack across it; the
+        // result map is assembled only after the last recursive collect.
+        let mut collected_vals: Vec<Slot> = vec![Slot::Reference(None); group_count];
+        let mut scope2 = NativeRootScope::new();
+        scope2.pin_slot(&mut downstream_slot);
+        scope2.pin_slots(&mut elems);
+        scope2.pin_slots(&mut group_keys);
+        scope2.pin_slots(&mut collected_vals);
+        #[allow(clippy::needless_range_loop)]
+        for g in 0..group_count {
+            let members = group_members[g].clone();
             let tmp_stream = heap.allocate("duke/util/Stream".to_string(), 1);
-            heap.get_mut(tmp_stream)?.fields[0] = group_size_field;
-            let group_elems: Vec<Slot> =
-                heap.get(list_ref)?.fields[1..=usize::try_from(group_size).unwrap_or(0)].to_vec();
-            heap.get_mut(tmp_stream)?.fields.extend(group_elems);
+            heap.get_mut(tmp_stream)?.fields[0] =
+                Slot::Int(i32::try_from(members.len()).unwrap_or(i32::MAX));
+            for &ei in &members {
+                heap.get_mut(tmp_stream)?.fields.push(elems[ei]);
+            }
             let tmp_args = vec![Slot::Reference(Some(tmp_stream)), downstream_slot];
             let collected = native_stream_collect(&tmp_args, heap, out, control, ops)?
                 .unwrap_or(Slot::Reference(None));
-            let cur_result_size = match heap.get(result_map)?.fields.first() {
-                Some(Slot::Int(n)) => *n,
-                _ => 0,
-            };
-            heap.get_mut(result_map)?.fields.push(key);
-            heap.get_mut(result_map)?.fields.push(collected);
-            heap.get_mut(result_map)?.fields[0] = Slot::Int(cur_result_size + 1);
+            collected_vals[g] = collected;
         }
+        // Assemble the result map after the last recursive collect.
+        let result_map = heap.allocate("java/util/HashMap".to_string(), 1);
+        heap.get_mut(result_map)?.fields[0] = Slot::Int(i32::try_from(group_count).unwrap_or(i32::MAX));
+        #[allow(clippy::needless_range_loop)]
+        for g in 0..group_count {
+            heap.get_mut(result_map)?.fields.push(group_keys[g]);
+            heap.get_mut(result_map)?.fields.push(collected_vals[g]);
+        }
+        drop(scope2);
         Ok(Some(Slot::Reference(Some(result_map))))
     } else if collector_class == "duke/util/MinByCollector" {
         // minBy(comparator): fields[0] = comparator
         let collector_ref = extract_ref_arg(args, 1)?;
-        let cmp_slot = extract_first_field_arg(heap, collector_ref)?;
+        let mut cmp_slot = extract_first_field_arg(heap, collector_ref)?;
         let Slot::Reference(Some(cmp_ref)) = cmp_slot else {
             let r = make_optional(heap, None);
             return Ok(Some(Slot::Reference(Some(r))));
         };
         let cmp_class = heap.get(cmp_ref)?.class_name.clone();
-        let mut min: Option<Slot> = None;
-        for elem in elems {
-            let is_less = if let Some(ref cur) = min {
+        // Pin the comparator receiver, the element snapshot, and the running
+        // minimum (a heap ref carried across, and compared by, every callback).
+        // `min_slot` holds the current best; `has_min` gates it.
+        let mut min_slot = Slot::Reference(None);
+        let mut has_min = false;
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut cmp_slot);
+        scope.pin_slots(&mut elems);
+        scope.pin_slot(&mut min_slot);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..elems.len() {
+            let is_less = if has_min {
                 let result = ops
                     .invoke(
                         heap,
@@ -975,7 +1102,7 @@ pub(crate) fn native_stream_collect(
                         &cmp_class,
                         "compare",
                         "(Ljava/lang/Object;Ljava/lang/Object;)I",
-                        vec![cmp_slot, elem, *cur],
+                        vec![cmp_slot, elems[i], min_slot],
                     )?
                     .unwrap_or(Slot::Int(0));
                 matches!(result, Slot::Int(n) if n < 0)
@@ -983,23 +1110,36 @@ pub(crate) fn native_stream_collect(
                 true
             };
             if is_less {
-                min = Some(elem);
+                // Read from the pinned snapshot after the callback so the new
+                // running minimum tracks any relocation the compare triggered.
+                min_slot = elems[i];
+                has_min = true;
             }
         }
+        let min = if has_min { Some(min_slot) } else { None };
+        drop(scope);
         let r = make_optional(heap, min);
         Ok(Some(Slot::Reference(Some(r))))
     } else if collector_class == "duke/util/MaxByCollector" {
         // maxBy(comparator): fields[0] = comparator
         let collector_ref = extract_ref_arg(args, 1)?;
-        let cmp_slot = extract_first_field_arg(heap, collector_ref)?;
+        let mut cmp_slot = extract_first_field_arg(heap, collector_ref)?;
         let Slot::Reference(Some(cmp_ref)) = cmp_slot else {
             let r = make_optional(heap, None);
             return Ok(Some(Slot::Reference(Some(r))));
         };
         let cmp_class = heap.get(cmp_ref)?.class_name.clone();
-        let mut max: Option<Slot> = None;
-        for elem in elems {
-            let is_greater = if let Some(ref cur) = max {
+        // Pin the comparator receiver, the element snapshot, and the running
+        // maximum (a heap ref carried across, and compared by, every callback).
+        let mut max_slot = Slot::Reference(None);
+        let mut has_max = false;
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut cmp_slot);
+        scope.pin_slots(&mut elems);
+        scope.pin_slot(&mut max_slot);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..elems.len() {
+            let is_greater = if has_max {
                 let result = ops
                     .invoke(
                         heap,
@@ -1007,7 +1147,7 @@ pub(crate) fn native_stream_collect(
                         &cmp_class,
                         "compare",
                         "(Ljava/lang/Object;Ljava/lang/Object;)I",
-                        vec![cmp_slot, elem, *cur],
+                        vec![cmp_slot, elems[i], max_slot],
                     )?
                     .unwrap_or(Slot::Int(0));
                 matches!(result, Slot::Int(n) if n > 0)
@@ -1015,21 +1155,32 @@ pub(crate) fn native_stream_collect(
                 true
             };
             if is_greater {
-                max = Some(elem);
+                // Read from the pinned snapshot after the callback so the new
+                // running maximum tracks any relocation the compare triggered.
+                max_slot = elems[i];
+                has_max = true;
             }
         }
+        let max = if has_max { Some(max_slot) } else { None };
+        drop(scope);
         let r = make_optional(heap, max);
         Ok(Some(Slot::Reference(Some(r))))
     } else if collector_class == "duke/util/SummingDoubleCollector" {
         // summingDouble: fields[0] = ToDoubleFunction
         let collector_ref = extract_ref_arg(args, 1)?;
-        let fn_slot = extract_first_field_arg(heap, collector_ref)?;
+        let mut fn_slot = extract_first_field_arg(heap, collector_ref)?;
         let Slot::Reference(Some(fn_ref)) = fn_slot else {
             return Err(Error::NullPointerException);
         };
         let fn_class = heap.get(fn_ref)?.class_name.clone();
+        // Pin the mapper receiver and element snapshot across the callbacks.
         let mut sum = 0.0_f64;
-        for elem in elems {
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut fn_slot);
+        scope.pin_slots(&mut elems);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..elems.len() {
+            let elem = elems[i];
             let result = ops.invoke(
                 heap,
                 out,
@@ -1045,20 +1196,27 @@ pub(crate) fn native_stream_collect(
                 _ => {}
             }
         }
+        drop(scope);
         let boxed = heap.allocate("java/lang/Double".to_string(), 1);
         heap.get_mut(boxed)?.fields[0] = Slot::Double(sum);
         Ok(Some(Slot::Reference(Some(boxed))))
     } else if collector_class == "duke/util/AveragingLongCollector" {
         // averagingLong: fields[0] = ToLongFunction
         let collector_ref = extract_ref_arg(args, 1)?;
-        let fn_slot = extract_first_field_arg(heap, collector_ref)?;
+        let mut fn_slot = extract_first_field_arg(heap, collector_ref)?;
         let Slot::Reference(Some(fn_ref)) = fn_slot else {
             return Err(Error::NullPointerException);
         };
         let fn_class = heap.get(fn_ref)?.class_name.clone();
+        // Pin the mapper receiver and element snapshot across the callbacks.
         let mut sum = 0_i64;
         let mut count = 0_usize;
-        for elem in elems {
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut fn_slot);
+        scope.pin_slots(&mut elems);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..elems.len() {
+            let elem = elems[i];
             let result = ops.invoke(
                 heap,
                 out,
@@ -1079,6 +1237,7 @@ pub(crate) fn native_stream_collect(
                 _ => {}
             }
         }
+        drop(scope);
         #[allow(clippy::cast_precision_loss)]
         let avg = if count == 0 {
             0.0
@@ -1091,16 +1250,24 @@ pub(crate) fn native_stream_collect(
     } else if collector_class == "duke/util/ReducingNoIdentityCollector" {
         // reducing(BinaryOperator) → Optional<T>
         let collector_ref = extract_ref_arg(args, 1)?;
-        let op_slot = extract_first_field_arg(heap, collector_ref)?;
+        let mut op_slot = extract_first_field_arg(heap, collector_ref)?;
         let Slot::Reference(Some(bop_ref)) = op_slot else {
             return Err(Error::NullPointerException);
         };
         let op_class = heap.get(bop_ref)?.class_name.clone();
+        // Pin the operator receiver, the element snapshot, and the running
+        // accumulator (a heap ref carried across every fold callback).
         let result = if elems.is_empty() {
             None
         } else {
             let mut acc = elems[0];
-            for elem in elems.into_iter().skip(1) {
+            let mut scope = NativeRootScope::new();
+            scope.pin_slot(&mut op_slot);
+            scope.pin_slots(&mut elems);
+            scope.pin_slot(&mut acc);
+            #[allow(clippy::needless_range_loop)]
+            for i in 1..elems.len() {
+                let elem = elems[i];
                 acc = ops
                     .invoke(
                         heap,
@@ -1112,6 +1279,7 @@ pub(crate) fn native_stream_collect(
                     )?
                     .unwrap_or(Slot::Reference(None));
             }
+            drop(scope);
             Some(acc)
         };
         let opt_ref = make_optional(heap, result);
@@ -1120,13 +1288,21 @@ pub(crate) fn native_stream_collect(
         // reducing(identity, BinaryOperator) → T
         let collector_ref = extract_ref_arg(args, 1)?;
         let identity_slot = extract_first_field_arg(heap, collector_ref)?;
-        let op_slot = extract_field_arg(heap, collector_ref, 1)?;
+        let mut op_slot = extract_field_arg(heap, collector_ref, 1)?;
         let Slot::Reference(Some(bop_ref)) = op_slot else {
             return Err(Error::NullPointerException);
         };
         let op_class = heap.get(bop_ref)?.class_name.clone();
+        // Pin the operator receiver, the element snapshot, and the running
+        // accumulator (a heap ref carried across every fold callback).
         let mut acc = identity_slot;
-        for elem in elems {
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut op_slot);
+        scope.pin_slots(&mut elems);
+        scope.pin_slot(&mut acc);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..elems.len() {
+            let elem = elems[i];
             acc = ops
                 .invoke(
                     heap,
@@ -1138,13 +1314,14 @@ pub(crate) fn native_stream_collect(
                 )?
                 .unwrap_or(Slot::Reference(None));
         }
+        drop(scope);
         Ok(Some(acc))
     } else if collector_class == "duke/util/ReducingMappingCollector" {
         // reducing(identity, mapper, BinaryOperator) → U
         let collector_ref = extract_ref_arg(args, 1)?;
         let identity_slot = extract_first_field_arg(heap, collector_ref)?;
-        let mapper_slot = extract_field_arg(heap, collector_ref, 1)?;
-        let op_slot = extract_field_arg(heap, collector_ref, 2)?;
+        let mut mapper_slot = extract_field_arg(heap, collector_ref, 1)?;
+        let mut op_slot = extract_field_arg(heap, collector_ref, 2)?;
         let Slot::Reference(Some(mapper_ref)) = mapper_slot else {
             return Err(Error::NullPointerException);
         };
@@ -1153,9 +1330,21 @@ pub(crate) fn native_stream_collect(
         };
         let mapper_class = heap.get(mapper_ref)?.class_name.clone();
         let op_class = heap.get(bop_ref)?.class_name.clone();
+        // Pin the mapper and operator receivers, the element snapshot, the
+        // running accumulator, and the per-iteration mapped value (held across
+        // the fold `ops.invoke`). All are held in Rust locals across callbacks.
         let mut acc = identity_slot;
-        for elem in elems {
-            let mapped = ops
+        let mut mapped = Slot::Reference(None);
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut mapper_slot);
+        scope.pin_slot(&mut op_slot);
+        scope.pin_slots(&mut elems);
+        scope.pin_slot(&mut acc);
+        scope.pin_slot(&mut mapped);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..elems.len() {
+            let elem = elems[i];
+            mapped = ops
                 .invoke(
                     heap,
                     out,
@@ -1176,16 +1365,25 @@ pub(crate) fn native_stream_collect(
                 )?
                 .unwrap_or(Slot::Reference(None));
         }
+        drop(scope);
         Ok(Some(acc))
     } else if collector_class == "duke/util/CollectingAndThenCollector" {
         // collectingAndThen(downstream, finisher): fields[0]=downstream, fields[1]=finisher
         let collector_ref = extract_ref_arg(args, 1)?;
         let downstream_slot = extract_first_field_arg(heap, collector_ref)?;
-        let finisher_slot = extract_field_arg(heap, collector_ref, 1)?;
+        let mut finisher_slot = extract_field_arg(heap, collector_ref, 1)?;
         let Slot::Reference(Some(finisher_ref)) = finisher_slot else {
             return Err(Error::NullPointerException);
         };
         let finisher_class = heap.get(finisher_ref)?.class_name.clone();
+        // The recursive downstream `native_stream_collect` is itself a GC point
+        // (it runs the downstream collector's callbacks, which allocate and can
+        // relocate). Pin the finisher receiver across it: it is held in a Rust
+        // local from before the recursive collect until the finisher `ops.invoke`
+        // afterwards, so a relocating GC inside the downstream collect would
+        // otherwise leave it stale.
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut finisher_slot);
         // First collect with downstream
         let tmp_args = vec![Slot::Reference(Some(stream_ref)), downstream_slot];
         let intermediate = native_stream_collect(&tmp_args, heap, out, control, ops)?
@@ -1199,6 +1397,7 @@ pub(crate) fn native_stream_collect(
             "(Ljava/lang/Object;)Ljava/lang/Object;",
             vec![finisher_slot, intermediate],
         )?;
+        drop(scope);
         Ok(result.or(Some(Slot::Reference(None))))
     } else if collector_class == "duke/util/ToUnmodifiableListCollector" {
         // toUnmodifiableList(): collect into UnmodifiableList (mutations throw).
@@ -1216,7 +1415,18 @@ pub(crate) fn native_stream_collect(
         //   for elem in elems { accumulator().accept(container, elem); }
         //   result = finisher().apply(container);
         let collector_ref = extract_ref_arg(args, 1)?;
-        let collector_slot = Slot::Reference(Some(collector_ref));
+        let mut collector_slot = Slot::Reference(Some(collector_ref));
+
+        // This branch drives a chain of callbacks (supplier → get → accumulator →
+        // accept per element → finisher → apply) and holds several heap refs in
+        // Rust locals across those `ops.invoke` GC points: the collector itself
+        // (re-passed to supplier()/accumulator()/finisher()), the result
+        // container (produced by get(), fed to every accept and to the final
+        // apply), the accumulator BiConsumer (re-passed to every accept), and the
+        // element snapshot. Pin them so a relocating GC inside any callback keeps
+        // them alive and forwarded.
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut collector_slot);
 
         // container = collector.supplier().get()
         let supplier = ops
@@ -1233,7 +1443,7 @@ pub(crate) fn native_stream_collect(
             return Err(Error::NullPointerException);
         };
         let supplier_class = heap.get(supplier_ref)?.class_name.clone();
-        let container = ops
+        let mut container = ops
             .invoke(
                 heap,
                 out,
@@ -1243,9 +1453,10 @@ pub(crate) fn native_stream_collect(
                 vec![supplier],
             )?
             .unwrap_or(Slot::Reference(None));
+        scope.pin_slot(&mut container);
 
         // accumulator = collector.accumulator()
-        let accumulator = ops
+        let mut accumulator = ops
             .invoke(
                 heap,
                 out,
@@ -1259,7 +1470,11 @@ pub(crate) fn native_stream_collect(
             return Err(Error::NullPointerException);
         };
         let acc_class = heap.get(acc_ref)?.class_name.clone();
-        for elem in elems {
+        scope.pin_slot(&mut accumulator);
+        scope.pin_slots(&mut elems);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..elems.len() {
+            let elem = elems[i];
             ops.invoke(
                 heap,
                 out,
@@ -1284,6 +1499,7 @@ pub(crate) fn native_stream_collect(
         let Slot::Reference(Some(fin_ref)) = finisher else {
             // No finisher (should not happen for a well-formed Collector) — the
             // container itself is the result (IDENTITY_FINISH semantics).
+            drop(scope);
             return Ok(Some(container));
         };
         let fin_class = heap.get(fin_ref)?.class_name.clone();
@@ -1295,6 +1511,7 @@ pub(crate) fn native_stream_collect(
             "(Ljava/lang/Object;)Ljava/lang/Object;",
             vec![finisher, container],
         )?;
+        drop(scope);
         Ok(result.or(Some(Slot::Reference(None))))
     } else {
         // ToListCollector (default): collect into ArrayList.

--- a/crates/duke-interpreter/src/native/duke_util.rs
+++ b/crates/duke-interpreter/src/native/duke_util.rs
@@ -2358,12 +2358,19 @@ pub(crate) fn native_comparing_int_compare(
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
     let fn_slot = extract_first_field_arg(heap, this_ref)?;
-    let Slot::Reference(Some(fn_ref)) = fn_slot else {
+    let Slot::Reference(Some(mut fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Int(0)));
     };
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let a = extract_slot_arg(args, 1);
-    let b = extract_slot_arg(args, 2);
+    let mut b = extract_slot_arg(args, 2);
+    // Pin the comparator receiver (re-passed to both `applyAsInt` invokes) and
+    // the second key `b`, which is held across the first invoke. Without this a
+    // relocating GC inside the first callback leaves `fn_ref`/`b` stale before
+    // the second invoke reads them.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut fn_ref);
+    scope.pin_slot(&mut b);
     let ka = ops
         .invoke(
             heap,
@@ -2384,6 +2391,7 @@ pub(crate) fn native_comparing_int_compare(
             vec![Slot::Reference(Some(fn_ref)), b],
         )?
         .unwrap_or(Slot::Int(0));
+    drop(scope);
     let result = match (ka, kb) {
         (Slot::Int(ia), Slot::Int(ib)) => ia.cmp(&ib) as i32,
         _ => 0,
@@ -2476,13 +2484,21 @@ pub(crate) fn native_comparing_comparator_compare(
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
     let a = extract_slot_arg(args, 1);
-    let b = extract_slot_arg(args, 2);
-    let fn_slot = extract_first_field_arg(heap, this_ref)?;
+    let mut b = extract_slot_arg(args, 2);
+    let mut fn_slot = extract_first_field_arg(heap, this_ref)?;
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Int(0)));
     };
     let fn_class = heap.get(fn_ref)?.class_name.clone();
-    let ka = ops
+    // Pin the key-extractor receiver (`fn_slot`, re-passed to both `apply`
+    // invokes) and the second element `b` (held across the first invoke). After
+    // the first invoke returns, also pin its object-typed key result `ka`, which
+    // is held across the second invoke and read by `compare_treemap_keys`.
+    // Without this a relocating GC inside either callback leaves these stale.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
+    scope.pin_slot(&mut b);
+    let mut ka = ops
         .invoke(
             heap,
             out,
@@ -2492,6 +2508,7 @@ pub(crate) fn native_comparing_comparator_compare(
             vec![fn_slot, a],
         )?
         .unwrap_or(Slot::Reference(None));
+    scope.pin_slot(&mut ka);
     let kb = ops
         .invoke(
             heap,
@@ -2502,6 +2519,7 @@ pub(crate) fn native_comparing_comparator_compare(
             vec![fn_slot, b],
         )?
         .unwrap_or(Slot::Reference(None));
+    drop(scope);
     // Compare extracted keys via natural ordering (String, Integer, Long, or raw int).
     let cmp = compare_treemap_keys(ka, kb, heap) as i32;
     Ok(Some(Slot::Int(cmp)))
@@ -4367,13 +4385,20 @@ pub(crate) fn native_comparing_long_compare(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let this_ref = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_first_field_arg(heap, this_ref)?;
+    let mut fn_slot = extract_first_field_arg(heap, this_ref)?;
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Int(0)));
     };
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let a = extract_slot_arg(args, 1);
-    let b = extract_slot_arg(args, 2);
+    let mut b = extract_slot_arg(args, 2);
+    // Pin the comparator receiver (`fn_slot`, re-passed to both `applyAsLong`
+    // invokes) and the second key `b`, held across the first invoke. Without
+    // this a relocating GC inside the first callback leaves them stale before
+    // the second invoke reads them.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
+    scope.pin_slot(&mut b);
     let ka = ops
         .invoke(
             heap,
@@ -4394,6 +4419,7 @@ pub(crate) fn native_comparing_long_compare(
             vec![fn_slot, b],
         )?
         .unwrap_or(Slot::Long(0));
+    drop(scope);
     let result = match (ka, kb) {
         (Slot::Long(la), Slot::Long(lb)) => la.cmp(&lb) as i32,
         (Slot::Int(ia), Slot::Int(ib)) => ia.cmp(&ib) as i32,

--- a/crates/duke-interpreter/src/native/duke_util.rs
+++ b/crates/duke-interpreter/src/native/duke_util.rs
@@ -3356,11 +3356,17 @@ pub(crate) fn native_bifunction_and_then_apply(
     let a = extract_slot_arg(args, 1);
     let b = extract_slot_arg(args, 2);
     let bifunction = extract_first_field_arg(heap, this_ref)?;
-    let after = extract_field_arg(heap, this_ref, 1)?;
+    let mut after = extract_field_arg(heap, this_ref, 1)?;
     let Slot::Reference(Some(bf_ref)) = bifunction else {
         return Ok(Some(Slot::Reference(None)));
     };
     let bf_class = heap.get(bf_ref)?.class_name.clone();
+    // Pin the `after` function, which is held across the wrapped bifunction's
+    // `apply` invoke and only consumed at the following `invoke_function_apply`.
+    // Without this a relocating GC inside the first callback leaves `after`
+    // stale before the second stage runs it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut after);
     let mid = ops
         .invoke(
             heap,
@@ -3371,6 +3377,7 @@ pub(crate) fn native_bifunction_and_then_apply(
             vec![bifunction, a, b],
         )?
         .unwrap_or(Slot::Reference(None));
+    drop(scope);
     Ok(Some(invoke_function_apply(after, mid, heap, out, ops)?))
 }
 /// Native: `Stream.mapToLong(ToLongFunction)LongStream` — maps each element via `applyAsLong`.

--- a/crates/duke-interpreter/src/native/duke_util.rs
+++ b/crates/duke-interpreter/src/native/duke_util.rs
@@ -38,17 +38,28 @@ pub(crate) fn native_stream_filter(
 ) -> Result<Option<Slot>> {
     let stream_ref = extract_ref_arg(args, 0)?;
     let pred_slot = extract_slot_arg(args, 1);
-    let Slot::Reference(Some(pred_ref)) = pred_slot else {
+    let Slot::Reference(Some(mut pred_ref)) = pred_slot else {
         return Ok(Some(Slot::Reference(None)));
     };
     let size = match heap.get(stream_ref)?.fields.first() {
         Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
         _ => 0,
     };
-    let elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    let mut elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
     let pred_class = heap.get(pred_ref)?.class_name.clone();
-    let mut kept: Vec<Slot> = Vec::new();
-    for elem in elems {
+    // Pin the callback receiver and the not-yet-visited element snapshot: the
+    // native holds them in Rust locals across every `ops.invoke`, and native
+    // args live in a Copy `Vec<Slot>` the collector never scans, so a relocating
+    // GC inside the callback would otherwise leave them stale. Record surviving
+    // elements as indices into the pinned snapshot (rather than a separate ref
+    // Vec that would itself go stale) and materialise them while still pinned.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut pred_ref);
+    scope.pin_slots(&mut elems);
+    let mut kept_idx: Vec<usize> = Vec::new();
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..elems.len() {
+        let elem = elems[i];
         let result = ops.invoke(
             heap,
             out,
@@ -58,13 +69,17 @@ pub(crate) fn native_stream_filter(
             vec![Slot::Reference(Some(pred_ref)), elem],
         )?;
         if matches!(result, Some(Slot::Int(1))) {
-            kept.push(elem);
+            kept_idx.push(i);
         }
     }
-    let new_size = i32::try_from(kept.len()).unwrap_or(0);
+    let new_size = i32::try_from(kept_idx.len()).unwrap_or(0);
     let new_stream = heap.allocate("duke/util/Stream".to_string(), 1);
     heap.get_mut(new_stream)?.fields[0] = Slot::Int(new_size);
-    heap.get_mut(new_stream)?.fields.extend(kept);
+    for &i in &kept_idx {
+        let elem = elems[i];
+        heap.get_mut(new_stream)?.fields.push(elem);
+    }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(new_stream))))
 }
 /// Native: `Stream.map(Function)Stream` — transforms each element via `function.apply()`.
@@ -77,17 +92,27 @@ pub(crate) fn native_stream_map(
 ) -> Result<Option<Slot>> {
     let stream_ref = extract_ref_arg(args, 0)?;
     let fn_slot = extract_slot_arg(args, 1);
-    let Slot::Reference(Some(fn_ref)) = fn_slot else {
+    let Slot::Reference(Some(mut fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(None)));
     };
     let size = match heap.get(stream_ref)?.fields.first() {
         Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
         _ => 0,
     };
-    let elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    let mut elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
     let fn_class = heap.get(fn_ref)?.class_name.clone();
-    let mut mapped: Vec<Slot> = Vec::with_capacity(elems.len());
-    for elem in elems {
+    // Pin the callback receiver, the not-yet-visited element snapshot, and the
+    // already-produced results: all are held in Rust locals across `ops.invoke`
+    // and would otherwise go stale if the callback triggers a relocating GC.
+    // `mapped` is pre-sized and index-assigned (never pushed), so its pinned
+    // buffer never reallocates.
+    let mut mapped: Vec<Slot> = vec![Slot::Reference(None); elems.len()];
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut fn_ref);
+    scope.pin_slots(&mut elems);
+    scope.pin_slots(&mut mapped);
+    for i in 0..elems.len() {
+        let elem = elems[i];
         let result = ops.invoke(
             heap,
             out,
@@ -98,12 +123,17 @@ pub(crate) fn native_stream_map(
         )?;
         // Box primitive results so stream elements are always References (Java type-erasure)
         let boxed = box_primitive_slot(result.unwrap_or(Slot::Reference(None)), heap);
-        mapped.push(boxed);
+        mapped[i] = boxed;
     }
     let new_size = i32::try_from(mapped.len()).unwrap_or(0);
     let new_stream = heap.allocate("duke/util/Stream".to_string(), 1);
     heap.get_mut(new_stream)?.fields[0] = Slot::Int(new_size);
-    heap.get_mut(new_stream)?.fields.extend(mapped);
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..mapped.len() {
+        let elem = mapped[i];
+        heap.get_mut(new_stream)?.fields.push(elem);
+    }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(new_stream))))
 }
 /// Native: `Stream.forEach(Consumer)V` — calls `consumer.accept()` on each element.
@@ -116,16 +146,24 @@ pub(crate) fn native_stream_for_each(
 ) -> Result<Option<Slot>> {
     let stream_ref = extract_ref_arg(args, 0)?;
     let consumer_slot = extract_slot_arg(args, 1);
-    let Slot::Reference(Some(consumer_ref)) = consumer_slot else {
+    let Slot::Reference(Some(mut consumer_ref)) = consumer_slot else {
         return Ok(None);
     };
     let size = match heap.get(stream_ref)?.fields.first() {
         Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
         _ => 0,
     };
-    let elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    let mut elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
     let consumer_class = heap.get(consumer_ref)?.class_name.clone();
-    for elem in elems {
+    // Pin the callback receiver and the not-yet-visited element snapshot across
+    // the per-element callback so a relocating GC inside the consumer cannot
+    // leave the re-passed receiver or a later element stale.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut consumer_ref);
+    scope.pin_slots(&mut elems);
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..elems.len() {
+        let elem = elems[i];
         ops.invoke(
             heap,
             out,
@@ -135,6 +173,7 @@ pub(crate) fn native_stream_for_each(
             vec![Slot::Reference(Some(consumer_ref)), elem],
         )?;
     }
+    drop(scope);
     Ok(None)
 }
 /// Native: `Stream.collect(Collector)Object` — collects to list (only toList collector supported).
@@ -1304,6 +1343,12 @@ pub(crate) fn native_stream_sorted(
         _ => 0,
     };
     let mut elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    // Pin the element snapshot: its refs are held (and swapped in place) across
+    // every `compareTo` callback and materialised into the result stream after,
+    // so a relocating GC inside a callback must not leave them stale. Swapping
+    // reorders values within the pinned buffer (its address is unchanged).
+    let mut scope = NativeRootScope::new();
+    scope.pin_slots(&mut elems);
     // Insertion sort via compareTo callbacks (stable, O(n²) — fine for test sizes).
     for i in 1..elems.len() {
         let mut j = i;
@@ -1334,7 +1379,12 @@ pub(crate) fn native_stream_sorted(
     let new_size = i32::try_from(elems.len()).unwrap_or(0);
     let new_stream = heap.allocate("duke/util/Stream".to_string(), 1);
     heap.get_mut(new_stream)?.fields[0] = Slot::Int(new_size);
-    heap.get_mut(new_stream)?.fields.extend(elems);
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..elems.len() {
+        let elem = elems[i];
+        heap.get_mut(new_stream)?.fields.push(elem);
+    }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(new_stream))))
 }
 /// Native: `Stream.anyMatch(Predicate)Z` — true if any element satisfies predicate.
@@ -1347,16 +1397,24 @@ pub(crate) fn native_stream_any_match(
 ) -> Result<Option<Slot>> {
     let stream_ref = extract_ref_arg(args, 0)?;
     let pred_slot = extract_slot_arg(args, 1);
-    let Slot::Reference(Some(pred_ref)) = pred_slot else {
+    let Slot::Reference(Some(mut pred_ref)) = pred_slot else {
         return Ok(Some(Slot::Int(0)));
     };
     let size = match heap.get(stream_ref)?.fields.first() {
         Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
         _ => 0,
     };
-    let elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    let mut elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
     let pred_class = heap.get(pred_ref)?.class_name.clone();
-    for elem in elems {
+    // Pin the callback receiver and the not-yet-visited element snapshot so a
+    // relocating GC inside the predicate cannot leave the re-passed receiver or
+    // a later element stale. `scope` is dropped by RAII on any return.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut pred_ref);
+    scope.pin_slots(&mut elems);
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..elems.len() {
+        let elem = elems[i];
         let result = ops.invoke(
             heap,
             out,
@@ -1369,6 +1427,7 @@ pub(crate) fn native_stream_any_match(
             return Ok(Some(Slot::Int(1)));
         }
     }
+    drop(scope);
     Ok(Some(Slot::Int(0)))
 }
 /// Native: `Stream.allMatch(Predicate)Z` — true if all elements satisfy predicate.
@@ -1381,16 +1440,24 @@ pub(crate) fn native_stream_all_match(
 ) -> Result<Option<Slot>> {
     let stream_ref = extract_ref_arg(args, 0)?;
     let pred_slot = extract_slot_arg(args, 1);
-    let Slot::Reference(Some(pred_ref)) = pred_slot else {
+    let Slot::Reference(Some(mut pred_ref)) = pred_slot else {
         return Ok(Some(Slot::Int(1)));
     };
     let size = match heap.get(stream_ref)?.fields.first() {
         Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
         _ => 0,
     };
-    let elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    let mut elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
     let pred_class = heap.get(pred_ref)?.class_name.clone();
-    for elem in elems {
+    // Pin the callback receiver and the not-yet-visited element snapshot so a
+    // relocating GC inside the predicate cannot leave the re-passed receiver or
+    // a later element stale. `scope` is dropped by RAII on any return.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut pred_ref);
+    scope.pin_slots(&mut elems);
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..elems.len() {
+        let elem = elems[i];
         let result = ops.invoke(
             heap,
             out,
@@ -1403,6 +1470,7 @@ pub(crate) fn native_stream_all_match(
             return Ok(Some(Slot::Int(0)));
         }
     }
+    drop(scope);
     Ok(Some(Slot::Int(1)))
 }
 /// Native: `Stream.noneMatch(Predicate)Z` — true if no element satisfies predicate.
@@ -1415,16 +1483,24 @@ pub(crate) fn native_stream_none_match(
 ) -> Result<Option<Slot>> {
     let stream_ref = extract_ref_arg(args, 0)?;
     let pred_slot = extract_slot_arg(args, 1);
-    let Slot::Reference(Some(pred_ref)) = pred_slot else {
+    let Slot::Reference(Some(mut pred_ref)) = pred_slot else {
         return Ok(Some(Slot::Int(1)));
     };
     let size = match heap.get(stream_ref)?.fields.first() {
         Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
         _ => 0,
     };
-    let elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    let mut elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
     let pred_class = heap.get(pred_ref)?.class_name.clone();
-    for elem in elems {
+    // Pin the callback receiver and the not-yet-visited element snapshot so a
+    // relocating GC inside the predicate cannot leave the re-passed receiver or
+    // a later element stale. `scope` is dropped by RAII on any return.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut pred_ref);
+    scope.pin_slots(&mut elems);
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..elems.len() {
+        let elem = elems[i];
         let result = ops.invoke(
             heap,
             out,
@@ -1437,6 +1513,7 @@ pub(crate) fn native_stream_none_match(
             return Ok(Some(Slot::Int(0)));
         }
     }
+    drop(scope);
     Ok(Some(Slot::Int(1)))
 }
 /// Native: `Stream.findFirst()Optional` — returns Optional of first element, or empty.
@@ -1471,22 +1548,35 @@ pub(crate) fn native_stream_reduce(
 ) -> Result<Option<Slot>> {
     let stream_ref = extract_ref_arg(args, 0)?;
     let op_slot = extract_slot_arg(args, 1);
-    let Slot::Reference(Some(op_ref)) = op_slot else {
+    let Slot::Reference(Some(mut op_ref)) = op_slot else {
         return Ok(Some(Slot::Reference(None)));
     };
     let size = match heap.get(stream_ref)?.fields.first() {
         Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
         _ => 0,
     };
-    let elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    let mut elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
     let op_class = heap.get(op_ref)?.class_name.clone();
-    let reduce_result_ref = heap.allocate("java/util/Optional".to_string(), 1);
+    let mut reduce_result_ref = heap.allocate("java/util/Optional".to_string(), 1);
     if elems.is_empty() {
         heap.get_mut(reduce_result_ref)?.fields[0] = Slot::Reference(None);
         return Ok(Some(Slot::Reference(Some(reduce_result_ref))));
     }
     let mut acc = elems[0];
-    for elem in elems.into_iter().skip(1) {
+    // Pin every ref held across the fold: the callback receiver, the
+    // not-yet-visited element snapshot, the running accumulator (reassigned each
+    // iteration — its stack storage is pinned), and the Optional container that
+    // is allocated before the loop and written after it. Index-walk the pinned
+    // snapshot; the accumulator stays pinned across the final `box_primitive_slot`
+    // (which may allocate).
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut op_ref);
+    scope.pin_ref(&mut reduce_result_ref);
+    scope.pin_slots(&mut elems);
+    scope.pin_slot(&mut acc);
+    #[allow(clippy::needless_range_loop)]
+    for i in 1..elems.len() {
+        let elem = elems[i];
         let result = ops.invoke(
             heap,
             out,
@@ -1500,6 +1590,7 @@ pub(crate) fn native_stream_reduce(
     // Box primitive accumulator before storing in Optional (Java generics always hold References)
     let acc_boxed = box_primitive_slot(acc, heap);
     heap.get_mut(reduce_result_ref)?.fields[0] = acc_boxed;
+    drop(scope);
     Ok(Some(Slot::Reference(Some(reduce_result_ref))))
 }
 /// Native: `Stream.reduce(identity, BinaryOperator)Object` — fold with initial value.
@@ -1512,7 +1603,7 @@ pub(crate) fn native_stream_reduce_with_identity(
 ) -> Result<Option<Slot>> {
     let stream_ref = extract_ref_arg(args, 0)?;
     let identity = extract_slot_arg(args, 1);
-    let fn_slot = extract_slot_arg(args, 2);
+    let mut fn_slot = extract_slot_arg(args, 2);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(identity));
     };
@@ -1521,9 +1612,18 @@ pub(crate) fn native_stream_reduce_with_identity(
         Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
         _ => 0,
     };
-    let elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    let mut elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
     let mut acc = identity;
-    for elem in elems {
+    // Pin the callback receiver slot, the not-yet-visited element snapshot, and
+    // the running accumulator (reassigned each iteration — its stack storage is
+    // pinned) so a relocating GC inside the accumulator cannot leave them stale.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
+    scope.pin_slots(&mut elems);
+    scope.pin_slot(&mut acc);
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..elems.len() {
+        let elem = elems[i];
         acc = ops
             .invoke(
                 heap,
@@ -1535,6 +1635,7 @@ pub(crate) fn native_stream_reduce_with_identity(
             )?
             .unwrap_or(Slot::Reference(None));
     }
+    drop(scope);
     // Autobox: if the identity was a Reference (stream of boxed type) but the accumulator
     // impl returned a raw primitive (e.g. Integer::sum returns int), re-box the result so
     // that the caller can apply intValue() / longValue() as expected.
@@ -1667,7 +1768,7 @@ pub(crate) fn native_stream_peek(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let stream_ref = extract_ref_arg(args, 0)?;
-    let consumer_slot = extract_slot_arg(args, 1);
+    let mut consumer_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(consumer_ref)) = consumer_slot else {
         return Ok(Some(Slot::Reference(Some(stream_ref))));
     };
@@ -1675,22 +1776,36 @@ pub(crate) fn native_stream_peek(
         Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
         _ => 0,
     };
-    let elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    let mut elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
     let consumer_class = heap.get(consumer_ref)?.class_name.clone();
-    for elem in &elems {
+    // Pin the callback receiver slot and the element snapshot: the snapshot is
+    // both re-visited across the per-element callback and materialised into the
+    // returned stream afterward, so a relocating GC inside the consumer must not
+    // leave its refs stale. Keep the pin across the final allocation.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut consumer_slot);
+    scope.pin_slots(&mut elems);
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..elems.len() {
+        let elem = elems[i];
         ops.invoke(
             heap,
             out,
             &consumer_class,
             "accept",
             "(Ljava/lang/Object;)V",
-            vec![consumer_slot, *elem],
+            vec![consumer_slot, elem],
         )?;
     }
     // Return a new stream with same elements (consumer may have GC'd things)
     let out_ref = heap.allocate("duke/util/Stream".to_string(), 1);
     heap.get_mut(out_ref)?.fields[0] = Slot::Int(i32::try_from(elems.len()).unwrap_or(0));
-    heap.get_mut(out_ref)?.fields.extend(elems);
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..elems.len() {
+        let elem = elems[i];
+        heap.get_mut(out_ref)?.fields.push(elem);
+    }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(out_ref))))
 }
 /// Native: `Stream.toArray()Object[]` — materializes stream into an Object array.
@@ -1730,12 +1845,19 @@ pub(crate) fn native_stream_limit(
     // Lazy generators: materialise N elements on limit().
     if class_name == "duke/util/GeneratorStream" {
         let supplier_slot = extract_first_field_arg(heap, stream_ref)?;
-        let Slot::Reference(Some(sup_ref)) = supplier_slot else {
+        let Slot::Reference(Some(mut sup_ref)) = supplier_slot else {
             return Ok(Some(Slot::Reference(None)));
         };
         let sup_class = heap.get(sup_ref)?.class_name.clone();
-        let out_ref = heap.allocate("duke/util/Stream".to_string(), 1);
+        let mut out_ref = heap.allocate("duke/util/Stream".to_string(), 1);
         heap.get_mut(out_ref)?.fields[0] = Slot::Int(i32::try_from(max_size).unwrap_or(0));
+        // Pin the supplier receiver and the result stream accumulator: both are
+        // held in Rust locals across every `get()` callback. Pinning `out_ref`
+        // roots the already-collected elements it holds, so they survive any
+        // relocating GC a later callback triggers.
+        let mut scope = NativeRootScope::new();
+        scope.pin_ref(&mut sup_ref);
+        scope.pin_ref(&mut out_ref);
         for _ in 0..max_size {
             let elem = ops
                 .invoke(
@@ -1749,20 +1871,29 @@ pub(crate) fn native_stream_limit(
                 .unwrap_or(Slot::Reference(None));
             heap.get_mut(out_ref)?.fields.push(elem);
         }
+        drop(scope);
         return Ok(Some(Slot::Reference(Some(out_ref))));
     }
 
     if class_name == "duke/util/IteratorStream" {
         // fields[0] = current seed, fields[1] = UnaryOperator fn
         let seed = extract_first_field_arg(heap, stream_ref)?;
-        let fn_slot = extract_field_arg(heap, stream_ref, 1)?;
+        let mut fn_slot = extract_field_arg(heap, stream_ref, 1)?;
         let Slot::Reference(Some(fn_ref)) = fn_slot else {
             return Ok(Some(Slot::Reference(None)));
         };
         let fn_class = heap.get(fn_ref)?.class_name.clone();
-        let out_ref = heap.allocate("duke/util/Stream".to_string(), 1);
+        let mut out_ref = heap.allocate("duke/util/Stream".to_string(), 1);
         heap.get_mut(out_ref)?.fields[0] = Slot::Int(i32::try_from(max_size).unwrap_or(0));
         let mut current = seed;
+        // Pin the callback receiver slot and the result stream accumulator:
+        // both are held across every `apply()` callback. Pinning `out_ref` roots
+        // the already-pushed elements it holds. `current` is pushed into `out_ref`
+        // (thus rooted) before each callback and then reassigned from the
+        // callback's result, so it is never read while stale and needs no pin.
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut fn_slot);
+        scope.pin_ref(&mut out_ref);
         for _ in 0..max_size {
             heap.get_mut(out_ref)?.fields.push(current);
             current = ops
@@ -1776,6 +1907,7 @@ pub(crate) fn native_stream_limit(
                 )?
                 .unwrap_or(Slot::Reference(None));
         }
+        drop(scope);
         return Ok(Some(Slot::Reference(Some(out_ref))));
     }
 
@@ -1826,7 +1958,7 @@ pub(crate) fn native_stream_flat_map(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let stream_ref = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(None)));
     };
@@ -1834,10 +1966,22 @@ pub(crate) fn native_stream_flat_map(
         Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
         _ => 0,
     };
-    let elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    let mut elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
     let fn_class = heap.get(fn_ref)?.class_name.clone();
-    let mut flat: Vec<Slot> = Vec::with_capacity(elems.len());
-    for elem in elems {
+    // Accumulate the flattened elements directly into the (heap-allocated,
+    // pinned) result stream rather than a growing Rust `Vec` — pinning cannot
+    // track a `Vec` that reallocates, but a pinned `out_ref` roots every element
+    // already pushed into it, so they survive any relocating GC a later callback
+    // triggers. Also pin the callback receiver slot and the element snapshot.
+    let mut out_ref = heap.allocate("duke/util/Stream".to_string(), 1);
+    heap.get_mut(out_ref)?.fields[0] = Slot::Int(0);
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
+    scope.pin_slots(&mut elems);
+    scope.pin_ref(&mut out_ref);
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..elems.len() {
+        let elem = elems[i];
         let inner = ops.invoke(
             heap,
             out,
@@ -1853,13 +1997,12 @@ pub(crate) fn native_stream_flat_map(
                 _ => 0,
             };
             let inner_elems: Vec<Slot> = heap.get(inner_ref)?.fields[1..=inner_size].to_vec();
-            flat.extend(inner_elems);
+            heap.get_mut(out_ref)?.fields.extend(inner_elems);
         }
     }
-    let new_size = i32::try_from(flat.len()).unwrap_or(0);
-    let out_ref = heap.allocate("duke/util/Stream".to_string(), 1);
+    let new_size = i32::try_from(heap.get(out_ref)?.fields.len().saturating_sub(1)).unwrap_or(0);
     heap.get_mut(out_ref)?.fields[0] = Slot::Int(new_size);
-    heap.get_mut(out_ref)?.fields.extend(flat);
+    drop(scope);
     Ok(Some(Slot::Reference(Some(out_ref))))
 }
 /// Native: `IntStream.range(int,int)IntStream` — half-open range [start, end).
@@ -2245,14 +2388,22 @@ pub(crate) fn native_int_stream_map_to_obj(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(None)));
     };
     let elems = int_stream_elems(heap, r);
     let fn_class = heap.get(fn_ref)?.class_name.clone();
-    let mut mapped = Vec::new();
-    for v in elems {
+    // Elements are primitive ints (no element-ref hazard), but the mapper
+    // produces object results that accumulate across later callbacks. Pin the
+    // callback receiver slot and the pre-sized, index-assigned result buffer
+    // (never pushed, so it never reallocates) so a relocating GC cannot leave
+    // an already-produced result stale.
+    let mut mapped: Vec<Slot> = vec![Slot::Reference(None); elems.len()];
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
+    scope.pin_slots(&mut mapped);
+    for (i, v) in elems.into_iter().enumerate() {
         let result = ops.invoke(
             heap,
             out,
@@ -2261,12 +2412,17 @@ pub(crate) fn native_int_stream_map_to_obj(
             "(I)Ljava/lang/Object;",
             vec![fn_slot, Slot::Int(v)],
         )?;
-        mapped.push(result.unwrap_or(Slot::Reference(None)));
+        mapped[i] = result.unwrap_or(Slot::Reference(None));
     }
     let new_size = i32::try_from(mapped.len()).unwrap_or(0);
     let stream_ref = heap.allocate("duke/util/Stream".to_string(), 1);
     heap.get_mut(stream_ref)?.fields[0] = Slot::Int(new_size);
-    heap.get_mut(stream_ref)?.fields.extend(mapped);
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..mapped.len() {
+        let elem = mapped[i];
+        heap.get_mut(stream_ref)?.fields.push(elem);
+    }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(stream_ref))))
 }
 /// Native: `IntStream.distinct()IntStream` — removes duplicate int values.
@@ -2594,7 +2750,7 @@ pub(crate) fn native_stream_map_to_int(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let stream_ref = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(Some(make_int_stream(heap, vec![])))));
     };
@@ -2603,9 +2759,17 @@ pub(crate) fn native_stream_map_to_int(
         Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
         _ => 0,
     };
-    let elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    let mut elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    // Object elements + object receiver held across each callback; the produced
+    // ints are primitives (no accumulator-ref hazard). Pin the receiver slot and
+    // the not-yet-visited element snapshot.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
+    scope.pin_slots(&mut elems);
     let mut values = Vec::with_capacity(elems.len());
-    for elem in elems {
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..elems.len() {
+        let elem = elems[i];
         let result = ops
             .invoke(
                 heap,
@@ -2629,6 +2793,7 @@ pub(crate) fn native_stream_map_to_int(
             _ => values.push(0),
         }
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_int_stream(heap, values)))))
 }
 /// Native: `IntStream.reduce(int, IntBinaryOperator)I` — fold with identity via callback.
@@ -3070,7 +3235,7 @@ pub(crate) fn native_stream_take_while(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let stream_ref = extract_ref_arg(args, 0)?;
-    let Slot::Reference(Some(pred_ref)) = extract_slot_arg(args, 1)
+    let Slot::Reference(Some(mut pred_ref)) = extract_slot_arg(args, 1)
     else {
         return Ok(Some(Slot::Reference(None)));
     };
@@ -3078,10 +3243,17 @@ pub(crate) fn native_stream_take_while(
         Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
         _ => 0,
     };
-    let elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    let mut elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
     let pred_class = heap.get(pred_ref)?.class_name.clone();
-    let mut kept: Vec<Slot> = Vec::new();
-    for elem in elems {
+    // Pin the receiver and the element snapshot; record kept elements as indices
+    // into the pinned snapshot and materialise them while still pinned.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut pred_ref);
+    scope.pin_slots(&mut elems);
+    let mut kept_idx: Vec<usize> = Vec::new();
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..elems.len() {
+        let elem = elems[i];
         let result = ops.invoke(
             heap,
             out,
@@ -3091,15 +3263,19 @@ pub(crate) fn native_stream_take_while(
             vec![Slot::Reference(Some(pred_ref)), elem],
         )?;
         if matches!(result, Some(Slot::Int(n)) if n != 0) {
-            kept.push(elem);
+            kept_idx.push(i);
         } else {
             break;
         }
     }
-    let new_size = i32::try_from(kept.len()).unwrap_or(0);
+    let new_size = i32::try_from(kept_idx.len()).unwrap_or(0);
     let new_stream = heap.allocate("duke/util/Stream".to_string(), 1);
     heap.get_mut(new_stream)?.fields[0] = Slot::Int(new_size);
-    heap.get_mut(new_stream)?.fields.extend(kept);
+    for &i in &kept_idx {
+        let elem = elems[i];
+        heap.get_mut(new_stream)?.fields.push(elem);
+    }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(new_stream))))
 }
 /// Native: `Stream.dropWhile(Predicate)Stream` — drops prefix while predicate holds, keeps rest.
@@ -3111,7 +3287,7 @@ pub(crate) fn native_stream_drop_while(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let stream_ref = extract_ref_arg(args, 0)?;
-    let Slot::Reference(Some(pred_ref)) = extract_slot_arg(args, 1)
+    let Slot::Reference(Some(mut pred_ref)) = extract_slot_arg(args, 1)
     else {
         return Ok(Some(Slot::Reference(None)));
     };
@@ -3119,11 +3295,18 @@ pub(crate) fn native_stream_drop_while(
         Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
         _ => 0,
     };
-    let elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    let mut elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
     let pred_class = heap.get(pred_ref)?.class_name.clone();
+    // Pin the receiver and the element snapshot; record kept elements as indices
+    // into the pinned snapshot and materialise them while still pinned.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut pred_ref);
+    scope.pin_slots(&mut elems);
     let mut dropping = true;
-    let mut kept: Vec<Slot> = Vec::new();
-    for elem in elems {
+    let mut kept_idx: Vec<usize> = Vec::new();
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..elems.len() {
+        let elem = elems[i];
         if dropping {
             let result = ops.invoke(
                 heap,
@@ -3138,12 +3321,16 @@ pub(crate) fn native_stream_drop_while(
             }
             dropping = false;
         }
-        kept.push(elem);
+        kept_idx.push(i);
     }
-    let new_size = i32::try_from(kept.len()).unwrap_or(0);
+    let new_size = i32::try_from(kept_idx.len()).unwrap_or(0);
     let new_stream = heap.allocate("duke/util/Stream".to_string(), 1);
     heap.get_mut(new_stream)?.fields[0] = Slot::Int(new_size);
-    heap.get_mut(new_stream)?.fields.extend(kept);
+    for &i in &kept_idx {
+        let elem = elems[i];
+        heap.get_mut(new_stream)?.fields.push(elem);
+    }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(new_stream))))
 }
 /// Native: `Stream.sorted(Comparator)Stream` — sorts stream elements using the given comparator.
@@ -3155,7 +3342,7 @@ pub(crate) fn native_stream_sorted_comparator(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     // If no comparator provided, fall back to natural-order sort.
-    let Slot::Reference(Some(comp_ref)) = extract_slot_arg(args, 1)
+    let Slot::Reference(Some(mut comp_ref)) = extract_slot_arg(args, 1)
     else {
         return native_stream_sorted(args, heap, out, control, ops);
     };
@@ -3165,6 +3352,13 @@ pub(crate) fn native_stream_sorted_comparator(
         _ => 0,
     };
     let mut elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    // Pin the comparator receiver and the element snapshot: the snapshot's refs
+    // are held (and swapped in place) across every `compare` callback and
+    // materialised into the result stream after. Keep the pin across the final
+    // allocation.
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut comp_ref);
+    scope.pin_slots(&mut elems);
     // Insertion sort using the provided comparator.
     for i in 1..elems.len() {
         let mut j = i;
@@ -3189,7 +3383,12 @@ pub(crate) fn native_stream_sorted_comparator(
     let new_size = i32::try_from(elems.len()).unwrap_or(0);
     let new_stream = heap.allocate("duke/util/Stream".to_string(), 1);
     heap.get_mut(new_stream)?.fields[0] = Slot::Int(new_size);
-    heap.get_mut(new_stream)?.fields.extend(elems);
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..elems.len() {
+        let elem = elems[i];
+        heap.get_mut(new_stream)?.fields.push(elem);
+    }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(new_stream))))
 }
 /// Native: `Collectors.partitioningBy(Predicate)Collector` — returns a sentinel collector.
@@ -3438,7 +3637,7 @@ pub(crate) fn native_stream_map_to_long(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let stream_ref = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(Some(make_long_stream(heap, vec![])))));
     };
@@ -3447,9 +3646,16 @@ pub(crate) fn native_stream_map_to_long(
         Some(Slot::Int(n)) => usize::try_from(*n).unwrap_or(0),
         _ => 0,
     };
-    let elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    let mut elems: Vec<Slot> = heap.get(stream_ref)?.fields[1..=size].to_vec();
+    // Object elements + object receiver held across each callback; produced
+    // longs are primitives. Pin the receiver slot and the element snapshot.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
+    scope.pin_slots(&mut elems);
     let mut values = Vec::with_capacity(elems.len());
-    for elem in elems {
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..elems.len() {
+        let elem = elems[i];
         let result = ops
             .invoke(
                 heap,
@@ -3467,6 +3673,7 @@ pub(crate) fn native_stream_map_to_long(
         };
         values.push(v);
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_long_stream(heap, values)))))
 }
 /// Native: `LongStream.sum()J` — sums all elements.
@@ -3500,7 +3707,7 @@ pub(crate) fn native_stream_map_to_double(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let stream_ref = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(Some(make_double_stream(
             heap,
@@ -3508,9 +3715,16 @@ pub(crate) fn native_stream_map_to_double(
         )))));
     };
     let fn_class = heap.get(fn_ref)?.class_name.clone();
-    let elems = stream_elements(heap, stream_ref)?;
+    let mut elems = stream_elements(heap, stream_ref)?;
+    // Object elements + object receiver held across each callback; produced
+    // doubles are primitives. Pin the receiver slot and the element snapshot.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
+    scope.pin_slots(&mut elems);
     let mut values = Vec::with_capacity(elems.len());
-    for elem in elems {
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..elems.len() {
+        let elem = elems[i];
         let result = ops
             .invoke(
                 heap,
@@ -3529,6 +3743,7 @@ pub(crate) fn native_stream_map_to_double(
         };
         values.push(v);
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_double_stream(
         heap, values,
     )))))
@@ -5396,8 +5611,8 @@ pub(crate) fn native_stream_iterate_predicate(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let seed = extract_slot_arg(args, 0);
-    let pred_slot = extract_slot_arg(args, 1);
-    let next_slot = extract_slot_arg(args, 2);
+    let mut pred_slot = extract_slot_arg(args, 1);
+    let mut next_slot = extract_slot_arg(args, 2);
     let Slot::Reference(Some(pred_ref)) = pred_slot else {
         return Err(Error::NullPointerException);
     };
@@ -5407,8 +5622,19 @@ pub(crate) fn native_stream_iterate_predicate(
     let pred_class = heap.get(pred_ref)?.class_name.clone();
     let next_class = heap.get(next_ref)?.class_name.clone();
 
-    let mut elems: Vec<Slot> = Vec::new();
+    // Accumulate into a pinned, heap-allocated result stream rather than a
+    // growing Rust `Vec` (which pinning cannot follow across reallocation).
+    // `current` is passed to the predicate, then read again (pushed) AFTER that
+    // callback's GC, so it must be pinned; both callback receiver slots are
+    // re-passed every iteration.
+    let mut out_ref = heap.allocate("duke/util/Stream".to_string(), 1);
+    heap.get_mut(out_ref)?.fields[0] = Slot::Int(0);
     let mut current = seed;
+    let mut scope = NativeRootScope::new();
+    scope.pin_ref(&mut out_ref);
+    scope.pin_slot(&mut pred_slot);
+    scope.pin_slot(&mut next_slot);
+    scope.pin_slot(&mut current);
     for _ in 0..10_000usize {
         let test = ops.invoke(
             heap,
@@ -5422,7 +5648,7 @@ pub(crate) fn native_stream_iterate_predicate(
             Some(Slot::Int(1)) => {}
             _ => break,
         }
-        elems.push(current);
+        heap.get_mut(out_ref)?.fields.push(current);
         current = ops
             .invoke(
                 heap,
@@ -5434,9 +5660,8 @@ pub(crate) fn native_stream_iterate_predicate(
             )?
             .unwrap_or(Slot::Reference(None));
     }
-    let out_ref = heap.allocate("duke/util/Stream".to_string(), 1);
-    let size = i32::try_from(elems.len()).unwrap_or(i32::MAX);
+    let size = i32::try_from(heap.get(out_ref)?.fields.len().saturating_sub(1)).unwrap_or(i32::MAX);
     heap.get_mut(out_ref)?.fields[0] = Slot::Int(size);
-    heap.get_mut(out_ref)?.fields.extend(elems);
+    drop(scope);
     Ok(Some(Slot::Reference(Some(out_ref))))
 }

--- a/crates/duke-interpreter/src/native/duke_util.rs
+++ b/crates/duke-interpreter/src/native/duke_util.rs
@@ -1931,7 +1931,7 @@ pub(crate) fn native_int_stream_iterate(
         Some(Slot::Int(n)) => n,
         _ => 0,
     };
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(Some(make_int_stream(
             heap,
@@ -1941,6 +1941,12 @@ pub(crate) fn native_int_stream_iterate(
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let mut values = Vec::with_capacity(MAX);
     let mut cur = seed;
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for _ in 0..MAX {
         values.push(cur);
         let next = ops
@@ -1958,6 +1964,7 @@ pub(crate) fn native_int_stream_iterate(
             _ => break,
         }
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_int_stream(heap, values)))))
 }
 /// Native: `IntStream.count()J`
@@ -2073,13 +2080,19 @@ pub(crate) fn native_int_stream_filter(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let pred_slot = extract_slot_arg(args, 1);
+    let mut pred_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(pred_ref)) = pred_slot else {
         return Ok(Some(Slot::Reference(None)));
     };
     let elems = int_stream_elems(heap, r);
     let pred_class = heap.get(pred_ref)?.class_name.clone();
     let mut kept = Vec::with_capacity(elems.len());
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut pred_slot);
     for v in elems {
         let result = ops.invoke(
             heap,
@@ -2093,6 +2106,7 @@ pub(crate) fn native_int_stream_filter(
             kept.push(v);
         }
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_int_stream(heap, kept)))))
 }
 /// Native: `IntStream.peek(IntConsumer)IntStream` — calls consumer for each element, returns same stream.
@@ -2104,10 +2118,16 @@ pub(crate) fn native_int_stream_peek(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let elems = int_stream_elems(heap, r);
     if let Slot::Reference(Some(fn_ref)) = fn_slot {
         let fn_class = heap.get(fn_ref)?.class_name.clone();
+        // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+        // iteration, but native args live in a Copy `Vec<Slot>` the collector
+        // never scans, so a relocating GC inside the callback would otherwise
+        // leave this ref stale before the next iteration re-passes it.
+        let mut scope = NativeRootScope::new();
+        scope.pin_slot(&mut fn_slot);
         for &v in &elems {
             ops.invoke(
                 heap,
@@ -2118,6 +2138,7 @@ pub(crate) fn native_int_stream_peek(
                 vec![fn_slot, Slot::Int(v)],
             )?;
         }
+        drop(scope);
     }
     Ok(Some(Slot::Reference(Some(make_int_stream(heap, elems)))))
 }
@@ -2130,13 +2151,19 @@ pub(crate) fn native_int_stream_map(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(None)));
     };
     let elems = int_stream_elems(heap, r);
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let mut result = Vec::with_capacity(elems.len());
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for v in elems {
         let r = ops.invoke(
             heap,
@@ -2151,6 +2178,7 @@ pub(crate) fn native_int_stream_map(
             _ => 0,
         });
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_int_stream(heap, result)))))
 }
 /// Native: `IntStream.forEach(IntConsumer)V`
@@ -2162,12 +2190,18 @@ pub(crate) fn native_int_stream_for_each(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let consumer_slot = extract_slot_arg(args, 1);
+    let mut consumer_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(consumer_ref)) = consumer_slot else {
         return Ok(None);
     };
     let elems = int_stream_elems(heap, r);
     let consumer_class = heap.get(consumer_ref)?.class_name.clone();
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut consumer_slot);
     for v in elems {
         ops.invoke(
             heap,
@@ -2178,6 +2212,7 @@ pub(crate) fn native_int_stream_for_each(
             vec![consumer_slot, Slot::Int(v)],
         )?;
     }
+    drop(scope);
     Ok(None)
 }
 /// Native: `IntStream.boxed()Stream` — wraps each int into `java/lang/Integer`.
@@ -2609,13 +2644,19 @@ pub(crate) fn native_int_stream_reduce_identity(
         Some(Slot::Int(n)) => *n,
         _ => 0,
     };
-    let fn_slot = extract_slot_arg(args, 2);
+    let mut fn_slot = extract_slot_arg(args, 2);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Int(identity)));
     };
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let values = int_stream_elems(heap, stream_ref);
     let mut acc = identity;
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for v in values {
         let result = ops
             .invoke(
@@ -2632,6 +2673,7 @@ pub(crate) fn native_int_stream_reduce_identity(
             _ => 0,
         };
     }
+    drop(scope);
     Ok(Some(Slot::Int(acc)))
 }
 /// Native: `IntStream.reduce(IntBinaryOperator)OptionalInt` — fold without identity.
@@ -2643,7 +2685,7 @@ pub(crate) fn native_int_stream_reduce_optional(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let stream_ref = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         // Return empty OptionalInt
         let r = make_optional_int(heap, None);
@@ -2655,6 +2697,12 @@ pub(crate) fn native_int_stream_reduce_optional(
         return Ok(Some(Slot::Reference(Some(make_optional_int(heap, None)))));
     }
     let mut acc = values[0];
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for &v in &values[1..] {
         let result = ops
             .invoke(
@@ -2671,6 +2719,7 @@ pub(crate) fn native_int_stream_reduce_optional(
             _ => 0,
         };
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_optional_int(
         heap,
         Some(acc),
@@ -3678,13 +3727,19 @@ pub(crate) fn native_long_stream_reduce_identity(
         Some(Slot::Long(n)) => n,
         _ => 0,
     };
-    let fn_slot = extract_slot_arg(args, 2);
+    let mut fn_slot = extract_slot_arg(args, 2);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Long(identity)));
     };
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let elems = long_stream_elems(heap, r);
     let mut acc = identity;
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for v in elems {
         let result = ops
             .invoke(
@@ -3702,6 +3757,7 @@ pub(crate) fn native_long_stream_reduce_identity(
             _ => acc,
         };
     }
+    drop(scope);
     Ok(Some(Slot::Long(acc)))
 }
 /// Native: `LongStream.boxed()Stream` — boxes each long into `java/lang/Long`.
@@ -3734,13 +3790,19 @@ pub(crate) fn native_long_stream_filter(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let pred_slot = extract_slot_arg(args, 1);
+    let mut pred_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(pred_ref)) = pred_slot else {
         return Ok(Some(Slot::Reference(Some(make_long_stream(heap, vec![])))));
     };
     let elems = long_stream_elems(heap, r);
     let pred_class = heap.get(pred_ref)?.class_name.clone();
     let mut kept = Vec::with_capacity(elems.len());
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut pred_slot);
     for v in elems {
         let result = ops.invoke(
             heap,
@@ -3754,6 +3816,7 @@ pub(crate) fn native_long_stream_filter(
             kept.push(v);
         }
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_long_stream(heap, kept)))))
 }
 /// Native: `LongStream.map(LongUnaryOperator)LongStream`
@@ -3765,13 +3828,19 @@ pub(crate) fn native_long_stream_map(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(Some(make_long_stream(heap, vec![])))));
     };
     let elems = long_stream_elems(heap, r);
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let mut result = Vec::with_capacity(elems.len());
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for v in elems {
         let r = ops.invoke(
             heap,
@@ -3787,6 +3856,7 @@ pub(crate) fn native_long_stream_map(
             _ => 0,
         });
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_long_stream(heap, result)))))
 }
 /// Native: `LongStream.forEach(LongConsumer)V`
@@ -3798,12 +3868,18 @@ pub(crate) fn native_long_stream_for_each(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let consumer_slot = extract_slot_arg(args, 1);
+    let mut consumer_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(consumer_ref)) = consumer_slot else {
         return Ok(None);
     };
     let elems = long_stream_elems(heap, r);
     let consumer_class = heap.get(consumer_ref)?.class_name.clone();
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut consumer_slot);
     for v in elems {
         ops.invoke(
             heap,
@@ -3814,6 +3890,7 @@ pub(crate) fn native_long_stream_for_each(
             vec![consumer_slot, Slot::Long(v)],
         )?;
     }
+    drop(scope);
     Ok(None)
 }
 /// Native: `LongStream.mapToInt(LongToIntFunction)IntStream`
@@ -3825,13 +3902,19 @@ pub(crate) fn native_long_stream_map_to_int(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(Some(make_int_stream(heap, vec![])))));
     };
     let elems = long_stream_elems(heap, r);
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let mut result = Vec::with_capacity(elems.len());
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for v in elems {
         let r = ops.invoke(
             heap,
@@ -3846,6 +3929,7 @@ pub(crate) fn native_long_stream_map_to_int(
             _ => 0,
         });
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_int_stream(heap, result)))))
 }
 /// Native: `DoubleStream.of(double[])DoubleStream` — from a double[] vararg array.
@@ -3987,7 +4071,7 @@ pub(crate) fn native_double_stream_filter(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let pred_slot = extract_slot_arg(args, 1);
+    let mut pred_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(pred_ref)) = pred_slot else {
         return Ok(Some(Slot::Reference(Some(make_double_stream(
             heap,
@@ -3997,6 +4081,12 @@ pub(crate) fn native_double_stream_filter(
     let elems = double_stream_elems(heap, r);
     let pred_class = heap.get(pred_ref)?.class_name.clone();
     let mut kept = Vec::with_capacity(elems.len());
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut pred_slot);
     for v in elems {
         let result = ops.invoke(
             heap,
@@ -4010,6 +4100,7 @@ pub(crate) fn native_double_stream_filter(
             kept.push(v);
         }
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_double_stream(heap, kept)))))
 }
 /// Native: `DoubleStream.map(DoubleUnaryOperator)DoubleStream`
@@ -4021,7 +4112,7 @@ pub(crate) fn native_double_stream_map(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(Some(make_double_stream(
             heap,
@@ -4031,6 +4122,12 @@ pub(crate) fn native_double_stream_map(
     let elems = double_stream_elems(heap, r);
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let mut result = Vec::with_capacity(elems.len());
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for v in elems {
         let r = ops.invoke(
             heap,
@@ -4047,6 +4144,7 @@ pub(crate) fn native_double_stream_map(
             _ => 0.0,
         });
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_double_stream(
         heap, result,
     )))))
@@ -4166,12 +4264,18 @@ pub(crate) fn native_int_stream_any_match(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let pred_slot = extract_slot_arg(args, 1);
+    let mut pred_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(pred_ref)) = pred_slot else {
         return Ok(Some(Slot::Int(0)));
     };
     let elems = int_stream_elems(heap, r);
     let pred_class = heap.get(pred_ref)?.class_name.clone();
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut pred_slot);
     for v in elems {
         let result = ops.invoke(
             heap,
@@ -4185,6 +4289,7 @@ pub(crate) fn native_int_stream_any_match(
             return Ok(Some(Slot::Int(1)));
         }
     }
+    drop(scope);
     Ok(Some(Slot::Int(0)))
 }
 /// Native: `IntStream.allMatch(IntPredicate)Z`
@@ -4196,12 +4301,18 @@ pub(crate) fn native_int_stream_all_match(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let pred_slot = extract_slot_arg(args, 1);
+    let mut pred_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(pred_ref)) = pred_slot else {
         return Ok(Some(Slot::Int(1)));
     };
     let elems = int_stream_elems(heap, r);
     let pred_class = heap.get(pred_ref)?.class_name.clone();
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut pred_slot);
     for v in elems {
         let result = ops.invoke(
             heap,
@@ -4215,6 +4326,7 @@ pub(crate) fn native_int_stream_all_match(
             return Ok(Some(Slot::Int(0)));
         }
     }
+    drop(scope);
     Ok(Some(Slot::Int(1)))
 }
 /// Native: `IntStream.noneMatch(IntPredicate)Z`
@@ -4226,12 +4338,18 @@ pub(crate) fn native_int_stream_none_match(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let pred_slot = extract_slot_arg(args, 1);
+    let mut pred_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(pred_ref)) = pred_slot else {
         return Ok(Some(Slot::Int(1)));
     };
     let elems = int_stream_elems(heap, r);
     let pred_class = heap.get(pred_ref)?.class_name.clone();
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut pred_slot);
     for v in elems {
         let result = ops.invoke(
             heap,
@@ -4245,6 +4363,7 @@ pub(crate) fn native_int_stream_none_match(
             return Ok(Some(Slot::Int(0)));
         }
     }
+    drop(scope);
     Ok(Some(Slot::Int(1)))
 }
 /// Native: `IntStream.mapToLong(IntToLongFunction)LongStream`
@@ -4256,13 +4375,19 @@ pub(crate) fn native_int_stream_map_to_long(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(Some(make_long_stream(heap, vec![])))));
     };
     let elems = int_stream_elems(heap, r);
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let mut result = Vec::with_capacity(elems.len());
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for v in elems {
         let r = ops.invoke(
             heap,
@@ -4278,6 +4403,7 @@ pub(crate) fn native_int_stream_map_to_long(
             _ => 0,
         });
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_long_stream(heap, result)))))
 }
 /// Native: `LongStream.findFirst()OptionalLong`
@@ -4302,12 +4428,18 @@ pub(crate) fn native_long_stream_any_match(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let pred_slot = extract_slot_arg(args, 1);
+    let mut pred_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(pred_ref)) = pred_slot else {
         return Ok(Some(Slot::Int(0)));
     };
     let elems = long_stream_elems(heap, r);
     let pred_class = heap.get(pred_ref)?.class_name.clone();
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut pred_slot);
     for v in elems {
         let result = ops.invoke(
             heap,
@@ -4321,6 +4453,7 @@ pub(crate) fn native_long_stream_any_match(
             return Ok(Some(Slot::Int(1)));
         }
     }
+    drop(scope);
     Ok(Some(Slot::Int(0)))
 }
 /// Native: `LongStream.allMatch(LongPredicate)Z`
@@ -4332,12 +4465,18 @@ pub(crate) fn native_long_stream_all_match(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let pred_slot = extract_slot_arg(args, 1);
+    let mut pred_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(pred_ref)) = pred_slot else {
         return Ok(Some(Slot::Int(1)));
     };
     let elems = long_stream_elems(heap, r);
     let pred_class = heap.get(pred_ref)?.class_name.clone();
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut pred_slot);
     for v in elems {
         let result = ops.invoke(
             heap,
@@ -4351,6 +4490,7 @@ pub(crate) fn native_long_stream_all_match(
             return Ok(Some(Slot::Int(0)));
         }
     }
+    drop(scope);
     Ok(Some(Slot::Int(1)))
 }
 /// Native: `LongStream.noneMatch(LongPredicate)Z`
@@ -4362,12 +4502,18 @@ pub(crate) fn native_long_stream_none_match(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let pred_slot = extract_slot_arg(args, 1);
+    let mut pred_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(pred_ref)) = pred_slot else {
         return Ok(Some(Slot::Int(1)));
     };
     let elems = long_stream_elems(heap, r);
     let pred_class = heap.get(pred_ref)?.class_name.clone();
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut pred_slot);
     for v in elems {
         let result = ops.invoke(
             heap,
@@ -4381,6 +4527,7 @@ pub(crate) fn native_long_stream_none_match(
             return Ok(Some(Slot::Int(0)));
         }
     }
+    drop(scope);
     Ok(Some(Slot::Int(1)))
 }
 /// Native: `ComparingLongComparator.compare(O,O)I` — calls `fn.applyAsLong(o)` for each element.
@@ -4501,13 +4648,19 @@ pub(crate) fn native_int_stream_flat_map(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(Some(make_int_stream(heap, vec![])))));
     };
     let elems = int_stream_elems(heap, r);
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let mut result = Vec::with_capacity(elems.len());
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for v in elems {
         let sub = ops.invoke(
             heap,
@@ -4522,6 +4675,7 @@ pub(crate) fn native_int_stream_flat_map(
             result.extend(sub_elems);
         }
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_int_stream(heap, result)))))
 }
 /// Native: `LongStream.limit(long)LongStream` — truncate to at most n elements.
@@ -4567,13 +4721,19 @@ pub(crate) fn native_long_stream_flat_map(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(Some(make_long_stream(heap, vec![])))));
     };
     let elems = long_stream_elems(heap, r);
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let mut result = Vec::with_capacity(elems.len());
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for v in elems {
         let sub = ops.invoke(
             heap,
@@ -4588,6 +4748,7 @@ pub(crate) fn native_long_stream_flat_map(
             result.extend(sub_elems);
         }
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_long_stream(heap, result)))))
 }
 /// Native: `DoubleStream.limit(long)DoubleStream`
@@ -4665,12 +4826,18 @@ pub(crate) fn native_double_stream_for_each(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let consumer_slot = extract_slot_arg(args, 1);
+    let mut consumer_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(consumer_ref)) = consumer_slot else {
         return Ok(None);
     };
     let elems = double_stream_elems(heap, r);
     let consumer_class = heap.get(consumer_ref)?.class_name.clone();
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut consumer_slot);
     for v in elems {
         ops.invoke(
             heap,
@@ -4681,6 +4848,7 @@ pub(crate) fn native_double_stream_for_each(
             vec![consumer_slot, Slot::Double(v)],
         )?;
     }
+    drop(scope);
     Ok(None)
 }
 /// Native: `DoubleStream.anyMatch(DoublePredicate)Z`
@@ -4692,12 +4860,18 @@ pub(crate) fn native_double_stream_any_match(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let pred_slot = extract_slot_arg(args, 1);
+    let mut pred_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(pred_ref)) = pred_slot else {
         return Ok(Some(Slot::Int(0)));
     };
     let elems = double_stream_elems(heap, r);
     let pred_class = heap.get(pred_ref)?.class_name.clone();
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut pred_slot);
     for v in elems {
         let result = ops.invoke(
             heap,
@@ -4711,6 +4885,7 @@ pub(crate) fn native_double_stream_any_match(
             return Ok(Some(Slot::Int(1)));
         }
     }
+    drop(scope);
     Ok(Some(Slot::Int(0)))
 }
 /// Native: `DoubleStream.allMatch(DoublePredicate)Z`
@@ -4722,12 +4897,18 @@ pub(crate) fn native_double_stream_all_match(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let pred_slot = extract_slot_arg(args, 1);
+    let mut pred_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(pred_ref)) = pred_slot else {
         return Ok(Some(Slot::Int(1)));
     };
     let elems = double_stream_elems(heap, r);
     let pred_class = heap.get(pred_ref)?.class_name.clone();
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut pred_slot);
     for v in elems {
         let result = ops.invoke(
             heap,
@@ -4741,6 +4922,7 @@ pub(crate) fn native_double_stream_all_match(
             return Ok(Some(Slot::Int(0)));
         }
     }
+    drop(scope);
     Ok(Some(Slot::Int(1)))
 }
 /// Native: `DoubleStream.noneMatch(DoublePredicate)Z`
@@ -4752,12 +4934,18 @@ pub(crate) fn native_double_stream_none_match(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let pred_slot = extract_slot_arg(args, 1);
+    let mut pred_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(pred_ref)) = pred_slot else {
         return Ok(Some(Slot::Int(1)));
     };
     let elems = double_stream_elems(heap, r);
     let pred_class = heap.get(pred_ref)?.class_name.clone();
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut pred_slot);
     for v in elems {
         let result = ops.invoke(
             heap,
@@ -4771,6 +4959,7 @@ pub(crate) fn native_double_stream_none_match(
             return Ok(Some(Slot::Int(0)));
         }
     }
+    drop(scope);
     Ok(Some(Slot::Int(1)))
 }
 /// Native: `DoubleStream.findFirst()OptionalDouble`
@@ -4798,13 +4987,19 @@ pub(crate) fn native_double_stream_reduce_identity(
         Some(Slot::Double(d)) => d,
         _ => 0.0,
     };
-    let fn_slot = extract_slot_arg(args, 2);
+    let mut fn_slot = extract_slot_arg(args, 2);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Double(identity)));
     };
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let elems = double_stream_elems(heap, r);
     let mut acc = identity;
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for v in elems {
         let result = ops
             .invoke(
@@ -4823,6 +5018,7 @@ pub(crate) fn native_double_stream_reduce_identity(
             _ => acc,
         };
     }
+    drop(scope);
     Ok(Some(Slot::Double(acc)))
 }
 /// Native: `DoubleStream.reduce(DoubleBinaryOperator)OptionalDouble`
@@ -4834,7 +5030,7 @@ pub(crate) fn native_double_stream_reduce_optional(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         let opt_ref = make_optional_double_val(heap, None);
         return Ok(Some(Slot::Reference(Some(opt_ref))));
@@ -4847,6 +5043,12 @@ pub(crate) fn native_double_stream_reduce_optional(
         )))));
     }
     let mut acc = elems[0];
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for &v in &elems[1..] {
         let result = ops
             .invoke(
@@ -4865,6 +5067,7 @@ pub(crate) fn native_double_stream_reduce_optional(
             _ => acc,
         };
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_optional_double_val(
         heap,
         Some(acc),
@@ -4879,7 +5082,7 @@ pub(crate) fn native_double_stream_flat_map(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(Some(make_double_stream(
             heap,
@@ -4889,6 +5092,12 @@ pub(crate) fn native_double_stream_flat_map(
     let elems = double_stream_elems(heap, r);
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let mut result = Vec::with_capacity(elems.len());
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for v in elems {
         let sub = ops.invoke(
             heap,
@@ -4902,6 +5111,7 @@ pub(crate) fn native_double_stream_flat_map(
             result.extend(double_stream_elems(heap, sub_ref));
         }
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_double_stream(
         heap, result,
     )))))
@@ -4915,13 +5125,19 @@ pub(crate) fn native_double_stream_map_to_int(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(Some(make_int_stream(heap, vec![])))));
     };
     let elems = double_stream_elems(heap, r);
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let mut result = Vec::with_capacity(elems.len());
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for v in elems {
         let r = ops.invoke(
             heap,
@@ -4936,6 +5152,7 @@ pub(crate) fn native_double_stream_map_to_int(
             _ => 0,
         });
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_int_stream(heap, result)))))
 }
 /// Native: `DoubleStream.mapToLong(DoubleToLongFunction)LongStream`
@@ -4947,13 +5164,19 @@ pub(crate) fn native_double_stream_map_to_long(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(Some(make_long_stream(heap, vec![])))));
     };
     let elems = double_stream_elems(heap, r);
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let mut result = Vec::with_capacity(elems.len());
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for v in elems {
         let r = ops.invoke(
             heap,
@@ -4969,6 +5192,7 @@ pub(crate) fn native_double_stream_map_to_long(
             _ => 0,
         });
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_long_stream(heap, result)))))
 }
 /// Native: `DoubleStream.distinct()DoubleStream` — removes duplicate values.
@@ -5032,7 +5256,7 @@ pub(crate) fn native_long_stream_reduce_optional(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         let opt_ref = make_optional_long(heap, None);
         return Ok(Some(Slot::Reference(Some(opt_ref))));
@@ -5043,6 +5267,12 @@ pub(crate) fn native_long_stream_reduce_optional(
         return Ok(Some(Slot::Reference(Some(make_optional_long(heap, None)))));
     }
     let mut acc = elems[0];
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for &v in &elems[1..] {
         let result = ops
             .invoke(
@@ -5060,6 +5290,7 @@ pub(crate) fn native_long_stream_reduce_optional(
             _ => acc,
         };
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_optional_long(
         heap,
         Some(acc),
@@ -5074,7 +5305,7 @@ pub(crate) fn native_long_stream_map_to_double(
     ops: &mut dyn CallbackOps,
 ) -> Result<Option<Slot>> {
     let r = extract_ref_arg(args, 0)?;
-    let fn_slot = extract_slot_arg(args, 1);
+    let mut fn_slot = extract_slot_arg(args, 1);
     let Slot::Reference(Some(fn_ref)) = fn_slot else {
         return Ok(Some(Slot::Reference(Some(make_double_stream(
             heap,
@@ -5084,6 +5315,12 @@ pub(crate) fn native_long_stream_map_to_double(
     let elems = long_stream_elems(heap, r);
     let fn_class = heap.get(fn_ref)?.class_name.clone();
     let mut result = Vec::with_capacity(elems.len());
+    // Pin the callback receiver: it is re-passed to `ops.invoke` on every
+    // iteration, but native args live in a Copy `Vec<Slot>` the collector
+    // never scans, so a relocating GC inside the callback would otherwise
+    // leave this ref stale before the next iteration re-passes it.
+    let mut scope = NativeRootScope::new();
+    scope.pin_slot(&mut fn_slot);
     for v in elems {
         let r = ops.invoke(
             heap,
@@ -5100,6 +5337,7 @@ pub(crate) fn native_long_stream_map_to_double(
             _ => 0.0,
         });
     }
+    drop(scope);
     Ok(Some(Slot::Reference(Some(make_double_stream(
         heap, result,
     )))))

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -37025,6 +37025,782 @@ fn stream_filter_receiver_and_element_survive_two_gcs_during_callback() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Group B — `native_stream_collect` mega-dispatch.
+//
+// Each collector branch loops over the (reference-typed) element snapshot
+// calling the collector's `*_fn` lambda(s) per element, while HOLDING the
+// element snapshot, the accumulator being built (a heap map/list/StringBuilder
+// or a running `acc`/`min`/`container` ref), and the re-passed lambda receiver
+// in Rust locals across each `ops.invoke`. The real-`Collector` protocol
+// additionally chains supplier→get→accumulator→accept→finisher→apply, holding
+// the container across the whole chain, and `collectingAndThen` holds its
+// finisher across a *recursive* collect (itself a GC point). Every callback
+// below retains no garbage of its own but forces >=2 relocating collections,
+// and every element/key/value/accumulator is a distinctly-tagged heap object,
+// so a stale native-local copy is observed as a reused (-777) or wrong object.
+// ---------------------------------------------------------------------------
+
+/// Builds a synthetic `duke/util/*` collector marker object of the given class
+/// whose fields hold the supplied function/argument slots.
+fn build_collector(heap: &mut duke_gc::Heap, class: &str, fields: &[Slot]) -> u64 {
+    let c = heap.allocate(class.to_string(), fields.len().max(1));
+    for (i, f) in fields.iter().enumerate() {
+        heap.get_mut(c).unwrap().fields[i] = *f;
+    }
+    c
+}
+
+/// Group B — `Collectors.toMap(keyFn, valFn)`. The accumulator HashMap ref, the
+/// element snapshot, both function receivers, and the intermediate key result
+/// (held across the value callback) are all held in native Rust locals across
+/// the per-element `apply` callbacks. Distinct-tagged key/value objects are
+/// produced inside each callback; the assembled map must have every key and
+/// value intact.
+#[test]
+fn collect_to_map_accumulator_keys_and_values_survive_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const KEY_FN_TAG: i32 = 7001;
+    const VAL_FN_TAG: i32 = 7002;
+    const ELEM_TAGS: [i32; 3] = [100, 101, 102];
+
+    struct CollectGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        observed_receiver_tags: Vec<i32>,
+        observed_elem_tags: Vec<i32>,
+    }
+
+    impl CallbackOps for CollectGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            // args[0] = key or value function receiver, args[1] = the element.
+            let recv_tag = stream_gc_tag(heap, args.first());
+            let elem_tag = stream_gc_tag(heap, args.get(1));
+            self.observed_receiver_tags.push(recv_tag);
+            self.observed_elem_tags.push(elem_tag);
+            // Key call produces an object tagged `elem`; value call one tagged
+            // `elem + 1000`. Each must survive its own callback's GCs and (for
+            // the key) the following value callback's GCs.
+            let out_tag = if recv_tag == VAL_FN_TAG {
+                elem_tag + 1000
+            } else {
+                elem_tag
+            };
+            let res = heap.allocate("duke/test/MapEntryPart".to_string(), 1);
+            heap.get_mut(res).unwrap().fields[0] = Slot::Int(out_tag);
+            let forwarded = stream_gc_two_collections(
+                heap,
+                &mut self.caller_frame,
+                &mut self.registry,
+                &mut self.string_intern,
+                Some(res),
+            );
+            Ok(Some(Slot::Reference(forwarded)))
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let stream_ref = build_tagged_object_stream(&mut heap, &ELEM_TAGS);
+    let key_fn = heap.allocate("duke/test/KeyFn".to_string(), 1);
+    heap.get_mut(key_fn).unwrap().fields[0] = Slot::Int(KEY_FN_TAG);
+    let val_fn = heap.allocate("duke/test/ValFn".to_string(), 1);
+    heap.get_mut(val_fn).unwrap().fields[0] = Slot::Int(VAL_FN_TAG);
+    let collector_ref = build_collector(
+        &mut heap,
+        "duke/util/ToMapCollector",
+        &[Slot::Reference(Some(key_fn)), Slot::Reference(Some(val_fn))],
+    );
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(collector_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = CollectGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        observed_receiver_tags: Vec::new(),
+        observed_elem_tags: Vec::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_stream_collect(
+        &[
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(collector_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    assert_eq!(
+        ops.observed_receiver_tags,
+        vec![
+            KEY_FN_TAG, VAL_FN_TAG, KEY_FN_TAG, VAL_FN_TAG, KEY_FN_TAG, VAL_FN_TAG
+        ],
+        "toMap key/value function receivers went stale across a callback's GCs"
+    );
+    assert_eq!(
+        ops.observed_elem_tags,
+        vec![100, 100, 101, 101, 102, 102],
+        "toMap element snapshot went stale across a callback's GCs; a key/value \
+         function was handed a dangling/reused element"
+    );
+
+    let Some(Slot::Reference(Some(map_ref))) = result else {
+        panic!("toMap did not return a map");
+    };
+    let map_fields = heap.get(map_ref).unwrap().fields.clone();
+    let count = match map_fields.first() {
+        Some(Slot::Int(n)) => *n,
+        _ => -1,
+    };
+    let mut keys: Vec<i32> = Vec::new();
+    let mut vals: Vec<i32> = Vec::new();
+    for i in 0..count.max(0) as usize {
+        keys.push(stream_gc_tag(&heap, map_fields.get(1 + i * 2)));
+        vals.push(stream_gc_tag(&heap, map_fields.get(2 + i * 2)));
+    }
+    assert_eq!(
+        count, 3,
+        "toMap accumulator map lost entries across the GCs"
+    );
+    assert_eq!(
+        keys,
+        vec![100, 101, 102],
+        "toMap accumulator map keys went stale across later callbacks; the \
+         accumulator (map) reference was not tracked across a relocating GC"
+    );
+    assert_eq!(
+        vals,
+        vec![1100, 1101, 1102],
+        "toMap accumulator map values went stale across later callbacks"
+    );
+}
+
+/// Group B — `Collectors.groupingBy(keyFn)`. Exercises the key-function
+/// receiver, the accumulator HashMap ref, and — the element-snapshot pin — the
+/// element pushed into each bucket AFTER its key callback. A distinct key is
+/// produced per element so every element lands in its own single-element list.
+#[test]
+fn collect_grouping_by_elements_and_map_survive_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const KEY_FN_TAG: i32 = 8001;
+    const ELEM_TAGS: [i32; 3] = [100, 101, 102];
+
+    struct CollectGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        observed_receiver_tags: Vec<i32>,
+        observed_elem_tags: Vec<i32>,
+    }
+
+    impl CallbackOps for CollectGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            self.observed_receiver_tags
+                .push(stream_gc_tag(heap, args.first()));
+            let elem_tag = stream_gc_tag(heap, args.get(1));
+            self.observed_elem_tags.push(elem_tag);
+            // Distinct key per element (tag + 500) so each gets its own bucket.
+            let key = heap.allocate("duke/test/GroupKey".to_string(), 1);
+            heap.get_mut(key).unwrap().fields[0] = Slot::Int(elem_tag + 500);
+            let forwarded = stream_gc_two_collections(
+                heap,
+                &mut self.caller_frame,
+                &mut self.registry,
+                &mut self.string_intern,
+                Some(key),
+            );
+            Ok(Some(Slot::Reference(forwarded)))
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let stream_ref = build_tagged_object_stream(&mut heap, &ELEM_TAGS);
+    let key_fn = heap.allocate("duke/test/KeyFn".to_string(), 1);
+    heap.get_mut(key_fn).unwrap().fields[0] = Slot::Int(KEY_FN_TAG);
+    let collector_ref = build_collector(
+        &mut heap,
+        "duke/util/GroupingByCollector",
+        &[Slot::Reference(Some(key_fn))],
+    );
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(collector_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = CollectGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        observed_receiver_tags: Vec::new(),
+        observed_elem_tags: Vec::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_stream_collect(
+        &[
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(collector_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    assert_eq!(
+        ops.observed_receiver_tags,
+        vec![KEY_FN_TAG; ELEM_TAGS.len()],
+        "groupingBy key-function receiver went stale across a callback's GCs"
+    );
+    assert_eq!(
+        ops.observed_elem_tags,
+        ELEM_TAGS.to_vec(),
+        "groupingBy element snapshot went stale across a callback's GCs"
+    );
+
+    let Some(Slot::Reference(Some(map_ref))) = result else {
+        panic!("groupingBy did not return a map");
+    };
+    let map_fields = heap.get(map_ref).unwrap().fields.clone();
+    let count = match map_fields.first() {
+        Some(Slot::Int(n)) => *n,
+        _ => -1,
+    };
+    assert_eq!(
+        count, 3,
+        "groupingBy accumulator map lost buckets across the GCs"
+    );
+    let mut key_tags: Vec<i32> = Vec::new();
+    let mut grouped_elem_tags: Vec<i32> = Vec::new();
+    for i in 0..count.max(0) as usize {
+        key_tags.push(stream_gc_tag(&heap, map_fields.get(1 + i * 2)));
+        // Each bucket is a one-element ArrayList: [count=1, elem].
+        if let Some(Slot::Reference(Some(list_ref))) = map_fields.get(2 + i * 2) {
+            let list_fields = heap.get(*list_ref).unwrap().fields.clone();
+            grouped_elem_tags.push(stream_gc_tag(&heap, list_fields.get(1)));
+        } else {
+            grouped_elem_tags.push(i32::MIN);
+        }
+    }
+    assert_eq!(
+        key_tags,
+        vec![600, 601, 602],
+        "groupingBy accumulator map keys went stale across later callbacks"
+    );
+    assert_eq!(
+        grouped_elem_tags,
+        vec![100, 101, 102],
+        "groupingBy grouped element went stale across a callback's GCs; the \
+         element pushed into its bucket was a dangling/reused reference"
+    );
+}
+
+/// Group B — `Collectors.reducing(identity, op)`. The running accumulator ref is
+/// carried across, and re-passed to, every fold callback, alongside the operator
+/// receiver and the element snapshot. The fold chains identity(0) with elements
+/// [10,20,30] via `op(acc, elem) = acc + elem`, so the accumulator advances
+/// 0 -> 10 -> 30 -> 60.
+#[test]
+fn collect_reducing_accumulator_survives_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const OP_TAG: i32 = 9001;
+    const IDENTITY_TAG: i32 = 0;
+    const ELEM_TAGS: [i32; 3] = [10, 20, 30];
+
+    struct CollectGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        observed_receiver_tags: Vec<i32>,
+        observed_acc_tags: Vec<i32>,
+        observed_elem_tags: Vec<i32>,
+    }
+
+    impl CallbackOps for CollectGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            // args[0] = operator receiver, args[1] = running acc, args[2] = elem.
+            self.observed_receiver_tags
+                .push(stream_gc_tag(heap, args.first()));
+            let acc_tag = stream_gc_tag(heap, args.get(1));
+            let elem_tag = stream_gc_tag(heap, args.get(2));
+            self.observed_acc_tags.push(acc_tag);
+            self.observed_elem_tags.push(elem_tag);
+            let res = heap.allocate("duke/test/Acc".to_string(), 1);
+            heap.get_mut(res).unwrap().fields[0] = Slot::Int(acc_tag + elem_tag);
+            let forwarded = stream_gc_two_collections(
+                heap,
+                &mut self.caller_frame,
+                &mut self.registry,
+                &mut self.string_intern,
+                Some(res),
+            );
+            Ok(Some(Slot::Reference(forwarded)))
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let stream_ref = build_tagged_object_stream(&mut heap, &ELEM_TAGS);
+    let identity = heap.allocate("duke/test/Identity".to_string(), 1);
+    heap.get_mut(identity).unwrap().fields[0] = Slot::Int(IDENTITY_TAG);
+    let op_fn = heap.allocate("duke/test/BinOp".to_string(), 1);
+    heap.get_mut(op_fn).unwrap().fields[0] = Slot::Int(OP_TAG);
+    let collector_ref = build_collector(
+        &mut heap,
+        "duke/util/ReducingCollector",
+        &[
+            Slot::Reference(Some(identity)),
+            Slot::Reference(Some(op_fn)),
+        ],
+    );
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(collector_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = CollectGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        observed_receiver_tags: Vec::new(),
+        observed_acc_tags: Vec::new(),
+        observed_elem_tags: Vec::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_stream_collect(
+        &[
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(collector_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    assert_eq!(
+        ops.observed_receiver_tags,
+        vec![OP_TAG; ELEM_TAGS.len()],
+        "reducing operator receiver went stale across a callback's GCs"
+    );
+    assert_eq!(
+        ops.observed_acc_tags,
+        vec![0, 10, 30],
+        "reducing running accumulator went stale across a callback's GCs; the \
+         fold was re-entered with a dangling/reused accumulator reference"
+    );
+    assert_eq!(
+        ops.observed_elem_tags,
+        ELEM_TAGS.to_vec(),
+        "reducing element snapshot went stale across a callback's GCs"
+    );
+
+    assert_eq!(
+        stream_gc_tag(&heap, result.as_ref()),
+        60,
+        "reducing final accumulator went stale across the fold's GCs"
+    );
+}
+
+/// Group B — a real (non-`duke/util/*`) `java.util.stream.Collector`. Drives the
+/// full supplier -> get -> accumulator -> accept* -> finisher -> apply protocol.
+/// The collector receiver (re-passed to supplier/accumulator/finisher) and the
+/// result container (produced by get, fed to every accept and to the final
+/// apply) are held in native Rust locals across the whole chain of callbacks,
+/// each of which forces two relocating GCs. The container accumulates the sum of
+/// element tags; the finisher reads it back.
+#[test]
+fn collect_real_collector_chain_container_survives_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const COLLECTOR_TAG: i32 = 4100;
+    const ELEM_TAGS: [i32; 3] = [10, 20, 30];
+
+    struct CollectGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        container_ref: u64,
+        observed_protocol_receiver_tags: Vec<i32>,
+        observed_accept_elem_tags: Vec<i32>,
+    }
+
+    impl CallbackOps for CollectGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            match method {
+                // supplier()/accumulator()/finisher() return a FRESH function
+                // object allocated at call time (no GC follows before the native
+                // reads its class), so the mock never hands back a stale id. The
+                // receiver each is invoked on is the collector itself (args[0]);
+                // recording its tag verifies the pinned collector slot.
+                "supplier" => {
+                    self.observed_protocol_receiver_tags
+                        .push(stream_gc_tag(heap, args.first()));
+                    Ok(Some(Slot::Reference(Some(
+                        heap.allocate("com/example/Supplier".to_string(), 1),
+                    ))))
+                }
+                "get" => Ok(Some(Slot::Reference(Some(self.container_ref)))),
+                "accumulator" => {
+                    self.observed_protocol_receiver_tags
+                        .push(stream_gc_tag(heap, args.first()));
+                    Ok(Some(Slot::Reference(Some(
+                        heap.allocate("com/example/Accumulator".to_string(), 1),
+                    ))))
+                }
+                "accept" => {
+                    // args[0] = accumulator, args[1] = container, args[2] = elem.
+                    let container = match args.get(1) {
+                        Some(Slot::Reference(Some(r))) => *r,
+                        _ => panic!("accept container was not a live reference"),
+                    };
+                    let elem_tag = stream_gc_tag(heap, args.get(2));
+                    self.observed_accept_elem_tags.push(elem_tag);
+                    let cur = match heap.get(container).unwrap().fields.first() {
+                        Some(Slot::Int(n)) => *n,
+                        _ => 0,
+                    };
+                    heap.get_mut(container).unwrap().fields[0] = Slot::Int(cur + elem_tag);
+                    stream_gc_two_collections(
+                        heap,
+                        &mut self.caller_frame,
+                        &mut self.registry,
+                        &mut self.string_intern,
+                        None,
+                    );
+                    Ok(None)
+                }
+                "finisher" => {
+                    self.observed_protocol_receiver_tags
+                        .push(stream_gc_tag(heap, args.first()));
+                    Ok(Some(Slot::Reference(Some(
+                        heap.allocate("com/example/Finisher".to_string(), 1),
+                    ))))
+                }
+                "apply" => {
+                    // finisher.apply(container): read the accumulated sum back.
+                    let container = match args.get(1) {
+                        Some(Slot::Reference(Some(r))) => *r,
+                        _ => panic!("finisher container was not a live reference"),
+                    };
+                    let sum = match heap.get(container).unwrap().fields.first() {
+                        Some(Slot::Int(n)) => *n,
+                        _ => -1,
+                    };
+                    let res = heap.allocate("duke/test/Result".to_string(), 1);
+                    heap.get_mut(res).unwrap().fields[0] = Slot::Int(sum);
+                    let forwarded = stream_gc_two_collections(
+                        heap,
+                        &mut self.caller_frame,
+                        &mut self.registry,
+                        &mut self.string_intern,
+                        Some(res),
+                    );
+                    Ok(Some(Slot::Reference(forwarded)))
+                }
+                other => panic!("unexpected collector protocol method {other}"),
+            }
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let stream_ref = build_tagged_object_stream(&mut heap, &ELEM_TAGS);
+    let collector_ref = heap.allocate("com/example/SummingCollector".to_string(), 1);
+    heap.get_mut(collector_ref).unwrap().fields[0] = Slot::Int(COLLECTOR_TAG);
+    let container_ref = heap.allocate("com/example/Container".to_string(), 1);
+    heap.get_mut(container_ref).unwrap().fields[0] = Slot::Int(0);
+
+    // Root the stream, collector and container via the caller frame so the
+    // collector's own callbacks relocate them (mirroring live objects) while the
+    // native holds its private, pinned copies.
+    let caller_frame = duke_runtime::Frame::new(
+        16,
+        8,
+        vec![
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(collector_ref)),
+            Slot::Reference(Some(container_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = CollectGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        container_ref,
+        observed_protocol_receiver_tags: Vec::new(),
+        observed_accept_elem_tags: Vec::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_stream_collect(
+        &[
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(collector_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    assert_eq!(
+        ops.observed_protocol_receiver_tags,
+        vec![COLLECTOR_TAG, COLLECTOR_TAG, COLLECTOR_TAG],
+        "real Collector receiver went stale across the protocol's callbacks; \
+         supplier()/accumulator()/finisher() saw a dangling/reused collector"
+    );
+    assert_eq!(
+        ops.observed_accept_elem_tags,
+        ELEM_TAGS.to_vec(),
+        "real Collector accept element snapshot went stale across the GCs"
+    );
+    assert_eq!(
+        stream_gc_tag(&heap, result.as_ref()),
+        60,
+        "real Collector container went stale across the accept/finisher \
+         callbacks; the finisher read the sum from a dangling/reused container"
+    );
+}
+
+/// Group B — `Collectors.collectingAndThen(downstream, finisher)`. The finisher
+/// lambda is held in a native Rust local across the RECURSIVE downstream
+/// `native_stream_collect` — itself a GC point, because the downstream
+/// (`groupingBy` here) runs its own per-element callbacks that force relocating
+/// collections. Without pinning the finisher slot, the finisher `apply` after
+/// the recursive collect is handed a dangling/reused receiver.
+#[test]
+fn collect_collecting_and_then_finisher_survives_two_gcs_during_recursive_collect() {
+    use std::collections::HashMap;
+
+    const KEY_FN_TAG: i32 = 6001;
+    const FINISHER_TAG: i32 = 6002;
+    const RESULT_TAG: i32 = 12321;
+    const ELEM_TAGS: [i32; 3] = [100, 101, 102];
+
+    struct CollectGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        observed_finisher_receiver_tag: Option<i32>,
+    }
+
+    impl CallbackOps for CollectGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            let recv_tag = stream_gc_tag(heap, args.first());
+            if recv_tag == FINISHER_TAG {
+                // The finisher callback, run AFTER the recursive downstream
+                // collect. Record the receiver tag it was invoked with — a stale
+                // finisher slot shows up here as a reused/wrong tag.
+                self.observed_finisher_receiver_tag = Some(recv_tag);
+                let res = heap.allocate("duke/test/Result".to_string(), 1);
+                heap.get_mut(res).unwrap().fields[0] = Slot::Int(RESULT_TAG);
+                let forwarded = stream_gc_two_collections(
+                    heap,
+                    &mut self.caller_frame,
+                    &mut self.registry,
+                    &mut self.string_intern,
+                    Some(res),
+                );
+                return Ok(Some(Slot::Reference(forwarded)));
+            }
+            // The downstream groupingBy key function: force GCs so the finisher
+            // slot the outer native holds is exercised across a relocating GC.
+            let elem_tag = stream_gc_tag(heap, args.get(1));
+            let key = heap.allocate("duke/test/GroupKey".to_string(), 1);
+            heap.get_mut(key).unwrap().fields[0] = Slot::Int(elem_tag);
+            let forwarded = stream_gc_two_collections(
+                heap,
+                &mut self.caller_frame,
+                &mut self.registry,
+                &mut self.string_intern,
+                Some(key),
+            );
+            Ok(Some(Slot::Reference(forwarded)))
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let stream_ref = build_tagged_object_stream(&mut heap, &ELEM_TAGS);
+    let key_fn = heap.allocate("duke/test/KeyFn".to_string(), 1);
+    heap.get_mut(key_fn).unwrap().fields[0] = Slot::Int(KEY_FN_TAG);
+    let downstream = build_collector(
+        &mut heap,
+        "duke/util/GroupingByCollector",
+        &[Slot::Reference(Some(key_fn))],
+    );
+    let finisher = heap.allocate("duke/test/Finisher".to_string(), 1);
+    heap.get_mut(finisher).unwrap().fields[0] = Slot::Int(FINISHER_TAG);
+    let collector_ref = build_collector(
+        &mut heap,
+        "duke/util/CollectingAndThenCollector",
+        &[
+            Slot::Reference(Some(downstream)),
+            Slot::Reference(Some(finisher)),
+        ],
+    );
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(collector_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = CollectGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        observed_finisher_receiver_tag: None,
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_stream_collect(
+        &[
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(collector_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    assert_eq!(
+        ops.observed_finisher_receiver_tag,
+        Some(FINISHER_TAG),
+        "collectingAndThen finisher receiver went stale across the recursive \
+         downstream collect's GCs; the finisher slot was not pinned across the \
+         recursive collect GC point"
+    );
+    assert_eq!(
+        stream_gc_tag(&heap, result.as_ref()),
+        RESULT_TAG,
+        "collectingAndThen finisher result went stale across the GCs"
+    );
+}
+
 /// Family 5a (Class.newInstance). `native_class_new_instance` allocates the
 /// instance, then holds its bare reference across the `<init>` constructor
 /// callback and returns it. A nested constructor can allocate heavily and trigger

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -38425,6 +38425,225 @@ fn collect_real_collector_chain_container_survives_two_gcs_during_callback() {
     );
 }
 
+/// Group A — real (non-`duke/util/*`) `Collector`, ELEMENT SNAPSHOT survival
+/// across the PRE-LOOP callbacks. The third-party-Collector branch acquires its
+/// element snapshot before driving `supplier()` → `get()` → `accumulator()`, and
+/// only THEN walks the snapshot feeding each element to `accept`. Those three
+/// pre-loop callbacks are relocating GC points the element refs must survive, so
+/// the snapshot must be pinned BEFORE `supplier()`, not after `accumulator()`.
+///
+/// This test forces a relocating GC inside each of `supplier`, `get` and
+/// `accumulator` — the points a late pin (after `accumulator()`) fails to cover
+/// — then asserts every element handed to `accept` still carries its original
+/// tag. With the pin placed after `accumulator()` the snapshot is relocated
+/// while unpinned and the `accept` loop is fed stale/reused element refs, so this
+/// test goes red; with the pin hoisted ahead of `supplier()` it stays green.
+/// (The sibling `..._container_survives_..` test only forces GC in `accept`/
+/// `apply`, i.e. AFTER the snapshot pin, so it cannot catch this ordering bug.)
+#[test]
+#[allow(clippy::too_many_lines)]
+fn collect_real_collector_element_snapshot_survives_two_gcs_before_accept_loop() {
+    use std::collections::HashMap;
+
+    const COLLECTOR_TAG: i32 = 4200;
+    const ELEM_TAGS: [i32; 3] = [11, 22, 33];
+
+    struct CollectPreLoopGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        container_ref: u64,
+        observed_protocol_receiver_tags: Vec<i32>,
+        observed_accept_elem_tags: Vec<i32>,
+    }
+
+    impl CallbackOps for CollectPreLoopGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            match method {
+                // supplier(): receiver is the collector (args[0]); force a GC
+                // BEFORE the per-element accept loop, then return a fresh Supplier
+                // allocated post-GC so its own id is never stale.
+                "supplier" => {
+                    self.observed_protocol_receiver_tags
+                        .push(stream_gc_tag(heap, args.first()));
+                    stream_gc_two_collections(
+                        heap,
+                        &mut self.caller_frame,
+                        &mut self.registry,
+                        &mut self.string_intern,
+                        None,
+                    );
+                    Ok(Some(Slot::Reference(Some(
+                        heap.allocate("com/example/Supplier".to_string(), 1),
+                    ))))
+                }
+                // get(): a real supplier().get() allocates a fresh container.
+                // Force the pre-loop GC FIRST, then allocate the container
+                // post-GC so its id is current; the native pins it immediately on
+                // return, so it survives the later accumulator() GC.
+                "get" => {
+                    stream_gc_two_collections(
+                        heap,
+                        &mut self.caller_frame,
+                        &mut self.registry,
+                        &mut self.string_intern,
+                        None,
+                    );
+                    let c = heap.allocate("com/example/Container".to_string(), 1);
+                    heap.get_mut(c).unwrap().fields[0] = Slot::Int(0);
+                    self.container_ref = c;
+                    Ok(Some(Slot::Reference(Some(c))))
+                }
+                // accumulator(): last pre-loop callback; force a GC, then return a
+                // fresh BiConsumer allocated post-GC.
+                "accumulator" => {
+                    self.observed_protocol_receiver_tags
+                        .push(stream_gc_tag(heap, args.first()));
+                    stream_gc_two_collections(
+                        heap,
+                        &mut self.caller_frame,
+                        &mut self.registry,
+                        &mut self.string_intern,
+                        None,
+                    );
+                    Ok(Some(Slot::Reference(Some(
+                        heap.allocate("com/example/Accumulator".to_string(), 1),
+                    ))))
+                }
+                "accept" => {
+                    // args[0] = accumulator, args[1] = container, args[2] = elem.
+                    // Record the tag of every element fed into the loop and fold
+                    // it into the container. No GC here — the whole point is that
+                    // the STALENESS must have already happened in the pre-loop
+                    // callbacks above if the snapshot was pinned too late.
+                    let container = match args.get(1) {
+                        Some(Slot::Reference(Some(r))) => *r,
+                        _ => panic!("accept container was not a live reference"),
+                    };
+                    let elem_tag = stream_gc_tag(heap, args.get(2));
+                    self.observed_accept_elem_tags.push(elem_tag);
+                    let cur = match heap.get(container).unwrap().fields.first() {
+                        Some(Slot::Int(n)) => *n,
+                        _ => 0,
+                    };
+                    // `wrapping_add`: a stale element ref reads back as `i32::MIN`
+                    // (see `stream_gc_tag`), which would overflow a plain `+` and
+                    // mask the failure as an arithmetic panic. Wrap so the loop
+                    // completes and the element-tag assertion reports the staleness.
+                    heap.get_mut(container).unwrap().fields[0] =
+                        Slot::Int(cur.wrapping_add(elem_tag));
+                    Ok(None)
+                }
+                "finisher" => {
+                    self.observed_protocol_receiver_tags
+                        .push(stream_gc_tag(heap, args.first()));
+                    Ok(Some(Slot::Reference(Some(
+                        heap.allocate("com/example/Finisher".to_string(), 1),
+                    ))))
+                }
+                "apply" => {
+                    // finisher.apply(container): read the accumulated sum back.
+                    let container = match args.get(1) {
+                        Some(Slot::Reference(Some(r))) => *r,
+                        _ => panic!("finisher container was not a live reference"),
+                    };
+                    let sum = match heap.get(container).unwrap().fields.first() {
+                        Some(Slot::Int(n)) => *n,
+                        _ => -1,
+                    };
+                    let res = heap.allocate("duke/test/Result".to_string(), 1);
+                    heap.get_mut(res).unwrap().fields[0] = Slot::Int(sum);
+                    Ok(Some(Slot::Reference(Some(res))))
+                }
+                other => panic!("unexpected collector protocol method {other}"),
+            }
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let stream_ref = build_tagged_object_stream(&mut heap, &ELEM_TAGS);
+    let collector_ref = heap.allocate("com/example/SummingCollector".to_string(), 1);
+    heap.get_mut(collector_ref).unwrap().fields[0] = Slot::Int(COLLECTOR_TAG);
+
+    // Root the stream and collector via the caller frame so the pre-loop
+    // callbacks relocate them (mirroring live objects) while the native holds its
+    // private, pinned snapshot copy. The stream's fields hold the live element
+    // objects, so they are relocated (not reclaimed) by each GC — meaning an
+    // unpinned native snapshot goes STALE (dangling into reused slots) rather
+    // than merely dangling into freed space. The container is allocated by get().
+    let caller_frame = duke_runtime::Frame::new(
+        16,
+        8,
+        vec![
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(collector_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = CollectPreLoopGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        container_ref: 0,
+        observed_protocol_receiver_tags: Vec::new(),
+        observed_accept_elem_tags: Vec::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_stream_collect(
+        &[
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(collector_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    // The load-bearing assertion: every element handed to `accept` still carries
+    // its original tag, in order. A snapshot pinned after `accumulator()` would
+    // have been relocated by the supplier/get/accumulator GCs and the loop would
+    // observe stale/reused tags here.
+    assert_eq!(
+        ops.observed_accept_elem_tags,
+        ELEM_TAGS.to_vec(),
+        "real Collector element snapshot went stale across the supplier()/get()/\
+         accumulator() GCs that precede the accept loop; the loop fed accept \
+         dangling/reused element references (element pin placed too late)"
+    );
+    assert_eq!(
+        ops.observed_protocol_receiver_tags,
+        vec![COLLECTOR_TAG, COLLECTOR_TAG, COLLECTOR_TAG],
+        "real Collector receiver went stale across the protocol's callbacks"
+    );
+    assert_eq!(
+        stream_gc_tag(&heap, result.as_ref()),
+        ELEM_TAGS.iter().sum::<i32>(),
+        "real Collector finisher read the wrong sum; the accept loop accumulated \
+         stale element tags into the container"
+    );
+}
+
 /// Group B — `Collectors.collectingAndThen(downstream, finisher)`. The finisher
 /// lambda is held in a native Rust local across the RECURSIVE downstream
 /// `native_stream_collect` — itself a GC point, because the downstream

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -36473,6 +36473,558 @@ fn double_stream_for_each_receiver_survives_two_gcs_during_callback() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Group A — object-stream callback natives.
+//
+// Object streams hold heap references (never primitives) as their elements, so
+// each per-element callback re-passes the RECEIVER lambda ref AND a locally
+// snapshotted ELEMENT ref, and map/reduce/flatMap additionally hold produced
+// RESULT/ACCUMULATOR refs across later callbacks. The live originals are rooted
+// by the caller frame (via the stream object) and are relocated by every
+// collection, so the native's private Rust-local copies go stale unless pinned.
+// Each callback below retains no garbage of its own but forces >=2 relocating
+// collections mid-iteration, and every element/result is a distinctly-tagged
+// heap object so a stale copy is observed as a reused (-777) or wrong object.
+// ---------------------------------------------------------------------------
+
+/// Reads the int tag stored in `fields[0]` of the object a slot references, or
+/// `i32::MIN` if the slot is not a live reference (i.e. it went stale).
+fn stream_gc_tag(heap: &duke_gc::Heap, slot: Option<&Slot>) -> i32 {
+    match slot {
+        Some(Slot::Reference(Some(r))) => heap
+            .get(*r)
+            .ok()
+            .and_then(|o| match o.fields.first() {
+                Some(Slot::Int(n)) => Some(*n),
+                _ => None,
+            })
+            .unwrap_or(i32::MIN),
+        _ => i32::MIN,
+    }
+}
+
+/// Fire two relocating collections, filling the young gen with `-777` garbage in
+/// between so freed slots are reused. `extra` is rooted alongside the frame (it
+/// simulates the callback's in-flight return value living on the callee's
+/// operand stack) and its forwarded address is returned.
+fn stream_gc_two_collections(
+    heap: &mut duke_gc::Heap,
+    caller_frame: &mut duke_runtime::Frame,
+    registry: &mut ClassRegistry,
+    string_intern: &mut std::collections::HashMap<(u8, String), u64>,
+    mut extra: Option<u64>,
+) -> Option<u64> {
+    for _ in 0..2 {
+        for _ in 0..4 {
+            let g = heap.allocate("duke/test/Garbage".to_string(), 1);
+            if let Ok(o) = heap.get_mut(g) {
+                o.fields[0] = Slot::Int(-777);
+            }
+        }
+        let mut roots = gather_roots(caller_frame, &[], registry, string_intern);
+        if let Some(e) = extra {
+            roots.push(Slot::Reference(Some(e)));
+        }
+        heap.collect(&roots);
+        patch_forwarded_slots(caller_frame, &mut [], registry, heap, string_intern);
+        if let Some(e) = extra {
+            let mut s = Slot::Reference(Some(e));
+            heap.apply_forward(&mut s);
+            extra = s.as_reference();
+        }
+    }
+    extra
+}
+
+/// Builds a `duke/util/Stream` whose elements are freshly-allocated objects each
+/// tagged with a distinct int in `fields[0]`. Returns the stream ref.
+fn build_tagged_object_stream(heap: &mut duke_gc::Heap, tags: &[i32]) -> u64 {
+    let stream_ref = heap.allocate("duke/util/Stream".to_string(), 1);
+    heap.get_mut(stream_ref).unwrap().fields[0] = Slot::Int(tags.len() as i32);
+    for &t in tags {
+        let e = heap.allocate("duke/test/Elem".to_string(), 1);
+        heap.get_mut(e).unwrap().fields[0] = Slot::Int(t);
+        heap.get_mut(stream_ref)
+            .unwrap()
+            .fields
+            .push(Slot::Reference(Some(e)));
+    }
+    stream_ref
+}
+
+/// Group A — `Stream.forEach`. The consumer holds both the re-passed receiver
+/// and a per-element ELEMENT reference across the callback; without the pins a
+/// later `accept` receives a stale receiver and/or a stale element.
+#[test]
+fn stream_for_each_receiver_and_element_survive_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const RECEIVER_TAG: i32 = 4242;
+    const ELEM_TAGS: [i32; 3] = [100, 101, 102];
+
+    struct StreamGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        observed_receiver_tags: Vec<i32>,
+        observed_elem_tags: Vec<i32>,
+    }
+
+    impl CallbackOps for StreamGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            // args[0] = consumer receiver, args[1] = the ELEMENT reference.
+            self.observed_receiver_tags
+                .push(stream_gc_tag(heap, args.first()));
+            self.observed_elem_tags
+                .push(stream_gc_tag(heap, args.get(1)));
+            stream_gc_two_collections(
+                heap,
+                &mut self.caller_frame,
+                &mut self.registry,
+                &mut self.string_intern,
+                None,
+            );
+            Ok(None)
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let stream_ref = build_tagged_object_stream(&mut heap, &ELEM_TAGS);
+    let consumer_ref = heap.allocate("duke/test/Consumer".to_string(), 1);
+    heap.get_mut(consumer_ref).unwrap().fields[0] = Slot::Int(RECEIVER_TAG);
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(consumer_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = StreamGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        observed_receiver_tags: Vec::new(),
+        observed_elem_tags: Vec::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    native_stream_for_each(
+        &[
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(consumer_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    assert_eq!(
+        ops.observed_receiver_tags,
+        vec![RECEIVER_TAG; ELEM_TAGS.len()],
+        "Stream.forEach consumer receiver went stale across a callback's GCs"
+    );
+    assert_eq!(
+        ops.observed_elem_tags,
+        ELEM_TAGS.to_vec(),
+        "Stream.forEach element snapshot went stale across a callback's GCs; a \
+         later `accept` was handed a dangling/reused element reference"
+    );
+}
+
+/// Group A — `Stream.map`. Beyond the receiver + element, the mapper's produced
+/// RESULT refs accumulate in the native's `mapped` buffer and are held across
+/// every later callback; without pinning that buffer the produced results are
+/// reclaimed and the output stream is built from stale references.
+#[test]
+fn stream_map_receiver_element_and_result_survive_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const RECEIVER_TAG: i32 = 7777;
+    const ELEM_TAGS: [i32; 3] = [100, 101, 102];
+
+    struct StreamGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        observed_receiver_tags: Vec<i32>,
+        observed_elem_tags: Vec<i32>,
+    }
+
+    impl CallbackOps for StreamGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            self.observed_receiver_tags
+                .push(stream_gc_tag(heap, args.first()));
+            let elem_tag = stream_gc_tag(heap, args.get(1));
+            self.observed_elem_tags.push(elem_tag);
+            // Produce a fresh mapped result tagged elem_tag + 1000. It must
+            // survive this callback's own GCs (rooted as the in-flight return
+            // value) and, once stored in the native's `mapped` buffer, survive
+            // every later callback (that survival is what the `mapped` pin buys).
+            let res = heap.allocate("duke/test/Mapped".to_string(), 1);
+            heap.get_mut(res).unwrap().fields[0] = Slot::Int(elem_tag + 1000);
+            let forwarded = stream_gc_two_collections(
+                heap,
+                &mut self.caller_frame,
+                &mut self.registry,
+                &mut self.string_intern,
+                Some(res),
+            );
+            Ok(Some(Slot::Reference(forwarded)))
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let stream_ref = build_tagged_object_stream(&mut heap, &ELEM_TAGS);
+    let fn_ref = heap.allocate("duke/test/Function".to_string(), 1);
+    heap.get_mut(fn_ref).unwrap().fields[0] = Slot::Int(RECEIVER_TAG);
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(fn_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = StreamGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        observed_receiver_tags: Vec::new(),
+        observed_elem_tags: Vec::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_stream_map(
+        &[
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(fn_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    assert_eq!(
+        ops.observed_receiver_tags,
+        vec![RECEIVER_TAG; ELEM_TAGS.len()],
+        "Stream.map mapper receiver went stale across a callback's GCs"
+    );
+    assert_eq!(
+        ops.observed_elem_tags,
+        ELEM_TAGS.to_vec(),
+        "Stream.map element snapshot went stale across a callback's GCs"
+    );
+
+    // The returned stream's elements must be the produced results, each still
+    // carrying its `elem + 1000` tag — i.e. the accumulated result buffer did
+    // not go stale across later callbacks.
+    let Some(Slot::Reference(Some(out_stream))) = result else {
+        panic!("Stream.map did not return a stream");
+    };
+    let out_obj = heap.get(out_stream).unwrap();
+    let out_tags: Vec<i32> = out_obj.fields[1..]
+        .iter()
+        .map(|s| stream_gc_tag(&heap, Some(s)))
+        .collect();
+    assert_eq!(
+        out_tags,
+        ELEM_TAGS.iter().map(|t| t + 1000).collect::<Vec<_>>(),
+        "Stream.map produced-result buffer went stale across later callbacks; \
+         the output stream was built from dangling/reused result references"
+    );
+}
+
+/// Group A — `Stream.reduce`. Exercises the receiver, the element snapshot, the
+/// running accumulator reference, AND the Optional result container that is
+/// allocated before the loop and written after it — every one of which the
+/// native holds across the fold's per-element callbacks.
+#[test]
+fn stream_reduce_receiver_accumulator_and_elements_survive_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const RECEIVER_TAG: i32 = 5150;
+    const ELEM_TAGS: [i32; 3] = [100, 101, 102];
+
+    struct StreamGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        observed_receiver_tags: Vec<i32>,
+        observed_acc_tags: Vec<i32>,
+        observed_elem_tags: Vec<i32>,
+    }
+
+    impl CallbackOps for StreamGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            // args[0] = op receiver, args[1] = running accumulator, args[2] = elem.
+            self.observed_receiver_tags
+                .push(stream_gc_tag(heap, args.first()));
+            let acc_tag = stream_gc_tag(heap, args.get(1));
+            self.observed_acc_tags.push(acc_tag);
+            self.observed_elem_tags
+                .push(stream_gc_tag(heap, args.get(2)));
+            // New accumulator tagged acc + 1000, so the fold chains 100 -> 1100
+            // -> 2100. It survives its own GCs and, stored in the native `acc`,
+            // is re-passed to the next callback.
+            let res = heap.allocate("duke/test/Acc".to_string(), 1);
+            heap.get_mut(res).unwrap().fields[0] = Slot::Int(acc_tag + 1000);
+            let forwarded = stream_gc_two_collections(
+                heap,
+                &mut self.caller_frame,
+                &mut self.registry,
+                &mut self.string_intern,
+                Some(res),
+            );
+            Ok(Some(Slot::Reference(forwarded)))
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let stream_ref = build_tagged_object_stream(&mut heap, &ELEM_TAGS);
+    let op_ref = heap.allocate("duke/test/BinaryOperator".to_string(), 1);
+    heap.get_mut(op_ref).unwrap().fields[0] = Slot::Int(RECEIVER_TAG);
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(op_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = StreamGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        observed_receiver_tags: Vec::new(),
+        observed_acc_tags: Vec::new(),
+        observed_elem_tags: Vec::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_stream_reduce(
+        &[
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(op_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    // Two callbacks for three elements; the receiver, the accumulators handed in
+    // (100 then the produced 1100), and the elements must all be intact.
+    assert_eq!(
+        ops.observed_receiver_tags,
+        vec![RECEIVER_TAG; 2],
+        "Stream.reduce operator receiver went stale across a callback's GCs"
+    );
+    assert_eq!(
+        ops.observed_acc_tags,
+        vec![100, 1100],
+        "Stream.reduce running accumulator went stale across a callback's GCs"
+    );
+    assert_eq!(
+        ops.observed_elem_tags,
+        vec![101, 102],
+        "Stream.reduce element snapshot went stale across a callback's GCs"
+    );
+
+    // Final fold result lives in the Optional container that was pinned across
+    // the whole loop: 100 -> 1100 -> 2100.
+    let Some(Slot::Reference(Some(opt_ref))) = result else {
+        panic!("Stream.reduce did not return an Optional");
+    };
+    let final_tag = stream_gc_tag(&heap, heap.get(opt_ref).unwrap().fields.first());
+    assert_eq!(
+        final_tag, 2100,
+        "Stream.reduce final accumulator / Optional container went stale across \
+         the fold's GCs"
+    );
+}
+
+/// Group A — `Stream.filter`. The predicate holds the re-passed receiver and a
+/// per-element ELEMENT reference across the callback, and the kept elements are
+/// re-read from the pinned snapshot to build the result stream.
+#[test]
+fn stream_filter_receiver_and_element_survive_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const RECEIVER_TAG: i32 = 9091;
+    const ELEM_TAGS: [i32; 4] = [100, 101, 102, 103];
+
+    struct StreamGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        observed_receiver_tags: Vec<i32>,
+        observed_elem_tags: Vec<i32>,
+    }
+
+    impl CallbackOps for StreamGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            self.observed_receiver_tags
+                .push(stream_gc_tag(heap, args.first()));
+            let elem_tag = stream_gc_tag(heap, args.get(1));
+            self.observed_elem_tags.push(elem_tag);
+            stream_gc_two_collections(
+                heap,
+                &mut self.caller_frame,
+                &mut self.registry,
+                &mut self.string_intern,
+                None,
+            );
+            // Keep the even-tagged elements.
+            Ok(Some(Slot::Int(i32::from(elem_tag % 2 == 0))))
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let stream_ref = build_tagged_object_stream(&mut heap, &ELEM_TAGS);
+    let pred_ref = heap.allocate("duke/test/Predicate".to_string(), 1);
+    heap.get_mut(pred_ref).unwrap().fields[0] = Slot::Int(RECEIVER_TAG);
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(pred_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = StreamGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        observed_receiver_tags: Vec::new(),
+        observed_elem_tags: Vec::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_stream_filter(
+        &[
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(pred_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    assert_eq!(
+        ops.observed_receiver_tags,
+        vec![RECEIVER_TAG; ELEM_TAGS.len()],
+        "Stream.filter predicate receiver went stale across a callback's GCs"
+    );
+    assert_eq!(
+        ops.observed_elem_tags,
+        ELEM_TAGS.to_vec(),
+        "Stream.filter element snapshot went stale across a callback's GCs"
+    );
+
+    // Kept elements (even tags) must be materialised intact from the pinned
+    // snapshot.
+    let Some(Slot::Reference(Some(out_stream))) = result else {
+        panic!("Stream.filter did not return a stream");
+    };
+    let out_tags: Vec<i32> = heap.get(out_stream).unwrap().fields[1..]
+        .iter()
+        .map(|s| stream_gc_tag(&heap, Some(s)))
+        .collect();
+    assert_eq!(
+        out_tags,
+        vec![100, 102],
+        "Stream.filter kept-element materialisation went stale across the GCs"
+    );
+}
+
 /// Family 5a (Class.newInstance). `native_class_new_instance` allocates the
 /// instance, then holds its bare reference across the `<init>` constructor
 /// callback and returns it. A nested constructor can allocate heavily and trigger

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -36074,6 +36074,405 @@ fn bifunction_and_then_apply_survives_two_gcs_during_callback() {
     );
 }
 
+/// Group C (primitive Int/Long/Double stream loops). These natives loop over a
+/// primitive element snapshot and re-pass the callback RECEIVER (the lambda ref)
+/// into `ops.invoke` on every iteration. The elements are primitives (never at
+/// risk), but the receiver is held in a Rust local — a Copy `Vec<Slot>` the
+/// collector never scans — across each callback. Each callback below forces two
+/// full relocating collections, so an unpinned receiver relocates mid-loop and
+/// the next iteration re-passes a stale/reused reference. With the
+/// `NativeRootScope` pin the receiver is rooted and forwarded across every
+/// collect, so every iteration observes the correct receiver.
+///
+/// IntStream leg — drives `native_int_stream_for_each`.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn int_stream_for_each_receiver_survives_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const RECEIVER_TAG: i32 = 6161;
+    const ELEMS: [i32; 3] = [11, 22, 33];
+
+    struct StreamGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        observed_receiver_tags: Vec<i32>,
+        observed_elems: Vec<i32>,
+    }
+
+    impl CallbackOps for StreamGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            // args[0] = consumer receiver, args[1] = the primitive element.
+            let recv_tag = match args.first() {
+                Some(Slot::Reference(Some(r))) => heap
+                    .get(*r)
+                    .ok()
+                    .and_then(|o| match o.fields.first() {
+                        Some(Slot::Int(n)) => Some(*n),
+                        _ => None,
+                    })
+                    .unwrap_or(i32::MIN),
+                _ => i32::MIN,
+            };
+            self.observed_receiver_tags.push(recv_tag);
+            if let Some(Slot::Int(v)) = args.get(1) {
+                self.observed_elems.push(*v);
+            }
+
+            for _ in 0..2 {
+                for _ in 0..4 {
+                    let g = heap.allocate("duke/test/Garbage".to_string(), 1);
+                    if let Ok(o) = heap.get_mut(g) {
+                        o.fields[0] = Slot::Int(-777);
+                    }
+                }
+                let roots =
+                    gather_roots(&self.caller_frame, &[], &self.registry, &self.string_intern);
+                heap.collect(&roots);
+                patch_forwarded_slots(
+                    &mut self.caller_frame,
+                    &mut [],
+                    &mut self.registry,
+                    heap,
+                    &mut self.string_intern,
+                );
+            }
+            Ok(None)
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let stream_ref = heap.allocate("duke/util/IntStream".to_string(), 1);
+    heap.get_mut(stream_ref).unwrap().fields[0] = Slot::Int(ELEMS.len() as i32);
+    for &v in &ELEMS {
+        heap.get_mut(stream_ref).unwrap().fields.push(Slot::Int(v));
+    }
+    let consumer_ref = heap.allocate("duke/test/Consumer".to_string(), 1);
+    heap.get_mut(consumer_ref).unwrap().fields[0] = Slot::Int(RECEIVER_TAG);
+
+    // Caller frame roots the LIVE receiver (as an interpreter frame would), so it
+    // survives and forwards; only the native's private `consumer_slot` copy is at
+    // risk without the pin.
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(consumer_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = StreamGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        observed_receiver_tags: Vec::new(),
+        observed_elems: Vec::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    native_int_stream_for_each(
+        &[
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(consumer_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    assert_eq!(
+        ops.observed_receiver_tags,
+        vec![RECEIVER_TAG; ELEMS.len()],
+        "IntStream.forEach consumer receiver went stale across a callback's GCs; \
+         a later `accept` invoke was handed a dangling/reused receiver reference"
+    );
+    assert_eq!(
+        ops.observed_elems,
+        ELEMS.to_vec(),
+        "IntStream.forEach did not process every element exactly once"
+    );
+}
+
+/// Group C — LongStream leg — drives `native_long_stream_for_each`.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn long_stream_for_each_receiver_survives_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const RECEIVER_TAG: i32 = 7272;
+    const ELEMS: [i64; 3] = [1_000_000_001, 1_000_000_002, 1_000_000_003];
+
+    struct StreamGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        observed_receiver_tags: Vec<i32>,
+        observed_elems: Vec<i64>,
+    }
+
+    impl CallbackOps for StreamGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            let recv_tag = match args.first() {
+                Some(Slot::Reference(Some(r))) => heap
+                    .get(*r)
+                    .ok()
+                    .and_then(|o| match o.fields.first() {
+                        Some(Slot::Int(n)) => Some(*n),
+                        _ => None,
+                    })
+                    .unwrap_or(i32::MIN),
+                _ => i32::MIN,
+            };
+            self.observed_receiver_tags.push(recv_tag);
+            if let Some(Slot::Long(v)) = args.get(1) {
+                self.observed_elems.push(*v);
+            }
+
+            for _ in 0..2 {
+                for _ in 0..4 {
+                    let g = heap.allocate("duke/test/Garbage".to_string(), 1);
+                    if let Ok(o) = heap.get_mut(g) {
+                        o.fields[0] = Slot::Int(-777);
+                    }
+                }
+                let roots =
+                    gather_roots(&self.caller_frame, &[], &self.registry, &self.string_intern);
+                heap.collect(&roots);
+                patch_forwarded_slots(
+                    &mut self.caller_frame,
+                    &mut [],
+                    &mut self.registry,
+                    heap,
+                    &mut self.string_intern,
+                );
+            }
+            Ok(None)
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let stream_ref = heap.allocate("duke/util/LongStream".to_string(), 1);
+    heap.get_mut(stream_ref).unwrap().fields[0] = Slot::Int(ELEMS.len() as i32);
+    for &v in &ELEMS {
+        heap.get_mut(stream_ref).unwrap().fields.push(Slot::Long(v));
+    }
+    let consumer_ref = heap.allocate("duke/test/Consumer".to_string(), 1);
+    heap.get_mut(consumer_ref).unwrap().fields[0] = Slot::Int(RECEIVER_TAG);
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(consumer_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = StreamGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        observed_receiver_tags: Vec::new(),
+        observed_elems: Vec::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    native_long_stream_for_each(
+        &[
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(consumer_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    assert_eq!(
+        ops.observed_receiver_tags,
+        vec![RECEIVER_TAG; ELEMS.len()],
+        "LongStream.forEach consumer receiver went stale across a callback's GCs; \
+         a later `accept` invoke was handed a dangling/reused receiver reference"
+    );
+    assert_eq!(
+        ops.observed_elems,
+        ELEMS.to_vec(),
+        "LongStream.forEach did not process every element exactly once"
+    );
+}
+
+/// Group C — DoubleStream leg — drives `native_double_stream_for_each`.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn double_stream_for_each_receiver_survives_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const RECEIVER_TAG: i32 = 8383;
+    const ELEMS: [f64; 3] = [1.5, 2.5, 3.5];
+
+    struct StreamGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        observed_receiver_tags: Vec<i32>,
+        observed_elems: Vec<f64>,
+    }
+
+    impl CallbackOps for StreamGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            let recv_tag = match args.first() {
+                Some(Slot::Reference(Some(r))) => heap
+                    .get(*r)
+                    .ok()
+                    .and_then(|o| match o.fields.first() {
+                        Some(Slot::Int(n)) => Some(*n),
+                        _ => None,
+                    })
+                    .unwrap_or(i32::MIN),
+                _ => i32::MIN,
+            };
+            self.observed_receiver_tags.push(recv_tag);
+            if let Some(Slot::Double(v)) = args.get(1) {
+                self.observed_elems.push(*v);
+            }
+
+            for _ in 0..2 {
+                for _ in 0..4 {
+                    let g = heap.allocate("duke/test/Garbage".to_string(), 1);
+                    if let Ok(o) = heap.get_mut(g) {
+                        o.fields[0] = Slot::Int(-777);
+                    }
+                }
+                let roots =
+                    gather_roots(&self.caller_frame, &[], &self.registry, &self.string_intern);
+                heap.collect(&roots);
+                patch_forwarded_slots(
+                    &mut self.caller_frame,
+                    &mut [],
+                    &mut self.registry,
+                    heap,
+                    &mut self.string_intern,
+                );
+            }
+            Ok(None)
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let stream_ref = heap.allocate("duke/util/DoubleStream".to_string(), 1);
+    heap.get_mut(stream_ref).unwrap().fields[0] = Slot::Int(ELEMS.len() as i32);
+    for &v in &ELEMS {
+        heap.get_mut(stream_ref)
+            .unwrap()
+            .fields
+            .push(Slot::Double(v));
+    }
+    let consumer_ref = heap.allocate("duke/test/Consumer".to_string(), 1);
+    heap.get_mut(consumer_ref).unwrap().fields[0] = Slot::Int(RECEIVER_TAG);
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(consumer_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = StreamGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        observed_receiver_tags: Vec::new(),
+        observed_elems: Vec::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    native_double_stream_for_each(
+        &[
+            Slot::Reference(Some(stream_ref)),
+            Slot::Reference(Some(consumer_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    assert_eq!(
+        ops.observed_receiver_tags,
+        vec![RECEIVER_TAG; ELEMS.len()],
+        "DoubleStream.forEach consumer receiver went stale across a callback's \
+         GCs; a later `accept` invoke was handed a dangling/reused receiver \
+         reference"
+    );
+    assert_eq!(
+        ops.observed_elems,
+        ELEMS.to_vec(),
+        "DoubleStream.forEach did not process every element exactly once"
+    );
+}
+
 /// Family 5a (Class.newInstance). `native_class_new_instance` allocates the
 /// instance, then holds its bare reference across the `<init>` constructor
 /// callback and returns it. A nested constructor can allocate heavily and trigger

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -36085,7 +36085,7 @@ fn bifunction_and_then_apply_survives_two_gcs_during_callback() {
 ///
 /// Predicate `and` leg — drives `native_and_predicate_test`.
 #[test]
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::branches_sharing_code)]
 fn and_predicate_test_survives_two_gcs_during_callback() {
     use std::collections::HashMap;
 
@@ -36515,7 +36515,7 @@ fn compose_function_apply_survives_two_gcs_during_callback() {
 
 /// Consumer `andThen` leg — drives `native_and_then_consumer_accept`.
 #[test]
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::branches_sharing_code)]
 fn and_then_consumer_accept_survives_two_gcs_during_callback() {
     use std::collections::HashMap;
 
@@ -36823,7 +36823,12 @@ fn then_comparing_compare_survives_two_gcs_during_callback() {
 ///
 /// IntStream leg — drives `native_int_stream_for_each`.
 #[test]
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    clippy::doc_markdown,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
 fn int_stream_for_each_receiver_survives_two_gcs_during_callback() {
     use std::collections::HashMap;
 
@@ -36954,7 +36959,12 @@ fn int_stream_for_each_receiver_survives_two_gcs_during_callback() {
 
 /// Group C — LongStream leg — drives `native_long_stream_for_each`.
 #[test]
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    clippy::doc_markdown,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
 fn long_stream_for_each_receiver_survives_two_gcs_during_callback() {
     use std::collections::HashMap;
 
@@ -37081,7 +37091,12 @@ fn long_stream_for_each_receiver_survives_two_gcs_during_callback() {
 
 /// Group C — DoubleStream leg — drives `native_double_stream_for_each`.
 #[test]
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    clippy::doc_markdown,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
 fn double_stream_for_each_receiver_survives_two_gcs_during_callback() {
     use std::collections::HashMap;
 
@@ -37275,6 +37290,7 @@ fn stream_gc_two_collections(
 
 /// Builds a `duke/util/Stream` whose elements are freshly-allocated objects each
 /// tagged with a distinct int in `fields[0]`. Returns the stream ref.
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 fn build_tagged_object_stream(heap: &mut duke_gc::Heap, tags: &[i32]) -> u64 {
     let stream_ref = heap.allocate("duke/util/Stream".to_string(), 1);
     heap.get_mut(stream_ref).unwrap().fields[0] = Slot::Int(tags.len() as i32);
@@ -37521,6 +37537,11 @@ fn stream_map_receiver_element_and_result_survive_two_gcs_during_callback() {
 /// allocated before the loop and written after it — every one of which the
 /// native holds across the fold's per-element callbacks.
 #[test]
+#[allow(
+    clippy::too_many_lines,
+    clippy::branches_sharing_code,
+    clippy::similar_names
+)]
 fn stream_reduce_receiver_accumulator_and_elements_survive_two_gcs_during_callback() {
     use std::collections::HashMap;
 
@@ -37795,6 +37816,7 @@ fn build_collector(heap: &mut duke_gc::Heap, class: &str, fields: &[Slot]) -> u6
 /// produced inside each callback; the assembled map must have every key and
 /// value intact.
 #[test]
+#[allow(clippy::too_many_lines, clippy::doc_markdown, clippy::cast_sign_loss)]
 fn collect_to_map_accumulator_keys_and_values_survive_two_gcs_during_callback() {
     use std::collections::HashMap;
 
@@ -37948,6 +37970,7 @@ fn collect_to_map_accumulator_keys_and_values_survive_two_gcs_during_callback() 
 /// element pushed into each bucket AFTER its key callback. A distinct key is
 /// produced per element so every element lands in its own single-element list.
 #[test]
+#[allow(clippy::too_many_lines, clippy::doc_markdown, clippy::cast_sign_loss)]
 fn collect_grouping_by_elements_and_map_survive_two_gcs_during_callback() {
     use std::collections::HashMap;
 
@@ -38094,6 +38117,7 @@ fn collect_grouping_by_elements_and_map_survive_two_gcs_during_callback() {
 /// [10,20,30] via `op(acc, elem) = acc + elem`, so the accumulator advances
 /// 0 -> 10 -> 30 -> 60.
 #[test]
+#[allow(clippy::too_many_lines)]
 fn collect_reducing_accumulator_survives_two_gcs_during_callback() {
     use std::collections::HashMap;
 
@@ -38228,6 +38252,7 @@ fn collect_reducing_accumulator_survives_two_gcs_during_callback() {
 /// each of which forces two relocating GCs. The container accumulates the sum of
 /// element tags; the finisher reads it back.
 #[test]
+#[allow(clippy::too_many_lines)]
 fn collect_real_collector_chain_container_survives_two_gcs_during_callback() {
     use std::collections::HashMap;
 
@@ -38407,6 +38432,7 @@ fn collect_real_collector_chain_container_survives_two_gcs_during_callback() {
 /// collections. Without pinning the finisher slot, the finisher `apply` after
 /// the recursive collect is handed a dangling/reused receiver.
 #[test]
+#[allow(clippy::too_many_lines)]
 fn collect_collecting_and_then_finisher_survives_two_gcs_during_recursive_collect() {
     use std::collections::HashMap;
 

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -35758,6 +35758,164 @@ fn system_get_properties_survives_gc_during_callbacks() {
     );
 }
 
+/// Group D (two-key comparator natives). Drives `native_comparing_int_compare`,
+/// which extracts a key from each of two elements by calling the comparator's
+/// `applyAsInt` twice. The receiver `fn_ref` is re-passed to BOTH invokes and the
+/// second element `b` is held across the FIRST invoke. This callback forces two
+/// full collections per invoke; with the pin (`NativeRootScope`) `fn_ref`/`b` are
+/// rooted and forwarded across every collect, so the second invoke sees the
+/// correct receiver and element. Without the pin they go stale/reused and the
+/// second invoke observes wrong tags.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn comparing_int_comparator_survives_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const FN_TAG: i32 = 4242;
+    const A_KEY: i32 = 10;
+    const B_KEY: i32 = 20;
+
+    struct CmpGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        observed_receiver_tags: Vec<i32>,
+        observed_elem_keys: Vec<i32>,
+    }
+
+    impl CallbackOps for CmpGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            // args[0] = comparator receiver (fn), args[1] = element.
+            let recv_tag = match args.first() {
+                Some(Slot::Reference(Some(r))) => heap
+                    .get(*r)
+                    .ok()
+                    .and_then(|o| match o.fields.first() {
+                        Some(Slot::Int(n)) => Some(*n),
+                        _ => None,
+                    })
+                    .unwrap_or(i32::MIN),
+                _ => i32::MIN,
+            };
+            let elem_key = match args.get(1) {
+                Some(Slot::Reference(Some(r))) => heap
+                    .get(*r)
+                    .ok()
+                    .and_then(|o| match o.fields.first() {
+                        Some(Slot::Int(n)) => Some(*n),
+                        _ => None,
+                    })
+                    .unwrap_or(i32::MIN),
+                _ => i32::MIN,
+            };
+            self.observed_receiver_tags.push(recv_tag);
+            self.observed_elem_keys.push(elem_key);
+
+            for _ in 0..2 {
+                for _ in 0..4 {
+                    let g = heap.allocate("duke/test/Garbage".to_string(), 1);
+                    if let Ok(o) = heap.get_mut(g) {
+                        o.fields[0] = Slot::Int(-777);
+                    }
+                }
+                let roots =
+                    gather_roots(&self.caller_frame, &[], &self.registry, &self.string_intern);
+                heap.collect(&roots);
+                patch_forwarded_slots(
+                    &mut self.caller_frame,
+                    &mut [],
+                    &mut self.registry,
+                    heap,
+                    &mut self.string_intern,
+                );
+            }
+            // Return the extracted key as the comparator's applyAsInt result.
+            Ok(Some(Slot::Int(elem_key)))
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let this_ref = heap.allocate("duke/util/ComparingIntComparator".to_string(), 1);
+    let fn_ref = heap.allocate("duke/test/KeyFn".to_string(), 1);
+    heap.get_mut(fn_ref).unwrap().fields[0] = Slot::Int(FN_TAG);
+    heap.get_mut(this_ref).unwrap().fields[0] = Slot::Reference(Some(fn_ref));
+    let a_ref = heap.allocate("duke/test/Elem".to_string(), 1);
+    heap.get_mut(a_ref).unwrap().fields[0] = Slot::Int(A_KEY);
+    let b_ref = heap.allocate("duke/test/Elem".to_string(), 1);
+    heap.get_mut(b_ref).unwrap().fields[0] = Slot::Int(B_KEY);
+
+    // Caller frame roots the LIVE this/a/b (as an interpreter frame would), so
+    // those survive and forward; only the native's private fn_ref/b copies are
+    // at risk without the pin (fn_ref survives via this_ref.fields[0]).
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(this_ref)),
+            Slot::Reference(Some(a_ref)),
+            Slot::Reference(Some(b_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = CmpGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        observed_receiver_tags: Vec::new(),
+        observed_elem_keys: Vec::new(),
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_comparing_int_compare(
+        &[
+            Slot::Reference(Some(this_ref)),
+            Slot::Reference(Some(a_ref)),
+            Slot::Reference(Some(b_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    )
+    .unwrap();
+
+    assert_eq!(
+        ops.observed_receiver_tags,
+        vec![FN_TAG, FN_TAG],
+        "comparator receiver went stale across the first callback's GCs; the \
+         second applyAsInt invoke was handed a dangling fn reference"
+    );
+    assert_eq!(
+        ops.observed_elem_keys,
+        vec![A_KEY, B_KEY],
+        "the second key `b` was held across the first callback's GCs and read \
+         stale/reused at the second applyAsInt invoke"
+    );
+    assert_eq!(
+        result,
+        Some(Slot::Int(-1)),
+        "compare(a, b) should order the smaller key before the larger one"
+    );
+}
+
 /// Family 5a (Class.newInstance). `native_class_new_instance` allocates the
 /// instance, then holds its bare reference across the `<init>` constructor
 /// callback and returns it. A nested constructor can allocate heavily and trigger

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -36074,6 +36074,743 @@ fn bifunction_and_then_apply_survives_two_gcs_during_callback() {
     );
 }
 
+/// Helper-invoke combinators (via the `invoke_*` common.rs helpers, which each
+/// run `ops.invoke` internally and are therefore GC points). Each native holds a
+/// second-stage receiver (and sometimes the element/argument) in a Rust local
+/// across the FIRST helper call and consumes it in the SECOND. The first callback
+/// forces two full relocating collections; without the `NativeRootScope` pin the
+/// held second-stage ref relocates mid-call and the second stage reads a
+/// dangling reference. With the pin it is rooted and forwarded across every
+/// collect, so the combined result is correct.
+///
+/// Predicate `and` leg — drives `native_and_predicate_test`.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn and_predicate_test_survives_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const RIGHT_TAG: i32 = 7001;
+    const ELEM_TAG: i32 = 7002;
+
+    struct AndPredGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        call_count: usize,
+        observed_right_tag: Option<i32>,
+        observed_elem_tag: Option<i32>,
+    }
+
+    fn tag_of(heap: &duke_gc::Heap, slot: Option<&Slot>) -> i32 {
+        match slot {
+            Some(Slot::Reference(Some(r))) => heap
+                .get(*r)
+                .ok()
+                .and_then(|o| match o.fields.first() {
+                    Some(Slot::Int(n)) => Some(*n),
+                    _ => None,
+                })
+                .unwrap_or(i32::MIN),
+            _ => i32::MIN,
+        }
+    }
+
+    impl CallbackOps for AndPredGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            self.call_count += 1;
+            if self.call_count == 1 {
+                // First stage: left.test(elem). Force two collections so the
+                // native's held `right`/`elem` copies relocate mid-call.
+                for _ in 0..2 {
+                    for _ in 0..4 {
+                        let g = heap.allocate("duke/test/Garbage".to_string(), 1);
+                        if let Ok(o) = heap.get_mut(g) {
+                            o.fields[0] = Slot::Int(-777);
+                        }
+                    }
+                    let roots =
+                        gather_roots(&self.caller_frame, &[], &self.registry, &self.string_intern);
+                    heap.collect(&roots);
+                    patch_forwarded_slots(
+                        &mut self.caller_frame,
+                        &mut [],
+                        &mut self.registry,
+                        heap,
+                        &mut self.string_intern,
+                    );
+                }
+                Ok(Some(Slot::Int(1))) // left is true → proceed to right
+            } else {
+                // Second stage: right.test(elem). args[0]=right, args[1]=elem.
+                self.observed_right_tag = Some(tag_of(heap, args.first()));
+                self.observed_elem_tag = Some(tag_of(heap, args.get(1)));
+                Ok(Some(Slot::Int(1)))
+            }
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let this_ref = heap.allocate("duke/util/AndPredicate".to_string(), 2);
+    let left_ref = heap.allocate("duke/test/LeftPred".to_string(), 1);
+    heap.get_mut(left_ref).unwrap().fields[0] = Slot::Int(1);
+    let right_ref = heap.allocate("duke/test/RightPred".to_string(), 1);
+    heap.get_mut(right_ref).unwrap().fields[0] = Slot::Int(RIGHT_TAG);
+    heap.get_mut(this_ref).unwrap().fields[0] = Slot::Reference(Some(left_ref));
+    heap.get_mut(this_ref).unwrap().fields[1] = Slot::Reference(Some(right_ref));
+    let elem_ref = heap.allocate("duke/test/Elem".to_string(), 1);
+    heap.get_mut(elem_ref).unwrap().fields[0] = Slot::Int(ELEM_TAG);
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(this_ref)),
+            Slot::Reference(Some(elem_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = AndPredGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        call_count: 0,
+        observed_right_tag: None,
+        observed_elem_tag: None,
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_and_predicate_test(
+        &[
+            Slot::Reference(Some(this_ref)),
+            Slot::Reference(Some(elem_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    );
+
+    assert_eq!(
+        ops.observed_right_tag,
+        Some(RIGHT_TAG),
+        "the `right` predicate went stale across the left predicate's test GCs; \
+         the and() second stage was handed a dangling predicate reference"
+    );
+    assert_eq!(
+        ops.observed_elem_tag,
+        Some(ELEM_TAG),
+        "the tested `elem` went stale across the left predicate's test GCs"
+    );
+    let result = result.expect("and predicate test should not error");
+    assert_eq!(
+        result,
+        Some(Slot::Int(1)),
+        "and() returned the wrong result after callback GCs"
+    );
+}
+
+/// Function `andThen` leg — drives `native_and_then_function_apply`.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn and_then_function_apply_survives_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const SECOND_TAG: i32 = 8101;
+    const RESULT_TAG: i32 = 8102;
+
+    struct AndThenFnGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        call_count: usize,
+        observed_second_tag: Option<i32>,
+    }
+
+    impl CallbackOps for AndThenFnGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            self.call_count += 1;
+            if self.call_count == 1 {
+                // First stage: first.apply(input). Force two collections so the
+                // native's held `second` copy relocates mid-call.
+                for _ in 0..2 {
+                    for _ in 0..4 {
+                        let g = heap.allocate("duke/test/Garbage".to_string(), 1);
+                        if let Ok(o) = heap.get_mut(g) {
+                            o.fields[0] = Slot::Int(-777);
+                        }
+                    }
+                    let roots =
+                        gather_roots(&self.caller_frame, &[], &self.registry, &self.string_intern);
+                    heap.collect(&roots);
+                    patch_forwarded_slots(
+                        &mut self.caller_frame,
+                        &mut [],
+                        &mut self.registry,
+                        heap,
+                        &mut self.string_intern,
+                    );
+                }
+                let mid = heap.allocate("duke/test/Mid".to_string(), 1);
+                heap.get_mut(mid)?.fields[0] = Slot::Int(0);
+                Ok(Some(Slot::Reference(Some(mid))))
+            } else {
+                // Second stage: second.apply(mid). args[0] is the `second` receiver.
+                let tag = match args.first() {
+                    Some(Slot::Reference(Some(r))) => heap
+                        .get(*r)
+                        .ok()
+                        .and_then(|o| match o.fields.first() {
+                            Some(Slot::Int(n)) => Some(*n),
+                            _ => None,
+                        })
+                        .unwrap_or(i32::MIN),
+                    _ => i32::MIN,
+                };
+                self.observed_second_tag = Some(tag);
+                let res = heap.allocate("duke/test/Result".to_string(), 1);
+                heap.get_mut(res)?.fields[0] = Slot::Int(RESULT_TAG);
+                Ok(Some(Slot::Reference(Some(res))))
+            }
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let this_ref = heap.allocate("duke/util/AndThenFunction".to_string(), 2);
+    let first_ref = heap.allocate("duke/test/FirstFn".to_string(), 1);
+    heap.get_mut(first_ref).unwrap().fields[0] = Slot::Int(1);
+    let second_ref = heap.allocate("duke/test/SecondFn".to_string(), 1);
+    heap.get_mut(second_ref).unwrap().fields[0] = Slot::Int(SECOND_TAG);
+    heap.get_mut(this_ref).unwrap().fields[0] = Slot::Reference(Some(first_ref));
+    heap.get_mut(this_ref).unwrap().fields[1] = Slot::Reference(Some(second_ref));
+    let input_ref = heap.allocate("duke/test/Input".to_string(), 1);
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(this_ref)),
+            Slot::Reference(Some(input_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = AndThenFnGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        call_count: 0,
+        observed_second_tag: None,
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_and_then_function_apply(
+        &[
+            Slot::Reference(Some(this_ref)),
+            Slot::Reference(Some(input_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    );
+
+    assert_eq!(
+        ops.observed_second_tag,
+        Some(SECOND_TAG),
+        "the `second` function went stale across the first function's apply GCs; \
+         andThen's second stage was handed a dangling function reference"
+    );
+    let result = result.expect("andThen function apply should not error");
+    let res_ref = match result {
+        Some(Slot::Reference(Some(r))) => r,
+        other => panic!("andThen function apply did not return a reference: {other:?}"),
+    };
+    let res_tag = match heap.get(res_ref).unwrap().fields.first() {
+        Some(Slot::Int(n)) => *n,
+        other => panic!("andThen function result has no int tag: {other:?}"),
+    };
+    assert_eq!(
+        res_tag, RESULT_TAG,
+        "andThen function apply returned the wrong result after callback GCs"
+    );
+}
+
+/// Function `compose` leg — drives `native_compose_function_apply`.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn compose_function_apply_survives_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const OUTER_TAG: i32 = 8201;
+    const RESULT_TAG: i32 = 8202;
+
+    struct ComposeGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        call_count: usize,
+        observed_outer_tag: Option<i32>,
+    }
+
+    impl CallbackOps for ComposeGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            self.call_count += 1;
+            if self.call_count == 1 {
+                // First stage: inner.apply(input). Force two collections so the
+                // native's held `outer` copy relocates mid-call.
+                for _ in 0..2 {
+                    for _ in 0..4 {
+                        let g = heap.allocate("duke/test/Garbage".to_string(), 1);
+                        if let Ok(o) = heap.get_mut(g) {
+                            o.fields[0] = Slot::Int(-777);
+                        }
+                    }
+                    let roots =
+                        gather_roots(&self.caller_frame, &[], &self.registry, &self.string_intern);
+                    heap.collect(&roots);
+                    patch_forwarded_slots(
+                        &mut self.caller_frame,
+                        &mut [],
+                        &mut self.registry,
+                        heap,
+                        &mut self.string_intern,
+                    );
+                }
+                let mid = heap.allocate("duke/test/Mid".to_string(), 1);
+                heap.get_mut(mid)?.fields[0] = Slot::Int(0);
+                Ok(Some(Slot::Reference(Some(mid))))
+            } else {
+                // Second stage: outer.apply(mid). args[0] is the `outer` receiver.
+                let tag = match args.first() {
+                    Some(Slot::Reference(Some(r))) => heap
+                        .get(*r)
+                        .ok()
+                        .and_then(|o| match o.fields.first() {
+                            Some(Slot::Int(n)) => Some(*n),
+                            _ => None,
+                        })
+                        .unwrap_or(i32::MIN),
+                    _ => i32::MIN,
+                };
+                self.observed_outer_tag = Some(tag);
+                let res = heap.allocate("duke/test/Result".to_string(), 1);
+                heap.get_mut(res)?.fields[0] = Slot::Int(RESULT_TAG);
+                Ok(Some(Slot::Reference(Some(res))))
+            }
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let this_ref = heap.allocate("duke/util/ComposeFunction".to_string(), 2);
+    let outer_ref = heap.allocate("duke/test/OuterFn".to_string(), 1);
+    heap.get_mut(outer_ref).unwrap().fields[0] = Slot::Int(OUTER_TAG);
+    let inner_ref = heap.allocate("duke/test/InnerFn".to_string(), 1);
+    heap.get_mut(inner_ref).unwrap().fields[0] = Slot::Int(1);
+    heap.get_mut(this_ref).unwrap().fields[0] = Slot::Reference(Some(outer_ref));
+    heap.get_mut(this_ref).unwrap().fields[1] = Slot::Reference(Some(inner_ref));
+    let input_ref = heap.allocate("duke/test/Input".to_string(), 1);
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(this_ref)),
+            Slot::Reference(Some(input_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = ComposeGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        call_count: 0,
+        observed_outer_tag: None,
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_compose_function_apply(
+        &[
+            Slot::Reference(Some(this_ref)),
+            Slot::Reference(Some(input_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    );
+
+    assert_eq!(
+        ops.observed_outer_tag,
+        Some(OUTER_TAG),
+        "the `outer` function went stale across the inner function's apply GCs; \
+         compose's outer stage was handed a dangling function reference"
+    );
+    let result = result.expect("compose function apply should not error");
+    let res_ref = match result {
+        Some(Slot::Reference(Some(r))) => r,
+        other => panic!("compose function apply did not return a reference: {other:?}"),
+    };
+    let res_tag = match heap.get(res_ref).unwrap().fields.first() {
+        Some(Slot::Int(n)) => *n,
+        other => panic!("compose function result has no int tag: {other:?}"),
+    };
+    assert_eq!(
+        res_tag, RESULT_TAG,
+        "compose function apply returned the wrong result after callback GCs"
+    );
+}
+
+/// Consumer `andThen` leg — drives `native_and_then_consumer_accept`.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn and_then_consumer_accept_survives_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const SECOND_TAG: i32 = 8301;
+    const ARG_TAG: i32 = 8302;
+
+    struct AndThenConsGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        call_count: usize,
+        observed_second_tag: Option<i32>,
+        observed_arg_tag: Option<i32>,
+    }
+
+    fn tag_of(heap: &duke_gc::Heap, slot: Option<&Slot>) -> i32 {
+        match slot {
+            Some(Slot::Reference(Some(r))) => heap
+                .get(*r)
+                .ok()
+                .and_then(|o| match o.fields.first() {
+                    Some(Slot::Int(n)) => Some(*n),
+                    _ => None,
+                })
+                .unwrap_or(i32::MIN),
+            _ => i32::MIN,
+        }
+    }
+
+    impl CallbackOps for AndThenConsGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            self.call_count += 1;
+            if self.call_count == 1 {
+                // First stage: first.accept(arg). Force two collections so the
+                // native's held `second`/`arg` copies relocate mid-call.
+                for _ in 0..2 {
+                    for _ in 0..4 {
+                        let g = heap.allocate("duke/test/Garbage".to_string(), 1);
+                        if let Ok(o) = heap.get_mut(g) {
+                            o.fields[0] = Slot::Int(-777);
+                        }
+                    }
+                    let roots =
+                        gather_roots(&self.caller_frame, &[], &self.registry, &self.string_intern);
+                    heap.collect(&roots);
+                    patch_forwarded_slots(
+                        &mut self.caller_frame,
+                        &mut [],
+                        &mut self.registry,
+                        heap,
+                        &mut self.string_intern,
+                    );
+                }
+                Ok(None)
+            } else {
+                // Second stage: second.accept(arg). args[0]=second, args[1]=arg.
+                self.observed_second_tag = Some(tag_of(heap, args.first()));
+                self.observed_arg_tag = Some(tag_of(heap, args.get(1)));
+                Ok(None)
+            }
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let this_ref = heap.allocate("duke/util/AndThenConsumer".to_string(), 2);
+    let first_ref = heap.allocate("duke/test/FirstCons".to_string(), 1);
+    heap.get_mut(first_ref).unwrap().fields[0] = Slot::Int(1);
+    let second_ref = heap.allocate("duke/test/SecondCons".to_string(), 1);
+    heap.get_mut(second_ref).unwrap().fields[0] = Slot::Int(SECOND_TAG);
+    heap.get_mut(this_ref).unwrap().fields[0] = Slot::Reference(Some(first_ref));
+    heap.get_mut(this_ref).unwrap().fields[1] = Slot::Reference(Some(second_ref));
+    let arg_ref = heap.allocate("duke/test/Arg".to_string(), 1);
+    heap.get_mut(arg_ref).unwrap().fields[0] = Slot::Int(ARG_TAG);
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(this_ref)),
+            Slot::Reference(Some(arg_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = AndThenConsGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        call_count: 0,
+        observed_second_tag: None,
+        observed_arg_tag: None,
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_and_then_consumer_accept(
+        &[
+            Slot::Reference(Some(this_ref)),
+            Slot::Reference(Some(arg_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    );
+
+    assert_eq!(
+        ops.observed_second_tag,
+        Some(SECOND_TAG),
+        "the `second` consumer went stale across the first consumer's accept GCs; \
+         andThen's second stage was handed a dangling consumer reference"
+    );
+    assert_eq!(
+        ops.observed_arg_tag,
+        Some(ARG_TAG),
+        "the accepted `arg` went stale across the first consumer's accept GCs"
+    );
+    result.expect("andThen consumer accept should not error");
+}
+
+/// Comparator `thenComparing` leg — drives `native_then_comparing_compare`.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn then_comparing_compare_survives_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const SECONDARY_TAG: i32 = 8401;
+    const A_TAG: i32 = 8402;
+    const B_TAG: i32 = 8403;
+    const SECONDARY_RESULT: i32 = 42;
+
+    struct ThenComparingGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        call_count: usize,
+        observed_secondary_tag: Option<i32>,
+        observed_a_tag: Option<i32>,
+        observed_b_tag: Option<i32>,
+    }
+
+    fn tag_of(heap: &duke_gc::Heap, slot: Option<&Slot>) -> i32 {
+        match slot {
+            Some(Slot::Reference(Some(r))) => heap
+                .get(*r)
+                .ok()
+                .and_then(|o| match o.fields.first() {
+                    Some(Slot::Int(n)) => Some(*n),
+                    _ => None,
+                })
+                .unwrap_or(i32::MIN),
+            _ => i32::MIN,
+        }
+    }
+
+    impl CallbackOps for ThenComparingGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            self.call_count += 1;
+            if self.call_count == 1 {
+                // First stage: primary.compare(a, b). Force two collections so the
+                // native's held `secondary`/`a`/`b` copies relocate mid-call.
+                for _ in 0..2 {
+                    for _ in 0..4 {
+                        let g = heap.allocate("duke/test/Garbage".to_string(), 1);
+                        if let Ok(o) = heap.get_mut(g) {
+                            o.fields[0] = Slot::Int(-777);
+                        }
+                    }
+                    let roots =
+                        gather_roots(&self.caller_frame, &[], &self.registry, &self.string_intern);
+                    heap.collect(&roots);
+                    patch_forwarded_slots(
+                        &mut self.caller_frame,
+                        &mut [],
+                        &mut self.registry,
+                        heap,
+                        &mut self.string_intern,
+                    );
+                }
+                Ok(Some(Slot::Int(0))) // primary ties → tie-break with secondary
+            } else {
+                // Second stage: secondary.compare(a, b).
+                // args[0]=secondary, args[1]=a, args[2]=b.
+                self.observed_secondary_tag = Some(tag_of(heap, args.first()));
+                self.observed_a_tag = Some(tag_of(heap, args.get(1)));
+                self.observed_b_tag = Some(tag_of(heap, args.get(2)));
+                Ok(Some(Slot::Int(SECONDARY_RESULT)))
+            }
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let this_ref = heap.allocate("duke/util/ThenComparingComparator".to_string(), 2);
+    let primary_ref = heap.allocate("duke/test/PrimaryCmp".to_string(), 1);
+    heap.get_mut(primary_ref).unwrap().fields[0] = Slot::Int(1);
+    let secondary_ref = heap.allocate("duke/test/SecondaryCmp".to_string(), 1);
+    heap.get_mut(secondary_ref).unwrap().fields[0] = Slot::Int(SECONDARY_TAG);
+    heap.get_mut(this_ref).unwrap().fields[0] = Slot::Reference(Some(primary_ref));
+    heap.get_mut(this_ref).unwrap().fields[1] = Slot::Reference(Some(secondary_ref));
+    let a_ref = heap.allocate("duke/test/ArgA".to_string(), 1);
+    heap.get_mut(a_ref).unwrap().fields[0] = Slot::Int(A_TAG);
+    let b_ref = heap.allocate("duke/test/ArgB".to_string(), 1);
+    heap.get_mut(b_ref).unwrap().fields[0] = Slot::Int(B_TAG);
+
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(this_ref)),
+            Slot::Reference(Some(a_ref)),
+            Slot::Reference(Some(b_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = ThenComparingGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        call_count: 0,
+        observed_secondary_tag: None,
+        observed_a_tag: None,
+        observed_b_tag: None,
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_then_comparing_compare(
+        &[
+            Slot::Reference(Some(this_ref)),
+            Slot::Reference(Some(a_ref)),
+            Slot::Reference(Some(b_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    );
+
+    assert_eq!(
+        ops.observed_secondary_tag,
+        Some(SECONDARY_TAG),
+        "the `secondary` comparator went stale across the primary's compare GCs; \
+         thenComparing's tie-break was handed a dangling comparator reference"
+    );
+    assert_eq!(
+        ops.observed_a_tag,
+        Some(A_TAG),
+        "the compared `a` went stale across the primary's compare GCs"
+    );
+    assert_eq!(
+        ops.observed_b_tag,
+        Some(B_TAG),
+        "the compared `b` went stale across the primary's compare GCs"
+    );
+    let result = result.expect("thenComparing compare should not error");
+    assert_eq!(
+        result,
+        Some(Slot::Int(SECONDARY_RESULT)),
+        "thenComparing returned the wrong tie-break result after callback GCs"
+    );
+}
+
 /// Group C (primitive Int/Long/Double stream loops). These natives loop over a
 /// primitive element snapshot and re-pass the callback RECEIVER (the lambda ref)
 /// into `ops.invoke` on every iteration. The elements are primitives (never at

--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -35916,6 +35916,164 @@ fn comparing_int_comparator_survives_two_gcs_during_callback() {
     );
 }
 
+/// Group E (`native_bifunction_and_then_apply`). The native calls the wrapped
+/// bifunction's `apply(a, b)` and then applies the `after` function to the
+/// result. `after` is a heap ref held across the first `apply` invoke and only
+/// consumed at the following `invoke_function_apply`. This callback forces two
+/// full collections during the first `apply`; with the pin (`NativeRootScope`)
+/// `after` is rooted and forwarded across every collect and the second stage runs
+/// the correct function. Without the pin `after` goes stale/reused and the second
+/// stage reads a dangling function reference.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn bifunction_and_then_apply_survives_two_gcs_during_callback() {
+    use std::collections::HashMap;
+
+    const AFTER_TAG: i32 = 9191;
+    const RESULT_TAG: i32 = 5050;
+
+    struct BiFnGcOps {
+        caller_frame: duke_runtime::Frame,
+        registry: ClassRegistry,
+        string_intern: HashMap<(u8, String), u64>,
+        call_count: usize,
+        observed_after_tag: Option<i32>,
+    }
+
+    impl CallbackOps for BiFnGcOps {
+        fn invoke(
+            &mut self,
+            heap: &mut duke_gc::Heap,
+            _output: &mut dyn Write,
+            _class: &str,
+            _method: &str,
+            _descriptor: &str,
+            args: Vec<Slot>,
+        ) -> Result<Option<Slot>> {
+            self.call_count += 1;
+            if self.call_count == 1 {
+                // First stage: bifunction.apply(a, b). Force two collections so
+                // the native's held `after` reference relocates mid-call.
+                for _ in 0..2 {
+                    for _ in 0..4 {
+                        let g = heap.allocate("duke/test/Garbage".to_string(), 1);
+                        if let Ok(o) = heap.get_mut(g) {
+                            o.fields[0] = Slot::Int(-777);
+                        }
+                    }
+                    let roots =
+                        gather_roots(&self.caller_frame, &[], &self.registry, &self.string_intern);
+                    heap.collect(&roots);
+                    patch_forwarded_slots(
+                        &mut self.caller_frame,
+                        &mut [],
+                        &mut self.registry,
+                        heap,
+                        &mut self.string_intern,
+                    );
+                }
+                // Intermediate `mid` value handed to the second stage; allocated
+                // after the collections so it is a live, valid reference.
+                let mid = heap.allocate("duke/test/Mid".to_string(), 1);
+                heap.get_mut(mid)?.fields[0] = Slot::Int(0);
+                Ok(Some(Slot::Reference(Some(mid))))
+            } else {
+                // Second stage: after.apply(mid). args[0] is the `after` receiver.
+                let tag = match args.first() {
+                    Some(Slot::Reference(Some(r))) => heap
+                        .get(*r)
+                        .ok()
+                        .and_then(|o| match o.fields.first() {
+                            Some(Slot::Int(n)) => Some(*n),
+                            _ => None,
+                        })
+                        .unwrap_or(i32::MIN),
+                    _ => i32::MIN,
+                };
+                self.observed_after_tag = Some(tag);
+                let res = heap.allocate("duke/test/Result".to_string(), 1);
+                heap.get_mut(res)?.fields[0] = Slot::Int(RESULT_TAG);
+                Ok(Some(Slot::Reference(Some(res))))
+            }
+        }
+
+        fn ensure_loaded(&mut self, _class: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn inspect_class(&mut self, _class: &str) -> Result<ReflectedClassInfo> {
+            Ok(empty_reflected_class_info())
+        }
+    }
+
+    let mut heap = duke_gc::Heap::new();
+    let this_ref = heap.allocate("duke/util/BiFunctionAndThen".to_string(), 2);
+    let bifunction_ref = heap.allocate("duke/test/BiFn".to_string(), 1);
+    heap.get_mut(bifunction_ref).unwrap().fields[0] = Slot::Int(1);
+    let after_ref = heap.allocate("duke/test/AfterFn".to_string(), 1);
+    heap.get_mut(after_ref).unwrap().fields[0] = Slot::Int(AFTER_TAG);
+    heap.get_mut(this_ref).unwrap().fields[0] = Slot::Reference(Some(bifunction_ref));
+    heap.get_mut(this_ref).unwrap().fields[1] = Slot::Reference(Some(after_ref));
+    let a_ref = heap.allocate("duke/test/ArgA".to_string(), 1);
+    let b_ref = heap.allocate("duke/test/ArgB".to_string(), 1);
+
+    // Caller frame roots the LIVE this/a/b, so those (and `after` via
+    // this_ref.fields[1]) survive and forward; only the native's private `after`
+    // copy is at risk without the pin.
+    let caller_frame = duke_runtime::Frame::new(
+        8,
+        4,
+        vec![
+            Slot::Reference(Some(this_ref)),
+            Slot::Reference(Some(a_ref)),
+            Slot::Reference(Some(b_ref)),
+        ],
+    )
+    .unwrap();
+
+    let mut ops = BiFnGcOps {
+        caller_frame,
+        registry: ClassRegistry::new(),
+        string_intern: HashMap::new(),
+        call_count: 0,
+        observed_after_tag: None,
+    };
+    let mut out: Vec<u8> = Vec::new();
+    let mut control = NativeControl::default();
+
+    let result = native_bifunction_and_then_apply(
+        &[
+            Slot::Reference(Some(this_ref)),
+            Slot::Reference(Some(a_ref)),
+            Slot::Reference(Some(b_ref)),
+        ],
+        &mut heap,
+        &mut out,
+        &mut control,
+        &mut ops,
+    );
+
+    assert_eq!(
+        ops.observed_after_tag,
+        Some(AFTER_TAG),
+        "the `after` function went stale across the bifunction's apply GCs; the \
+         andThen second stage was handed a dangling function reference"
+    );
+    let result = result.expect("andThen apply should not error");
+    let res_ref = match result {
+        Some(Slot::Reference(Some(r))) => r,
+        other => panic!("andThen apply did not return a reference: {other:?}"),
+    };
+    let res_tag = match heap.get(res_ref).unwrap().fields.first() {
+        Some(Slot::Int(n)) => *n,
+        other => panic!("andThen result has no int tag: {other:?}"),
+    };
+    assert_eq!(
+        res_tag, RESULT_TAG,
+        "andThen apply returned the wrong result after callback GCs"
+    );
+}
+
 /// Family 5a (Class.newInstance). `native_class_new_instance` allocates the
 /// instance, then holds its bare reference across the `<init>` constructor
 /// callback and returns it. A nested constructor can allocate heavily and trigger


### PR DESCRIPTION
## Before / After (plain language)

**Before:** Many `duke/util` collection/stream/comparator natives in `duke_util.rs` read a JVM heap reference (the callback lambda receiver, a snapshotted element, or an accumulator) into a plain Rust local and then call `ops.invoke(...)`, which runs arbitrary user Java (a lambda) and can trigger one or more **relocating** GCs. Native call arguments are popped off the operand stack into a `Copy` `Vec` that `gather_roots` never scans, and the derived Rust locals live in no interpreter frame slot either. So across the callback those refs go **stale** (point at the object's old address) or **alias an unrelated live object** once the address is reused — the same root cause fixed for `HashMap.forEach` / `computeIfAbsent` in #1384 / #1386 / #1395.

**After:** Each converted native opens a `NativeRootScope` (the existing JNI-local-handle-style pin API) and pins every heap ref it holds across an `ops.invoke`. `gather_roots` then keeps those targets alive and `patch_forwarded_slots` forwards them in place on **every** collect, so held refs track their object across ANY number of GCs. Behavior is otherwise unchanged — only pinning is added.

## How

Idiom mirrors the post-#1386 exemplar `native_hashmap_for_each` (`java_util.rs`): snapshot/read → `NativeRootScope::new()` → `pin_ref`/`pin_slot`/`pin_slots` immediately before the invoke(s) → index-walk pinned buffers (never `&`-iterate across an invoke) → `drop(scope)` after the last use. No `patch_forwarded_*` one-shot fix-ups. `NativeRootScope` is used as-is (not reimplemented).

**All hazard families on this branch are now converted** (see the audit below for the family → commit map). Each family landed with its own sabotage-verified GC-stress regression tests.

## GC-safety audit

Natives that held a JVM heap ref across `ops.invoke` could hand the callback a **stale or reused** reference once a GC relocated the object mid-callback — the callback runs user lambda bytecode, allocates, and can fire several relocating collections (on the real Spring Boot app, **6** major GCs fired inside a single `computeIfAbsent` mapping-function). Those refs live in an unrooted Rust-local copy that `gather_roots` never scans, so they were invisible to the collector. Every such ref is now pinned via `NativeRootScope`, so `gather_roots`/`patch_forwarded_slots` keep it alive and forward it in place across any number of collections. The reachable real-world path is stream/collector/comparator ops exercised under Spring Boot and gson.

**Counts: 97 direct `ops.invoke` sites → 3 SAFE / 94 HAZARD / 0 UNCLEAR.** All 94 hazards converted. Independently adversarially re-verified (spot-checked A/B/C/D/E + all 3 SAFE) — no downward revision. Separately, 6 combinator natives are HAZARD via the `invoke_*` helper GC-points (1 helper site SAFE); these are supplementary to the 94 and are also converted.

### Families converted (94 direct hazards across 5 families + the supplementary helper-invoke set)

| Family | Sites | Refs pinned | Commit |
|---|---|---|---|
| **A** — Object-stream per-element loops (`filter`/`map`/`forEach`/`any`·`all`·`noneMatch`/`reduce`/`peek`/`flatMap`/`sorted`/`takeWhile`/`dropWhile`/`mapToInt`·`Long`·`Double`/`iterate`/`limit`/`mapToObj`) | 22 | receiver (`pin_ref`) + element snapshot `elems`/`kept`/`mapped` + accumulator `Vec` (`pin_slots`), index-walk | `0caa9eb` |
| **B** — `native_stream_collect` collector mega-dispatch (all collector branches + real-`Collector` supplier/accumulator/finisher protocol) | 31 | every `*_fn`/`collector_slot` receiver + `elems` + accumulator map/list + carried `acc`/`min`/`max`/`existing`/`merged`/`container`; write-back after re-lock | `ab41a8c` |
| **C** — Primitive-stream per-element loops (Int/Long/Double `filter`/`map`/`mapTo*`/`forEach`/`peek`/`reduce*`/`*Match`/`flatMap`/`iterate`) | 34 | single `fn_slot`/`pred_slot`/`consumer_slot` receiver (`pin_slot`) — elements are primitive, no snapshot pin | `67360e2` |
| **D** — Two-key comparator natives (`comparing_int`/`comparing_comparator`/`comparing_long`) | 6 | comparator receiver + held second arg `b` (+ object key `ka`) across **both** key-extraction invokes | `8599a41` |
| **E** — `native_bifunction_and_then_apply` | 1 | `after` function ref across the wrapped `apply` invoke | `c538d37` |
| **§7** — Helper-invoke combinators (`then_comparing`/`and_predicate`/`or_predicate`/`and_then_function`/`and_then_consumer`/`compose_function`) — *supplementary, not among the 94* | 6 fns | held second operand/element ref across the first `invoke_*` helper GC-point | `cd33fd0` |
| **B (follow-up)** — `native_stream_collect` real-`Collector` element-snapshot pin-hoist (element snapshot pinned before the pre-loop supplier/get/accumulator GC points in the accept loop) | 1 | element snapshot `elems` (`pin_slots`) hoisted to pin before the pre-loop GC points | `04bc260` |

(A 7th commit, the CI-gate clippy fixup on the new tests, is `4dae3b1`.)

### SAFE sites — no action (verified pass-through)

- **`1155`** `native_stream_collect` (`CollectingAndThenCollector` finisher) — single invoke; `finisher_slot` + `intermediate` only build args, result is returned. (The enclosing function still pins `finisher_slot` across the *recursive* `native_stream_collect` GC-point — handled in family B / `ab41a8c`.)
- **`2326`** `native_natural_order_compare` — single `compareTo(o1, o2)`; args build the call, primitive result returned.
- **`2818`** `native_reversed_comparator_compare` — single `compare(delegate, a, b)`; result negated and returned.

### Test evidence (sabotage-verified: RED without the pin, GREEN with it)

- **Workspace tests: 3177 → 3197 passed** (0 failed, 3 ignored). **+20 GC-stress regressions** added (the `*_survives_two_gcs_during_callback` object/primitive-stream, collector, and combinator tests, plus the real-`Collector` element-snapshot regression `collect_real_collector_element_snapshot_survives_two_gcs_before_accept_loop`).
- Each family is sabotage-verified: the harness drives the native directly with a `CallbackOps` mock that forces **≥2 full relocating collections per callback** (consumer retains `int[512]×N` garbage to trigger multi-GC + young-index reuse) and asserts every held receiver/element/accumulator survives intact — it aborts with an invalid-ref/NPE when unpinned and passes once pinned.
- Full CI-equivalent gate green on this branch (with the local unbreak line, see below): `cargo build --workspace` clean; `cargo fmt --all --check` clean; CI clippy `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -W clippy::pedantic -W clippy::nursery` exits 0; HelloWorld prints `Hello, World!` in both `duke run` and `duke exec` modes; OSS-jar canaries (slf4j-simple, gson, commons-lang3) and the Spring Boot ladder canary + real-JDK pinned canaries all green.

### Baseline caveat

The #1396 × #1395 unbreak line — a one-line `signature: None,` on the stale `#[cfg(test)]` `CallbackOps::inspect_class` mock in `tests.rs` (the literal missing the `signature` field #1396 added to `ReflectedMethodInfo`) — is applied **locally / uncommitted** only to make the test target compile for gating. It is **not** committed to this branch and is deliberately kept out of every commit here. Trunk still lacks this field on that literal, so once #1396 lands on trunk and this branch rebases, the branch compiles and the gate is green in CI unchanged; production code compiles without it today.



<b>Full 97-row audit table</b> (site → classification → justification). Action for every HAZARD row: pinned via <code>NativeRootScope</code> — see the family → commit table above. SAFE rows: no action.

| line | enclosing fn | class | justification |
|---|---|---|---|
| 52 | native_stream_filter | HAZARD | H1/H2: `pred_ref` re-passed + object `elems` snapshot held across per-elem invoke; `kept` accumulator held |
| 91 | native_stream_map | HAZARD | H1/H2: `fn_slot` re-passed + object `elems` snapshot held across; `mapped` accumulator held |
| 129 | native_stream_for_each | HAZARD | H1/H2: `consumer_slot` re-passed + object `elems` snapshot held across per-elem invoke |
| 240 | native_stream_collect (GroupingByCollector) | HAZARD | H1/H2/H3: `fn_slot` re-passed, object `elems` snapshot + `map_ref` accumulator held across per-elem invoke, `elem` stored into lists after |
| 329 | native_stream_collect (ToMapCollector) key | HAZARD | H1/H2: `key_fn`+`elems`+`map_ref` held across; two invokes per elem |
| 339 | native_stream_collect (ToMapCollector) val | HAZARD | H1/H2: `val_fn`+`elems`+`map_ref` held across; result `v` stored after |
| 377 | native_stream_collect (ToUnmodifiableMapCollector) key | HAZARD | H1/H2: `key_fn`+`elems`+`map_ref` held across |
| 387 | native_stream_collect (ToUnmodifiableMapCollector) val | HAZARD | H1/H2: `val_fn`+`elems`+`map_ref` held across |
| 429 | native_stream_collect (ToMapMergeCollector) key | HAZARD | H1/H2: `key_fn`+`elems`+`map_ref` held across |
| 439 | native_stream_collect (ToMapMergeCollector) val | HAZARD | H1/H2: `val_fn`+`elems`+`map_ref` held; `k` held across next invoke |
| 453 | native_stream_collect (ToMapMergeCollector) merge | HAZARD | H1/H3: `merge_fn`, `existing`, `v` held across; `merged` written to `map_ref.fields[i+1]` after |
| 488 | native_stream_collect (PartitioningByCollector) | HAZARD | H1/H2: `pred_ref`+`elems`+`true_list`/`false_list` accumulators held across; `elem` pushed after |
| 537 | native_stream_collect (PartitioningByDownstreamCollector) | HAZARD | H1/H2: `pred_ref`+`elems`+`true_elems`/`false_elems` Vec accumulators held across |
| 620 | native_stream_collect (SummingIntCollector) | HAZARD | H1/H2: `fn_slot` re-passed, object `elems` snapshot held across (result is primitive) |
| 647 | native_stream_collect (AveragingIntCollector) | HAZARD | H1/H2: `fn_slot`+object `elems` held across |
| 683 | native_stream_collect (SummarizingIntCollector) | HAZARD | H1/H2: `fn_slot`+object `elems` held across |
| 723 | native_stream_collect (SummingLongCollector) | HAZARD | H1/H2: `fn_slot`+object `elems` held across |
| 752 | native_stream_collect (AveragingDoubleCollector) | HAZARD | H1/H2: `fn_slot`+object `elems` held across |
| 795 | native_stream_collect (MappingCollector) | HAZARD | H1/H2: `mapper_slot`+`elems`+`mapped_elems` (ref) accumulator held across |
| 827 | native_stream_collect (GroupingBy2Collector) | HAZARD | H1/H2: `fn_slot`+`elems`+`raw_map` accumulator held across; `elem` stored after |
| 933 | native_stream_collect (MinByCollector) | HAZARD | H1/H2/H3: `cmp_slot`+`elems`+`min` (held `Some(elem)` ref) carried across per-elem invoke |
| 965 | native_stream_collect (MaxByCollector) | HAZARD | H1/H2/H3: `cmp_slot`+`elems`+`max` ref held across |
| 994 | native_stream_collect (SummingDoubleCollector) | HAZARD | H1/H2: `fn_slot`+object `elems` held across |
| 1023 | native_stream_collect (AveragingLongCollector) | HAZARD | H1/H2: `fn_slot`+object `elems` held across |
| 1066 | native_stream_collect (ReducingNoIdentityCollector) | HAZARD | H1/H3: `op_slot`+`elems`+`acc` (ref) held across; `acc` reassigned & reused each iter |
| 1092 | native_stream_collect (ReducingCollector) | HAZARD | H1/H3: `op_slot`+`elems`+`acc` ref held across |
| 1120 | native_stream_collect (ReducingMappingCollector) mapper | HAZARD | H1/H3: `mapper_slot`+`elems`+`acc` held; `mapped` held across next invoke |
| 1130 | native_stream_collect (ReducingMappingCollector) op | HAZARD | H1/H3: `op_slot`+`acc`+`mapped` held across |
| 1155 | native_stream_collect (CollectingAndThenCollector) finisher | SAFE | single invoke; `finisher_slot`+`intermediate` only build args, result returned. NOTE: `finisher_slot` IS held across the preceding recursive `native_stream_collect` GC-point (a separate hazard, not an ops.invoke line) |
| 1184 | native_stream_collect (real Collector) supplier | HAZARD | H3: `collector_slot`/`collector_ref` held across this and re-passed at 1210/1236 |
| 1198 | native_stream_collect (real Collector) get | HAZARD | H3: `collector_slot` still held; `container` result used across accumulator loop |
| 1210 | native_stream_collect (real Collector) accumulator | HAZARD | H3: `collector_slot` held; `accumulator`+`container` used in loop after |
| 1224 | native_stream_collect (real Collector) accept-loop | HAZARD | H1/H2/H3: `accumulator`+`container`+object `elems` re-passed/held across per-elem invoke |
| 1236 | native_stream_collect (real Collector) finisher | HAZARD | H3: `collector_slot`+`container` held across |
| 1251 | native_stream_collect (real Collector) apply-finisher | HAZARD | H3: `finisher`+`container` (long-held) passed; container held across many prior invokes |
| 1318 | native_stream_sorted | HAZARD | H2: `elems` (object refs) Vec held across compareTo invoke; `elems.swap` after; `a`,`b` from elems |
| 1360 | native_stream_any_match | HAZARD | H1/H2: `pred_ref` re-passed + object `elems` snapshot held across |
| 1394 | native_stream_all_match | HAZARD | H1/H2: `pred_ref`+object `elems` held across |
| 1428 | native_stream_none_match | HAZARD | H1/H2: `pred_ref`+object `elems` held across |
| 1490 | native_stream_reduce | HAZARD | H1/H2/H3: `op_ref`+`elems`+`acc` ref held across |
| 1528 | native_stream_reduce_with_identity | HAZARD | H1/H2/H3: `fn_slot`+`elems`+`acc` (ref) held across |
| 1681 | native_stream_peek | HAZARD | H1/H2: `consumer_slot` re-passed; `for elem in &elems` holds live borrow of ref Vec across invoke; `elems` extended into out stream after |
| 1741 | native_stream_limit (GeneratorStream) | HAZARD | H1/H3: `sup_ref` re-passed; `out_ref` accumulator (bare u64) deref'd after each invoke |
| 1769 | native_stream_limit (IteratorStream) | HAZARD | H1/H3: `fn_slot` re-passed; `current` (ref) held across & re-passed; `out_ref` deref'd after |
| 1841 | native_stream_flat_map | HAZARD | H1/H2/H3: `fn_slot`+object `elems`+`flat` accumulator held; `inner_ref` result deref'd after |
| 1947 | native_int_stream_iterate | HAZARD | H1: `fn_slot` re-passed across per-elem invoke (element `cur` is primitive) |
| 2084 | native_int_stream_filter | HAZARD | H1: `pred_slot` re-passed (primitive elems) |
| 2112 | native_int_stream_peek | HAZARD | H1: `fn_slot` re-passed (primitive elems) |
| 2141 | native_int_stream_map | HAZARD | H1: `fn_slot` re-passed |
| 2172 | native_int_stream_for_each | HAZARD | H1: `consumer_slot` re-passed |
| 2221 | native_int_stream_map_to_obj | HAZARD | H1/H2: `fn_slot` re-passed; `mapped` accumulates REF results held across later invokes |
| 2326 | native_natural_order_compare | SAFE | single invoke `compareTo(o1,o2)`; `o1`/`o2` only build args; result returned, nothing reused after |
| 2368 | native_comparing_int_compare (ka) | HAZARD | H1/H3: `fn_ref` re-passed and `b` held across this invoke, both used at kb (2378) |
| 2378 | native_comparing_int_compare (kb) | HAZARD | H1/H3: second key extraction; `fn_ref` reached here after 2368's GC (use-after of held ref); must be inside same pin scope |
| 2486 | native_comparing_comparator_compare (ka) | HAZARD | H1/H3: `fn_slot` re-passed, `b` held across, used at 2496 |
| 2496 | native_comparing_comparator_compare (kb) | HAZARD | H1/H3: `ka` (ref result) held across this invoke, used after in `compare_treemap_keys` |
| 2556 | native_stream_map_to_int | HAZARD | H1/H2: `fn_slot`+object `elems` snapshot held across |
| 2602 | native_int_stream_reduce_identity | HAZARD | H1: `fn_slot` re-passed (primitive acc/elems) |
| 2641 | native_int_stream_reduce_optional | HAZARD | H1: `fn_slot` re-passed |
| 2818 | native_reversed_comparator_compare | SAFE | single invoke `compare(delegate,a,b)`; refs only build args; result negated & returned |
| 3018 | native_stream_take_while | HAZARD | H1/H2: `pred_ref`+object `elems`+`kept` accumulator held across |
| 3061 | native_stream_drop_while | HAZARD | H1/H2: `pred_ref`+object `elems`+`kept` held across |
| 3106 | native_stream_sorted_comparator | HAZARD | H1/H2: `comp_ref` re-passed; object `elems` Vec held across; `elems.swap` after |
| 3347 | native_bifunction_and_then_apply | HAZARD | H3: `after` (ref) held across this ops.invoke, used at `invoke_function_apply(after, mid)` (3356) |
| 3379 | native_stream_map_to_long | HAZARD | H1/H2: `fn_slot`+object `elems` snapshot held across |
| 3440 | native_stream_map_to_double | HAZARD | H1/H2: `fn_slot`+object `elems` held across |
| 3664 | native_long_stream_reduce_identity | HAZARD | H1: `fn_slot` re-passed (primitive) |
| 3720 | native_long_stream_filter | HAZARD | H1: `pred_slot` re-passed |
| 3751 | native_long_stream_map | HAZARD | H1: `fn_slot` re-passed |
| 3783 | native_long_stream_for_each | HAZARD | H1: `consumer_slot` re-passed |
| 3811 | native_long_stream_map_to_int | HAZARD | H1: `fn_slot` re-passed |
| 3976 | native_double_stream_filter | HAZARD | H1: `pred_slot` re-passed |
| 4010 | native_double_stream_map | HAZARD | H1: `fn_slot` re-passed |
| 4151 | native_int_stream_any_match | HAZARD | H1: `pred_slot` re-passed |
| 4181 | native_int_stream_all_match | HAZARD | H1: `pred_slot` re-passed |
| 4211 | native_int_stream_none_match | HAZARD | H1: `pred_slot` re-passed |
| 4242 | native_int_stream_map_to_long | HAZARD | H1: `fn_slot` re-passed |
| 4287 | native_long_stream_any_match | HAZARD | H1: `pred_slot` re-passed |
| 4317 | native_long_stream_all_match | HAZARD | H1: `pred_slot` re-passed |
| 4347 | native_long_stream_none_match | HAZARD | H1: `pred_slot` re-passed |
| 4378 | native_comparing_long_compare (ka) | HAZARD | H1/H3: `fn_slot` re-passed, `b` held across, used at 4388 |
| 4388 | native_comparing_long_compare (kb) | HAZARD | H1/H3: second key extraction; use-after of held `fn_slot`; same pin scope |
| 4479 | native_int_stream_flat_map | HAZARD | H1: `fn_slot` re-passed (primitive; `sub_ref` result deref'd immediately) |
| 4545 | native_long_stream_flat_map | HAZARD | H1: `fn_slot` re-passed |
| 4642 | native_double_stream_for_each | HAZARD | H1: `consumer_slot` re-passed |
| 4669 | native_double_stream_any_match | HAZARD | H1: `pred_slot` re-passed |
| 4699 | native_double_stream_all_match | HAZARD | H1: `pred_slot` re-passed |
| 4729 | native_double_stream_none_match | HAZARD | H1: `pred_slot` re-passed |
| 4777 | native_double_stream_reduce_identity | HAZARD | H1: `fn_slot` re-passed |
| 4819 | native_double_stream_reduce_optional | HAZARD | H1: `fn_slot` re-passed |
| 4860 | native_double_stream_flat_map | HAZARD | H1: `fn_slot` re-passed |
| 4893 | native_double_stream_map_to_int | HAZARD | H1: `fn_slot` re-passed |
| 4925 | native_double_stream_map_to_long | HAZARD | H1: `fn_slot` re-passed |
| 5015 | native_long_stream_reduce_optional | HAZARD | H1: `fn_slot` re-passed |
| 5055 | native_long_stream_map_to_double | HAZARD | H1: `fn_slot` re-passed |
| 5142 | native_stream_iterate_predicate (test) | HAZARD | H1/H2/H3: `pred_slot`+`next_slot` re-passed; `current` (ref) held across, stored into `elems` + re-passed |
| 5156 | native_stream_iterate_predicate (next) | HAZARD | H1/H3: `next_slot` re-passed; `current` ref held across, reassigned/reused |



---
_Generated by [Claude Code](https://claude.ai/code/session_01QkiMrtajvPKwXVrAMEoHXB)_