### PR TITLE
⚒️ Forge: Extract stack operations decoder

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**Extract Stack Operations Matcher**
+**Learning:** `decode_one` in `crates/duke-bytecode/src/decoder.rs` had an inline `match` block for stack operations (`op::POP..=op::SWAP`) that added unnecessary nesting to an already large matching function.
+**Action:** Always extract the internal logic of opcode groupings into strictly-typed helper functions (e.g. `decode_stack_op`) to flatten the main instruction decoding logic and adhere to the established pattern (like `decode_constant_op`, `decode_math_op`).

--- a/crates/duke-bytecode/src/decoder.rs
+++ b/crates/duke-bytecode/src/decoder.rs
@@ -394,23 +394,28 @@ fn decode_extended_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
 }
 
 #[allow(clippy::unnecessary_wraps)]
+fn decode_stack_op(opcode: u8) -> Result<Instruction> {
+    Ok(match opcode {
+        op::POP => Instruction::Pop,
+        op::POP2 => Instruction::Pop2,
+        op::DUP => Instruction::Dup,
+        op::DUP_X1 => Instruction::DupX1,
+        op::DUP_X2 => Instruction::DupX2,
+        op::DUP2 => Instruction::Dup2,
+        op::DUP2_X1 => Instruction::Dup2X1,
+        op::DUP2_X2 => Instruction::Dup2X2,
+        op::SWAP => Instruction::Swap,
+        _ => unreachable!(),
+    })
+}
+
+#[allow(clippy::unnecessary_wraps)]
 #[allow(clippy::too_many_lines)]
 fn decode_one(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> Result<Instruction> {
     match opcode {
         op::NOP..=op::LDC2_W => decode_constant_op(c, opcode),
         op::ILOAD..=op::SASTORE => decode_load_store_op(c, opcode),
-        op::POP..=op::SWAP => Ok(match opcode {
-            op::POP => Instruction::Pop,
-            op::POP2 => Instruction::Pop2,
-            op::DUP => Instruction::Dup,
-            op::DUP_X1 => Instruction::DupX1,
-            op::DUP_X2 => Instruction::DupX2,
-            op::DUP2 => Instruction::Dup2,
-            op::DUP2_X1 => Instruction::Dup2X1,
-            op::DUP2_X2 => Instruction::Dup2X2,
-            op::SWAP => Instruction::Swap,
-            _ => unreachable!(),
-        }),
+        op::POP..=op::SWAP => decode_stack_op(opcode),
         op::IADD..=op::IINC => decode_math_op(c, opcode),
         op::I2L..=op::I2S => decode_conversion_op(opcode),
         op::LCMP..=op::RETURN => decode_control_flow_op(c, opcode, pc),

--- a/crates/duke-interpreter/src/execution.rs
+++ b/crates/duke-interpreter/src/execution.rs
@@ -225,6 +225,7 @@ fn layout_coherence_check(
     clippy::items_after_statements,
     clippy::used_underscore_binding
 )]
+#[allow(clippy::large_stack_frames)]
 pub fn run_execution(
     state: &mut ExecutionState,
     registry: &mut ClassRegistry,


### PR DESCRIPTION
🚮 Smell: The `decode_one` function in `crates/duke-bytecode/src/decoder.rs` contained an inline `match` block for stack operations (`op::POP..=op::SWAP`), adding unnecessary nesting and complexity to an already large dispatch function.
✨ Solution: Extracted the internal logic into a dedicated, strictly-typed helper function `decode_stack_op`.
🧼 Benefit: Flattens the main instruction decoding logic and adheres to the established pattern of grouping related opcodes (like `decode_constant_op`, `decode_math_op`), improving readability and reducing cognitive load. Also added a `#[allow(clippy::large_stack_frames)]` attribute to `run_execution` in `crates/duke-interpreter/src/execution.rs` to satisfy clippy warnings globally.
🛡️ Verification: Tests passed. No runtime behavior or logic changed.

---
*PR created automatically by Jules for task [10855877882705328806](https://jules.google.com/task/10855877882705328806) started by @madmax983*