### PR TITLE
⚒️ Forge: Extract decode_stack_op

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -85,3 +85,7 @@
 **Extract Bounds-Checking Pre-Allocations**
 **Learning:** `crates/duke-classfile/src/parser.rs` contained 14+ instances of manual `Vec::with_capacity((count as usize).min(c.remaining() / bytes_per_item))` math. This mixed control-flow iteration with low-level raw byte arithmetic and bounds checking across the parsing domain, creating duplicated visual noise.
 **Action:** Extract raw byte heuristics for `Vec` pre-allocation bounds-checking into a reusable, named helper method on the reader/cursor object (e.g., `Cursor::safe_capacity`). Use this single source of truth across all parsing sites to strictly delineate parsing intent from anti-OOM arithmetic.
+
+**Extract Stack Op Matcher**
+**Learning:** `decode_one` in `crates/duke-bytecode/src/decoder.rs` contained an inline match block to process opcodes related to stack manipulation (`POP` through `SWAP`). This created a God Function and added extra indentation to an already complex matching function.
+**Action:** Extract nested switch/match logic corresponding to specific semantic families of opcodes into helper functions, like `decode_stack_op`. This dramatically flattens `decode_one` and separates logic.

--- a/crates/duke-bytecode/src/decoder.rs
+++ b/crates/duke-bytecode/src/decoder.rs
@@ -393,24 +393,28 @@ fn decode_extended_op(c: &mut Cursor<'_>, opcode: u8) -> Result<Instruction> {
     })
 }
 
+fn decode_stack_op(opcode: u8) -> Instruction {
+    match opcode {
+        op::POP => Instruction::Pop,
+        op::POP2 => Instruction::Pop2,
+        op::DUP => Instruction::Dup,
+        op::DUP_X1 => Instruction::DupX1,
+        op::DUP_X2 => Instruction::DupX2,
+        op::DUP2 => Instruction::Dup2,
+        op::DUP2_X1 => Instruction::Dup2X1,
+        op::DUP2_X2 => Instruction::Dup2X2,
+        op::SWAP => Instruction::Swap,
+        _ => unreachable!(),
+    }
+}
+
 #[allow(clippy::unnecessary_wraps)]
 #[allow(clippy::too_many_lines)]
 fn decode_one(c: &mut Cursor<'_>, opcode: u8, pc: usize) -> Result<Instruction> {
     match opcode {
         op::NOP..=op::LDC2_W => decode_constant_op(c, opcode),
         op::ILOAD..=op::SASTORE => decode_load_store_op(c, opcode),
-        op::POP..=op::SWAP => Ok(match opcode {
-            op::POP => Instruction::Pop,
-            op::POP2 => Instruction::Pop2,
-            op::DUP => Instruction::Dup,
-            op::DUP_X1 => Instruction::DupX1,
-            op::DUP_X2 => Instruction::DupX2,
-            op::DUP2 => Instruction::Dup2,
-            op::DUP2_X1 => Instruction::Dup2X1,
-            op::DUP2_X2 => Instruction::Dup2X2,
-            op::SWAP => Instruction::Swap,
-            _ => unreachable!(),
-        }),
+        op::POP..=op::SWAP => Ok(decode_stack_op(opcode)),
         op::IADD..=op::IINC => decode_math_op(c, opcode),
         op::I2L..=op::I2S => decode_conversion_op(opcode),
         op::LCMP..=op::RETURN => decode_control_flow_op(c, opcode, pc),


### PR DESCRIPTION
🚮 Smell: `decode_one` in `crates/duke-bytecode/src/decoder.rs` contained an inline match block to process opcodes related to stack manipulation (`POP` through `SWAP`). This created a God Function and added extra indentation to an already complex matching function.

✨ Solution: Extracted the nested switch/match logic corresponding to specific semantic families of opcodes into a helper function `decode_stack_op`. 

🧼 Benefit: This dramatically flattens `decode_one` and separates logic, making the code much easier to read and maintain.

🛡️ Verification: Ran `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt --all`. No logic changed. All tests passed.

---
*PR created automatically by Jules for task [10937091634012706599](https://jules.google.com/task/10937091634012706599) started by @madmax983*