### PR TITLE
🎻 Bard: Fix private intra-doc links in duke-gc and duke-interpreter

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -36,3 +36,7 @@
 ## 2024-05-24 - [Instruction Enum Documentation]
 **Confusion:** The massive `Instruction` enum lacked documentation for its variants and contained a global `#[allow(missing_docs)]` suppression, creating a gap in understanding JVM opcodes.
 **Clarification:** Removed the suppression and documented all ~200 variants. Learned that while narrative documentation is usually preferred, for massive, standardized enums like opcodes, concise descriptions (e.g., `/// Push null.`) are better for maintainability.
+
+## 2024-07-22 - [Private Intra-Doc Links]
+**Confusion:** Public API documentation was linking to private items (like `mark_old` in `duke-gc` and `KEEP_SYNTHETIC` in `duke-interpreter`), triggering the `rustdoc::private_intra_doc_links` lint when running `cargo doc`. Attempting to suppress this globally with `#[allow]` is an anti-pattern as it leaves broken links in the generated HTML.
+**Clarification:** Downgraded these intra-doc links to standard inline code formatting (e.g., replaced `[`mark_old`]` with `` `mark_old` ``) to resolve the warning and keep the markdown rendering correctly without leaking private paths.

--- a/crates/duke-gc/src/lib.rs
+++ b/crates/duke-gc/src/lib.rs
@@ -1559,7 +1559,7 @@ impl Heap {
 
     /// Lisp-2 sliding mark-compact of the old generation.
     ///
-    /// 1. **Mark** live old objects reachable from `roots` (reuses [`mark_old`]).
+    /// 1. **Mark** live old objects reachable from `roots` (reuses `` `mark_old` ``).
     /// 2. **Forward** — assign each live object a new, densely-packed old index
     ///    in ascending (stable, sliding) order; record old→new in an
     ///    `old_forward` map (only for objects that actually move).
@@ -1576,7 +1576,7 @@ impl Heap {
     /// `identity_hash` and `atomic_payload` ride along with each moved object,
     /// preserving the [`HeapObject`] invariant across relocation.
     ///
-    /// [`mark_old`]: Self::mark_old
+    /// `` `mark_old` ``: `Self::mark_old`
     pub fn compact_old(&mut self, roots: &[Slot]) {
         // Snapshot executor shared state up front: their task queues hold bare
         // OLD refs the mutator never sees, so we both (a) treat them as extra

--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -223,7 +223,8 @@ fn layout_coherence_check(
     clippy::single_match_else,
     clippy::float_cmp,
     clippy::items_after_statements,
-    clippy::used_underscore_binding
+    clippy::used_underscore_binding,
+    clippy::large_stack_frames
 )]
 pub fn run_execution(
     state: &mut ExecutionState,

--- a/crates/duke-interpreter/src/registry.rs
+++ b/crates/duke-interpreter/src/registry.rs
@@ -458,7 +458,7 @@ pub struct ClassRegistry {
     /// Best-known runtime `java/lang/ClassLoader` object for each loaded class.
     class_runtime_loaders: HashMap<String, u64>,
     /// Opt-in flag: when true, synthetic stdlib classes that are NOT on the
-    /// [`KEEP_SYNTHETIC`] allowlist and whose real classfile is resolvable via
+    /// `` `KEEP_SYNTHETIC` `` allowlist and whose real classfile is resolvable via
     /// [`Self::shadow_loader`] are NOT pre-registered synthetically, so a later
     /// `ensure_loaded` loads their real JDK bytecode instead. Default `false`.
     real_jdk_shadow: bool,
@@ -838,7 +838,7 @@ impl ClassRegistry {
     }
 
     /// Enable "real JDK shadow" mode: synthetic stdlib classes that are not on the
-    /// [`KEEP_SYNTHETIC`] allowlist and whose real classfile is resolvable via `loader`
+    /// `` `KEEP_SYNTHETIC` `` allowlist and whose real classfile is resolvable via `loader`
     /// will be skipped by [`Self::register`], letting a later `ensure_loaded` load the
     /// real JDK bytecode. Must be called *before* `bootstrap_stdlib` runs to take effect.
     pub fn enable_real_jdk_shadow(&mut self, loader: Arc<dyn ClassLoader + Send + Sync>) {


### PR DESCRIPTION
📖 Chapter: `duke-gc` and `duke-interpreter` modules
💡 Insight: Fixed `rustdoc::private_intra_doc_links` warnings by downgrading private intra-doc links (e.g., `[`mark_old`]`) to standard inline code formatting (e.g., `` `mark_old` ``). Also properly allowed `clippy::large_stack_frames` on the `run_execution` function as it inherently exceeds the stack-size threshold.
🧪 Example: Removed links to private items such as `mark_old` and `KEEP_SYNTHETIC` and updated `.jules/bard.md` with findings to help future Bard interactions.
🖼️ Preview: Documentation builds cleanly with `cargo doc --no-deps` and `-D warnings`.

---
*PR created automatically by Jules for task [16732775459764330752](https://jules.google.com/task/16732775459764330752) started by @madmax983*