### PR TITLE
fix(test): add missing signature field to ReflectedMethodInfo test double

### DIFF
--- a/crates/duke-interpreter/src/tests.rs
+++ b/crates/duke-interpreter/src/tests.rs
@@ -35691,6 +35691,7 @@ fn class_new_instance_survives_gc_during_constructor() {
                 is_static: false,
                 annotations: Vec::new(),
                 annotation_default: None,
+                signature: None,
             }];
             Ok(info)
         }


### PR DESCRIPTION
## Before / After

**Before:** `cargo test --workspace` fails to compile on trunk. `cargo build --workspace` succeeds, but the test build hits a semantic merge conflict between #1396 (which added the `signature` field to `ReflectedMethodInfo`) and #1395 (which updated the sibling literals but not the test double), so the entire test gate is red for every lane branching off trunk.

**After:** `cargo test --workspace` compiles and the full test suite runs.

## How

Add `signature: None,` to the `ReflectedMethodInfo` test-double literal in the `#[cfg(test)] inspect_class` mock (`crates/duke-interpreter/src/tests.rs`). One line, test-only; no product/runtime code is touched.

## Why now

This is an immediate fast-merge to unblock the `cargo test --workspace` gate for multiple in-flight lanes. It supersedes #1398, whose branch was accidentally advanced beyond the one-line fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q99uT2T2QLYh5UgJcy5Wfh)_