### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -47,3 +47,6 @@
 ## 2024-05-24 - Testing ReentrantReadWriteLock Native Operations
 **Learning:** Found several native functions implementing `ReentrantReadWriteLock` and `PriorityQueue` operations missing test coverage in `duke-interpreter`. Adding dummy tests correctly executes these logic branches without needing fully mocked multi-threading scenarios.
 **Action:** Add inline unit tests using a mocked heap and manually setting up the `obj_ref` payload.
+## 2026-05-18 - Testing Report Print Bounds with LimitWriter
+**Learning:** Testing functions that execute multiple sequential `write!` or `writeln!` calls inside loops (like generating markdown or reports) cannot be effectively tested for all I/O error (`?`) propagation paths using a simple Failing Writer that always fails on the first call.
+**Action:** Implement a custom `LimitWriter` that implements `Write` and counts bytes, returning `std::io::Error` only after a specific configurable `limit` is reached. Iterate over multiple bounds limits (e.g., `0..1000`) within a unit test loop until the report succeeds to successfully assert that partial writes correctly propagate errors instead of panicking.

--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -223,7 +223,8 @@ fn layout_coherence_check(
     clippy::single_match_else,
     clippy::float_cmp,
     clippy::items_after_statements,
-    clippy::used_underscore_binding
+    clippy::used_underscore_binding,
+    clippy::large_stack_frames
 )]
 pub fn run_execution(
     state: &mut ExecutionState,

--- a/crates/duke-telemetry/src/helpers.rs
+++ b/crates/duke-telemetry/src/helpers.rs
@@ -171,6 +171,14 @@ mod tests {
     }
 
     #[test]
+    fn test_site2_u16_empty() {
+        let map = HashMap::new();
+        let w = Site2Wrapper { map };
+        let json = serde_json::to_string(&w).unwrap();
+        assert_eq!(json, r#"{"map":{}}"#);
+    }
+
+    #[test]
     fn test_site2_u16() {
         let mut map = HashMap::new();
         map.insert(("java/lang/String".to_string(), 42), Dummy { val: 1 });
@@ -178,6 +186,14 @@ mod tests {
         let w = Site2Wrapper { map };
         let json = serde_json::to_string(&w).unwrap();
         assert_eq!(json, r#"{"map":{"java/lang/String@42":{"val":1}}}"#);
+    }
+
+    #[test]
+    fn test_pair_str_empty() {
+        let map = HashMap::new();
+        let w = PairWrapper { map };
+        let json = serde_json::to_string(&w).unwrap();
+        assert_eq!(json, r#"{"map":{}}"#);
     }
 
     #[test]

--- a/crates/duke-telemetry/src/lib.rs
+++ b/crates/duke-telemetry/src/lib.rs
@@ -598,4 +598,48 @@ mod tests {
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("java/lang/Exception"));
     }
+
+    #[test]
+    fn test_print_report_with_limit_writer() {
+        struct LimitWriter {
+            limit: usize,
+            written: usize,
+        }
+        impl std::io::Write for LimitWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                if self.written + buf.len() > self.limit {
+                    return Err(std::io::Error::other("limit reached"));
+                }
+                self.written += buf.len();
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        let mut store = crate::TelemetryStore::default();
+        store.bytecode_cost.record("iadd", "Foo", "bar", 10, 100);
+        store
+            .object_lineage
+            .record("java/lang/String", "Foo", 10, "bar");
+        store
+            .class_init_dag
+            .record("java/lang/String", "java/lang/System", 500);
+        store
+            .exception_flow
+            .record_throw("java/lang/Exception", "Foo", "bar", 10);
+        store
+            .dispatch_resolution
+            .record("Foo", 42, "java/lang/String", true);
+        store
+            .native_boundary
+            .record_call("java/lang/String", "intern", 100, true);
+
+        for limit in 0..1000 {
+            let mut w = LimitWriter { limit, written: 0 };
+            if store.print_report(&mut w).is_ok() {
+                break;
+            }
+        }
+    }
 }


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]

🎯 Target: `duke-telemetry` lib.rs and helpers.rs
💣 Risk: I/O errors during large report printing could cause unexpected panics. Empty telemetry formatting structures might serialize incorrectly.
🔬 Strategy: Added `LimitWriter` in `lib.rs` to fuzz bounding limits recursively and ensure robust `Err` bubbling instead of unwrapping across the formatting cascade. Added missing `HashMap::new()` tests to serde helper site wrappers. Added clippy lint suppression for `large_stack_frames` to resolve compiler warning in `execution.rs`.
🔭 Verification: `cargo test -p duke-telemetry`

---
*PR created automatically by Jules for task [10532155343064786018](https://jules.google.com/task/10532155343064786018) started by @madmax983*